### PR TITLE
Add more helpful error messages to OCI flow

### DIFF
--- a/src/osimage/cosi/reader.rs
+++ b/src/osimage/cosi/reader.rs
@@ -265,9 +265,9 @@ impl HttpFile {
         Ok(match img_ref.digest() {
             Some(digest) => digest.to_string(),
             None => {
-                let tag = img_ref
-                    .tag()
-                    .with_context(|| format!("No tag provided in OCI URL '{}'", img_ref.whole()))?;
+                let tag = img_ref.tag().with_context(|| {
+                    format!("Failed to retrieve tag from OCI URL '{}'", img_ref.whole())
+                })?;
                 // Attempt to retrieve digest from manifest
                 let client = OciClient::default();
                 let manifest = client.pull_image_manifest(img_ref, &RegistryAuth::Anonymous);


### PR DESCRIPTION
This PR adds more helpful error messages to the OCI flow.

If given an invalid registry name, the new error message will be:
<img width="895" height="254" alt="image" src="https://github.com/user-attachments/assets/72ba34e1-ab86-4b8f-967e-a3b85de94212" />

If given an invalid repository name (or unknown tag), the error message will be:
<img width="1241" height="154" alt="image" src="https://github.com/user-attachments/assets/e90fb0c3-662b-49c4-90c5-8a5304b542b2" />
