### PR TITLE
docs: Add PR template to github

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+# 🔍 Description
+ 
+What is this PR about? feature/doc/engineering/bug?
+
+# 🤔 Rationale
+
+Why is this PR needed?
+
+# 📝 Checks
+
+- [ ] Check [dev-docs/manual-validation.md](/dev-docs/manual-validation.md)
+
+
+# 📌 Follow-ups
+
+TODO:
+
+- #0000
+
+# 🗒️ Notes


### PR DESCRIPTION
Hopefully this should add our PR template to github (source: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)