### PR TITLE
engineering: Add permissions for LG

### DIFF
--- a/selinux-policy-trident/trident.te
+++ b/selinux-policy-trident/trident.te
@@ -19,10 +19,6 @@ files_type(trident_var_lib_t)
 #
 # Trident policy
 #
-
-# REMOVE
-permissive trident_t;
-
 require {
         type admin_passwd_exec_t;
         type anacron_exec_t;


### PR DESCRIPTION
# 🔍 Description
 
This PR gives permission to Trident to copy SSH keys, which is required for a LG user script.