### PR TITLE
doc: Update docs related to enabled ORAS support

### DIFF
--- a/docs/Reference/Host-Configuration/API-Reference/OsImage.md
+++ b/docs/Reference/Host-Configuration/API-Reference/OsImage.md
@@ -25,7 +25,7 @@ The Sha384 of the entire COSI file.
 
 The path to the COSI file.
 
-URLs may have one of the following three schemes: `https://`, `file://`, or `oci://`. COSI files stored as an OCI image must allow for anonymous pulls.
+URLs may have one of the following four schemes: `http://`, `https://`, `file://`, or `oci://`. COSI files stored as an OCI image must allow for anonymous pulls.
 
 | Characteristic | Value    |
 | -------------- | -------- |

--- a/trident_api/schemas/host-config-schema.json
+++ b/trident_api/schemas/host-config-schema.json
@@ -612,7 +612,7 @@
           ]
         },
         "url": {
-          "description": "The path to the COSI file.\n\nURLs may have one of the following three schemes: `https://`, `file://`, or `oci://`. COSI files stored as an OCI image must allow for anonymous pulls.",
+          "description": "The path to the COSI file.\n\nURLs may have one of the following four schemes: `http://`, `https://`, `file://`, or `oci://`. COSI files stored as an OCI image must allow for anonymous pulls.",
           "type": "string",
           "format": "uri"
         }

--- a/trident_api/src/config/host/image.rs
+++ b/trident_api/src/config/host/image.rs
@@ -16,8 +16,8 @@ use crate::schema_helpers::unit_enum_with_untagged_variant;
 pub struct OsImage {
     /// The path to the COSI file.
     ///
-    /// URLs may have one of the following three schemes: `https://`, `file://`, or `oci://`. COSI
-    /// files stored as an OCI image must allow for anonymous pulls.
+    /// URLs may have one of the following four schemes: `http://`, `https://`, `file://`, or
+    /// `oci://`. COSI files stored as an OCI image must allow for anonymous pulls.
     pub url: Url,
 
     /// The Sha384 of the entire COSI file.


### PR DESCRIPTION
# 🔍 Description
 
Add doc comments to explain how Trident can be used with COSI images hosted in a container registry.

(Do not merge until after https://github.com/microsoft/trident/pull/20 since this PR contains a couple necessary SELinux permissions.)