### PR TITLE
engineering: Display audit logs for BM tests

### DIFF
--- a/.pipelines/templates/stages/testing_baremetal/baremetal-testing.yml
+++ b/.pipelines/templates/stages/testing_baremetal/baremetal-testing.yml
@@ -292,7 +292,7 @@ stages:
           - bash: |
               set -eux
               ./bin/storm-trident helper check-selinux \
-                  "$(tridentSourceDirectory)/e2e_tests/helpers/key" \
+                  "$(Build.SourcesDirectory)/e2e_tests/helpers/key" \
                   "${{ variables.BAREMETAL_OAM_IP }}" \
                   "testing-user" \
                   "${{ parameters.runtimeEnv }}" \


### PR DESCRIPTION
# 🔍 Description
 
Display audit logs and run audit2allow for bare metal tests.
