### PR TITLE
Improve message if Trident fails to get verity signature info

### DIFF
--- a/osutils/src/veritysetup.rs
+++ b/osutils/src/veritysetup.rs
@@ -552,15 +552,6 @@ impl Display for VeritySignatureInfo {
 }
 
 pub fn get_verity_signature_info(path: impl AsRef<Path>) -> Result<VeritySignatureInfo, Error> {
-    get_verity_signature_info_inner(path.as_ref()).with_context(|| {
-        format!(
-            "Failed to read verity signature info from file '{}'",
-            path.as_ref().display()
-        )
-    })
-}
-
-fn get_verity_signature_info_inner(path: impl AsRef<Path>) -> Result<VeritySignatureInfo, Error> {
     let der = fs::read(path.as_ref()).context("Failed to read verity signature file")?;
     let pkcs7 = Pkcs7::from_der(&der).context("Failed to parse verity signature file as PKCS#7")?;
     let empty_stack = Stack::<X509>::new().context("Failed to create empty X509 stack")?;

--- a/src/engine/storage/verity.rs
+++ b/src/engine/storage/verity.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::{anyhow, bail, ensure, Context, Error};
-use log::{debug, error, trace};
+use log::{debug, trace, warn};
 
 use osutils::{
     block_devices,
@@ -278,10 +278,9 @@ fn open_verity_device_with_signature(
             );
         }
         Err(e) => {
-            error!(
-                "Failed to get signature info from file '{}': {}",
+            warn!(
+                "Failed to get signature info from file '{}': {e:?}",
                 temp_signature_file_path.display(),
-                e
             );
         }
     }


### PR DESCRIPTION
This downgrades the message to a warning if we fail to load and parse the verity signature. It also changes from a display print (`{}`) to a debug print (`{:?}`) which causes the backtrace of contexts to also be printed rather, than just the outermost error message.

Previously the output looked like this, which isn't super helpful:
```
[ERROR trident::engine::storage::verity] Failed to get signature info from file '/tmp/.tmpMdH5D4': Failed to read verity signature info from file '/tmp/.tmpMdH5D4'
```