### PR TITLE
engineering: Check that image exists before removing from ACR

### DIFF
--- a/.pipelines/templates/stages/common_tasks/remove_from_acr.yml
+++ b/.pipelines/templates/stages/common_tasks/remove_from_acr.yml
@@ -54,17 +54,11 @@ stages:
                   tag="v${build_id}.${i}"
 
                   if az acr repository show --name ${{ parameters.registry }} --image ${host_repository_name}:${tag} &> /dev/null; then
-                    echo "Deleting image ${host_repository_name}:${tag} from ACR ${{ parameters.registry }}"
                     az acr repository delete --name ${{ parameters.registry }} --image ${host_repository_name}:${tag} --yes
-                  else
-                    echo "Image ${host_repository_name}:${tag} not found in ACR ${{ parameters.registry }}."
                   fi
 
                   if az acr repository show --name ${{ parameters.registry }} --image ${container_repository_name}:${tag} &> /dev/null; then
-                    echo "Deleting image ${container_repository_name}:${tag} from ACR ${{ parameters.registry }}"
                     az acr repository delete --name ${{ parameters.registry }} --image ${container_repository_name}:${tag} --yes
-                  else
-                    echo "Image ${container_repository_name}:${tag} not found in ACR ${{ parameters.registry }}."
                   fi
                 done
             displayName: "Log into ACR and delete images by tag"


### PR DESCRIPTION
# 🔍 Description
 
If "Delete From ACR" stage is run twice, then it will fail the second time. This PR should prevent errors on the second run.

pr-e2e run (in progress): https://dev.azure.com/mariner-org/ECF/_build/results?buildId=879254&view=results