### PR TITLE
bug: Fix root-verity SELinux failures

### DIFF
--- a/e2e_tests/target-configurations.yaml
+++ b/e2e_tests/target-configurations.yaml
@@ -7,22 +7,22 @@ bareMetal:
       - split
       - usr-verity
     validation:
-      # - base
-      # - combined
-      # - encrypted-partition
-      # - encrypted-raid
-      # - encrypted-swap
-      # - memory-constraint-combined
-      # # - misc TODO #14249
-      # - raid-big
-      # - raid-mirrored
-      # - raid-resync-small
-      # - rerun
+      - base
+      - combined
+      - encrypted-partition
+      - encrypted-raid
+      - encrypted-swap
+      - memory-constraint-combined
+      # - misc TODO #14249
+      - raid-big
+      - raid-mirrored
+      - raid-resync-small
+      - rerun
       - root-verity
-      # - simple
-      # - split
-      # - usr-verity
-      # - usr-verity-raid
+      - simple
+      - split
+      - usr-verity
+      - usr-verity-raid
     weekly:
       - base
       - combined


### PR DESCRIPTION
# 🔍 Description
 
Root verity (non-UKI) is failing in bare metal scenario because of SELinux denials. Specifically, OS modifier is unable to enable a systemd service since SELinux prevents some relabeling actions. This PR adds the permissions.

trident-testing pipeline succeeding on Clean Install: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=879358&view=results

