### PR TITLE
Bug: Job reattempt failed because artifact was published twice

### DIFF
--- a/.pipelines/templates/stages/common_tasks/remove_from_acr.yml
+++ b/.pipelines/templates/stages/common_tasks/remove_from_acr.yml
@@ -29,6 +29,10 @@ stages:
         pool:
           type: linux
 
+        variables:
+          ob_outputDirectory: $(Build.SourcesDirectory)/build
+          ob_artifactBaseName: deleteImageAcr_$(System.JobAttempt)
+
         steps:
           - task: AzureCLI@2
             inputs:


### PR DESCRIPTION
# 🔍 Description
 
Change the artifact name on DeleteCosiFromAcr according to the number of job attempts.

# 🤔 Rationale

We can rerun the same job without worrying on the published artifact, as we can't publish to artifacts with the same name in the same pipeline run.

Note: Preferred solution would be to not publish anything at all here but seems one branch always attempts to publish an artifact if the job was successful.  

#  📝 Checks

Multiple reruns of the stage: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=885247&view=results




