### PR TITLE
engineering: Update LVM and SSH key file SELinux rules for LG

### DIFF
--- a/selinux-policy-trident/trident.te
+++ b/selinux-policy-trident/trident.te
@@ -866,7 +866,7 @@ allow lvm_t init_t:key search; # Allows LVM to write to search the kernel keyrin
 allow lvm_t tpm_device_t:chr_file write; # Allows LVM to write to the TPM device.
 
 # This is necessary for veritysetup to be able to read a key file in /tmp.
-allow lvm_t tmp_t:file { getattr read open ioctl };
+allow lvm_t tmp_t:file { getattr ioctl open read };
 
 #============= mount_t =============
 allow mount_t trident_var_lib_t:dir mounton;


### PR DESCRIPTION
# 🔍 Description
 
Add rules to Trident SELinux policy for LG.

Requested rules were:

- allow trident_t sshd_key_t:file manage_file_perms;
- lvm_domtrans(trident_t)

Other rules were added so e2e tests pass. `lvm_domtrans` means when Trident executes a file with type `lvm_exec_t`, we transition into the `lvm_t` domain, which is not how Trident previously operated. As a result, additional rules were required.

pr-e2e successful run: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=886932&view=results (from "ff49af3" commit; only change since then was alphabetizing a permission)