### PR TITLE
Have netlaunch specifically set SecureBootEnabled variable to false

### DIFF
--- a/tools/cmd/netlaunch/main.go
+++ b/tools/cmd/netlaunch/main.go
@@ -359,8 +359,8 @@ func startLocalVm(localVmUuidStr string, isoLocation string) {
 	}
 	defer vm.Disconnect()
 
-	if err = vm.SetVmHttpBootUri(isoLocation); err != nil {
-		log.WithError(err).Fatalf("failed to set VM HTTP boot URI")
+	if err = vm.SetFirmwareVars(isoLocation, false); err != nil {
+		log.WithError(err).Fatalf("failed to set UEFI variables")
 	}
 
 	if err = vm.Start(); err != nil {


### PR DESCRIPTION
This will let us switch virt-deploy over to using a version of the OVMF firmware with all the secure boot variables set.