### PR TITLE
Use sudo when tdnf install is called for azl-installer

### DIFF
--- a/.pipelines/templates/stages/trident_usb_iso/trident-usb-iso.yml
+++ b/.pipelines/templates/stages/trident_usb_iso/trident-usb-iso.yml
@@ -73,7 +73,7 @@ stages:
       displayName: Download trident docker image
 
     - script: |
-        tdnf install -y squashfs-tools lsof
+        sudo tdnf install -y squashfs-tools lsof
       displayName: Ensure mksquashfs
 
     - script: |


### PR DESCRIPTION
# 🔍 Description
 
The prism cicd pipeline complains that sudo is required for tdnf install.

https://dev.azure.com/mariner-org/ECF/_build/results?buildId=887516

Seems `sudo` is needed for MockOB, not for OneBranch.

Validation:
* pr-e2e: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=887674&view=results
* prism cicd: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=887667&view=results
* pipeline-tester (OneBranch): https://dev.azure.com/mariner-org/ECF/_build/results?buildId=887676&view=results