### PR TITLE
tests: Account for daily build extra update

### DIFF
--- a/.pipelines/templates/stages/common_tasks/push-to-acr.yml
+++ b/.pipelines/templates/stages/common_tasks/push-to-acr.yml
@@ -54,7 +54,7 @@ steps:
 
         cd $(Build.SourcesDirectory)/artifacts/test-image
 
-        for version in {1..3}; do
+        for version in {1..4}; do
           if [[ $version == 1 ]]; then
             filename="regular.cosi"
           else

--- a/.pipelines/templates/stages/common_tasks/remove-from-acr.yml
+++ b/.pipelines/templates/stages/common_tasks/remove-from-acr.yml
@@ -37,7 +37,7 @@ steps:
         az acr repository show-tags -n ${{ parameters.registry }} --repository $repository_name
 
         # Delete repository with COSI images
-        for i in {1..3}; do
+        for i in {1..4}; do
           tag="v${build_id}.${{ parameters.config }}.${i}"
           if az acr repository show --name ${{ parameters.registry }} --image ${repository_name}:${tag} &> /dev/null; then
             az acr repository delete --name ${{ parameters.registry }} --image ${repository_name}:${tag} --yes


### PR DESCRIPTION
# 🔍 Description
 
VM misc tests are failing in daily builds where an additional update is executed.

# 🤔 Rationale

Why is this PR needed?

# 📝 Checks

- trident-pipeline-tester[pre]: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=889568&view=results


# 📌 Follow-ups

# 🗒️ Notes
