### PR TITLE
bug: Do not fail on accessibility check when it's an OCI image

### DIFF
--- a/tools/storm/helpers/ab_update.go
+++ b/tools/storm/helpers/ab_update.go
@@ -309,7 +309,7 @@ func (h *AbUpdateHelper) checkTridentService(tc storm.TestCase) error {
 func checkUrlIsAccessible(url string) error {
 	// If this is an OCI image, skip check
 	if strings.HasPrefix(url, "oci://") {
-		logrus.Infof("Skipping accessibility check for OCI URL: %s", url)
+		logrus.Infof("Skipping accessibility check for OCI URL because OCI protocol is not supported by http: %s", url)
 		return nil
 	}
 


### PR DESCRIPTION
# 🔍 Description
 
This PR skips checking if a URL is accessible if the image is an OCI.
