### PR TITLE
Engineer: Live image detection

### DIFF
--- a/src/engine/clean_install.rs
+++ b/src/engine/clean_install.rs
@@ -114,7 +114,10 @@ fn clean_install_safety_check(
     // Check if Trident is running from a live image
     let cmdline =
         fs::read_to_string("/proc/cmdline").structured(InitializationError::ReadCmdline)?;
-    if cmdline.contains("root=/dev/ram0") || cmdline.contains("root=live:LABEL=CDROM") {
+    if cmdline.contains("root=/dev/ram0")
+        || cmdline.contains("root=live:LABEL=CDROM")
+        || !cmdline.contains("root=")
+    {
         debug!("Trident is running from a live image.");
         return Ok(());
     }


### PR DESCRIPTION
# 🔍 Description
 
This PR improves detection for a live image during clean install by adding the detection when the ISO created by Prism has an initramfs of type full-os. 

# 🤔 Rationale

When Prism creates an ISO with initramfsType=full-os, the root file system is the same as the initramfs. The Image Customizer tool itself is the one that copies all the mounted partitions (minus the /boot folder) to the initramfs image and [the root parameter is removed from the kernel parameters](https://microsoft.github.io/azure-linux-image-tools/imagecustomizer/concepts/liveos.html). This means that when looking on /proc/cmdline no information related for root will be found. On the other hand, if Trident is running from an OS installed on persistent storage, the root argument will show the persistent storage, so we could use the lack of root as a way to detect a live image.


