### PR TITLE
engineering: Implement is_secure_boot_enabled()

### DIFF
--- a/osutils/src/pcrlock.rs
+++ b/osutils/src/pcrlock.rs
@@ -15,6 +15,7 @@ use tempfile::NamedTempFile;
 use crate::{
     bootloaders::{BOOT_EFI, GRUB_EFI},
     dependencies::Dependency,
+    efivar,
     exe::RunAndCheck,
 };
 use sysdefs::tpm2::Pcr;
@@ -601,27 +602,26 @@ fn generate_pcrlock_files(
                 bootloader_path.display()
             ))?;
         }
-        // Second, if SecureBoot is disabled, the authenticode of the .linux section of each UKI
-        // binary is measured into PCR 4 as well.
-        //
-        // TODO: Once SecureBoot is enabled, gate this logic with a conditional, or remove
-        // entirely, as SecureBoot will likely be enabled always.
-        // https://dev.azure.com/mariner-org/polar/_workitems/edit/14286/.
-        for (index, uki_path) in uki_binaries.into_iter().enumerate() {
-            let pcrlock_file =
-                generate_pcrlock_output_path(BOOT_LOADER_CODE_UKI_PCRLOCK_DIR, index);
-            debug!(
-                    "Generating .pcrlock file at '{}' to measure .linux section of UKI PE binary at '{}'",
+        // If SecureBoot is disabled, the authenticode of the .linux section of each UKI binary is
+        // measured into PCR 4 as well.
+        if !efivar::is_secure_boot_enabled() {
+            for (index, uki_path) in uki_binaries.into_iter().enumerate() {
+                let pcrlock_file =
+                    generate_pcrlock_output_path(BOOT_LOADER_CODE_UKI_PCRLOCK_DIR, index);
+                debug!(
+                    "SecureBoot is disabled, so generating .pcrlock file at '{}' \
+                    to measure .linux section of UKI PE binary at '{}'",
                     pcrlock_file.clone().display(),
                     uki_path.clone().display()
                 );
-            generate_linux_authenticode(uki_path.clone(), pcrlock_file.clone()).context(
+                generate_linux_authenticode(uki_path.clone(), pcrlock_file.clone()).context(
                     format!(
                         "Failed to generate .pcrlock file at '{}' for .linux section of UKI PE binary at '{}'",
                         pcrlock_file.display(),
                         uki_path.display()
                     ),
                 )?;
+            }
         }
     } else {
         debug!("Skipping generating bootloader and UKI .pcrlock files as PCR 4 is not requested");


### PR DESCRIPTION
# 🔍 Description
 
This PR adds a method `is_secure_boot_enabled()` that is needed to use the EFI var-s, to check if the system has `SecureBoot` enabled. This is needed because the firmware and SHIM make different measurements into PCRs 4 and 7 (at least), depending on the state of `SecureBoot`.