### PR TITLE
engineering: storm: Output logs to files

### DIFF
--- a/storm/internal/cli/run/helper.go
+++ b/storm/internal/cli/run/helper.go
@@ -8,6 +8,7 @@ import (
 type HelperCmd struct {
 	Helper     string   `arg:"" name:"helper" help:"Name of the helper to run"`
 	Watch      bool     `short:"w" help:"Watch the output of the helper live"`
+	LogDir     *string  `short:"l" help:"Optional directory to save logs to. Will be created if it does not exist." type:"path"`
 	HelperArgs []string `arg:"" passthrough:"all" help:"Arguments to pass to the helper, you may use '--' to force passthrough." optional:""`
 }
 
@@ -17,5 +18,5 @@ func (cmd *HelperCmd) Run(suite core.SuiteContext) error {
 
 	helper := suite.Helper(cmd.Helper)
 
-	return runner.RegisterAndRunTests(suite, helper, cmd.HelperArgs, cmd.Watch)
+	return runner.RegisterAndRunTests(suite, helper, cmd.HelperArgs, cmd.Watch, cmd.LogDir)
 }

--- a/storm/internal/cli/run/scenario.go
+++ b/storm/internal/cli/run/scenario.go
@@ -8,6 +8,7 @@ import (
 type ScenarioCmd struct {
 	Scenario     string   `arg:"" name:"scenario" help:"Name of the scenario to run"`
 	Watch        bool     `short:"w" help:"Watch the output of the scenario live"`
+	LogDir       *string  `short:"l" help:"Optional directory to save logs to. Will be created if it does not exist." type:"path"`
 	ScenarioArgs []string `arg:"" passthrough:"all" help:"Arguments to pass to the scenario, you may use '--' to force passthrough." optional:""`
 }
 
@@ -17,5 +18,5 @@ func (cmd *ScenarioCmd) Run(suite core.SuiteContext) error {
 
 	scenario := suite.Scenario(cmd.Scenario)
 
-	return runner.RegisterAndRunTests(suite, scenario, cmd.ScenarioArgs, cmd.Watch)
+	return runner.RegisterAndRunTests(suite, scenario, cmd.ScenarioArgs, cmd.Watch, cmd.LogDir)
 }

--- a/storm/internal/runner/runner.go
+++ b/storm/internal/runner/runner.go
@@ -23,6 +23,7 @@ func RegisterAndRunTests(suite core.SuiteContext,
 	},
 	args []string,
 	watch bool,
+	logDir *string,
 ) error {
 	// Create a new runnable instance
 	registrantInstance := &runnableInstance{
@@ -63,6 +64,15 @@ func RegisterAndRunTests(suite core.SuiteContext,
 	rep := reporter.NewTestReporter(testMgr)
 
 	rep.PrintReport()
+
+	if logDir != nil {
+		suite.Logger().Infof("Saving logs to '%s'", *logDir)
+		err := os.MkdirAll(*logDir, 0755)
+		if err != nil {
+			return fmt.Errorf("failed to create log directory '%s': %w", *logDir, err)
+		}
+		rep.SaveLogs(*logDir)
+	}
 
 	return rep.ExitError()
 }

--- a/storm/pkg/storm/utils/ansi.go
+++ b/storm/pkg/storm/utils/ansi.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"regexp"
+)
+
+var (
+	// ANSI escape code cleaner
+	ANSI_CLEANER = regexp.MustCompile(`(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]`)
+
+	// ANSI non-color escape code cleaner, matches only control codes
+	ANSI_CONTROL_CLEANER = regexp.MustCompile(`(\x9B|\x1B\[)[0-?]*[ -\/]*[@-ln-~]`)
+)


### PR DESCRIPTION
# 🔍 Description
 
Support for exporting per test case logs to files. Use the `-l` option under the `run` and `helper` subcommands to specify a directory to save logs in.

# Validation
- https://dev.azure.com/mariner-org/ECF/_build/results?buildId=890732&view=results
