### PR TITLE
engineering: Transition in setfiles_t domain when running setfiles

### DIFF
--- a/selinux-policy-trident/trident.te
+++ b/selinux-policy-trident/trident.te
@@ -240,6 +240,7 @@ optional_policy(`
     role ci_unconfined_r types trident_t;
 
     allow trident_t ci_unconfined_t:fd use;
+    seutil_run_setfiles(trident_t, ci_unconfined_r);
 ')
 
 # Allow transition between unconfined_t and trident_t domains; necessary for an interactive run
@@ -399,8 +400,8 @@ allow trident_t root_t:file { create getattr map open read relabelfrom write };
 allow trident_t rpm_unit_t:file getattr;
 allow trident_t rpm_var_cache_t:dir relabelto;
 allow trident_t rpm_var_cache_t:file relabelto;
-allow trident_t rpm_var_lib_t:dir relabelto;
-allow trident_t rpm_var_lib_t:file relabelto;
+allow trident_t rpm_var_lib_t:dir { add_name relabelto };
+allow trident_t rpm_var_lib_t:file { create relabelto setattr write };
 allow trident_t security_t:file { map write };
 allow trident_t security_t:filesystem getattr;
 allow trident_t security_t:security read_policy;
@@ -715,6 +716,8 @@ seutil_manage_file_contexts(trident_t)
 seutil_manage_module_store(trident_t)
 seutil_read_default_contexts(trident_t)
 seutil_read_bin_policy(trident_t)
+seutil_run_setfiles(trident_t, system_r)
+seutil_run_setfiles(trident_t, unconfined_r)
 udev_relabel_rules_files(trident_t)
 
 ###########################################


### PR DESCRIPTION
# 🔍 Description
 
This PR uses the "seutil_run_setiles" interface so that Trident transitions into the setfiles_t domain when running setfiles instead of using trident_t.

# 🤔 Rationale

setfiles_t has broader permissions to access file and directory attributes than trident_t. Currently, running setfiles in trident_t is causing some errors because we are not anticipating all file and directory labels. This should hopefully resolve the bug.

