### PR TITLE
bug: Fix pcrlock RPM build warning

### DIFF
--- a/trident.spec
+++ b/trident.spec
@@ -185,8 +185,7 @@ Statically defined .pcrlock files for PCR-based encryption. This is a workaround
 be removed once the fix is merged in AZL 4.0.
 
 %files static-pcrlock-files
-%dir %{_sharedstatedir}/pcrlock.d
-%{_sharedstatedir}/pcrlock.d/
+%{_sharedstatedir}/pcrlock.d
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
# 🔍 Description
 
This PR corrects `trident.spec` to fix the following warning in the build logs:

```
#29 124.2 RPM build warnings:
#29 124.2     File listed twice: /var/lib/pcrlock.d
```

Example run: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=895849&view=logs&j=88c74772-d549-5da7-88c4-f97a42df57cc&t=da4140a2-6f9c-5561-90b4-19c438775d65&l=1550