### PR TITLE
engineering: Reduce the number of BM container tests on pre-release

### DIFF
--- a/e2e_tests/target-configurations.yaml
+++ b/e2e_tests/target-configurations.yaml
@@ -46,11 +46,9 @@ bareMetal:
       - combined
       - encrypted-swap
       - misc
-      - raid-mirrored
-      - raid-resync-small
+      - raid-small
       - rerun
       - root-verity
-      - simple
     validation:
       - base
       - combined


### PR DESCRIPTION
# 🔍 Description
 
Removing `encrypted-partition` (24m), `encrypted-raid` (31m), `usr-verity` (50m), and `usr-verity-raid` (26m) since these configurations are also covered by `combined`. Also removing `raid-resync-small` (59m), `raid-mirrored` (34m), and `simple` (24m).

This should cut ~4.5 hours.