### PR TITLE
Update rust version in docs.

### DIFF
--- a/dev-docs/prerequisites.md
+++ b/dev-docs/prerequisites.md
@@ -22,7 +22,7 @@
         ```
 
 - Install Rust and Cargo: `curl https://sh.rustup.rs -sSf | sh`.
-  - The required version of Rust is 1.72.0. To install this version, run `rustup
+  - The required version of Rust is 1.88.0. To install this version, run `rustup
   install 1.88.0`. To set this as your default version, also run `rustup default
   1.88.0`.
 - Install `build-essential`, `pkg-config`, `libssl-dev`, `libclang-dev`, and


### PR DESCRIPTION
# 🔍 Description
 
Update the rust version in the docs from 1.72.0 to 1.88.0.

# 🤔 Rationale

Ensure the docs are accurate.

# 📝 Checks

- [x] Check [dev-docs/manual-validation.md](/dev-docs/manual-validation.md)

# 📌 Follow-ups

None

# 🗒️ Notes

None