### PR TITLE
engineering: rerun e2e test fails to deploy, shows truncated serial log

### DIFF
--- a/.pipelines/templates/stages/testing_vm/netlaunch-testing.yml
+++ b/.pipelines/templates/stages/testing_vm/netlaunch-testing.yml
@@ -133,9 +133,9 @@ stages:
           - bash: |
               set -eux
 
-              # increase virtlogd max size to 10MB
+              # Disable virtlogd rollover by setting max_size to 0
               cat /etc/libvirt/virtlogd.conf
-              echo "max_size = 10485760" >> /etc/libvirt/virtlogd.conf
+              echo "max_size = 0" | sudo tee -a /etc/libvirt/virtlogd.conf
               cat /etc/libvirt/virtlogd.conf
               sudo systemctl restart virtlogd.socket
 


### PR DESCRIPTION
# 🔍 Description
 
Test times out waiting for login prompt to show up in serial log, but no errors show up in netlaunch or trident logs.

Serial log shows as truncated, serial log artifacts (on successful runs) are typically around 2MB which seems to be the default rollover size for libvirt's logging.

This PR increases the size to 10MB.

Validated: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=905281&view=results