### PR TITLE
bug: Trim SElinux context

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,13 +186,11 @@ impl Trident {
 
         if let Ok(selinux_context) = fs::read_to_string("/proc/self/attr/current") {
             debug!(
-                "selinux debug: Trident is running in SELinux domain '{}'",
+                "Trident is running in SELinux domain '{}'",
                 selinux_context.trim()
             );
         } else {
-            error!(
-                "selinux debug: Failed to retrieve the SELinux context in which Trident is running"
-            );
+            error!("Failed to retrieve the SELinux context in which Trident is running");
         }
 
         if !Uid::effective().is_root() {


### PR DESCRIPTION
# 🔍 Description
 
This PR removes leading and trailing whitespace for a better-formatted log.