### PR TITLE
engineering: retry cleanup task up to 3 times

### DIFF
--- a/.pipelines/templates/stages/testing_servicing/testing-template.yml
+++ b/.pipelines/templates/stages/testing_servicing/testing-template.yml
@@ -263,5 +263,6 @@ jobs:
             fi
 
           displayName: "Cleanup even if timeout"
+          retryCountOnTaskFailure: 3
           timeoutInMinutes: 20
           condition: always()


### PR DESCRIPTION
# 🔍 Description
 
az cli transient failures are leading to lingering azure resources.  Add retry to avoid this.