### PR TITLE
SFI: use explicit service-connection rather than attaching managed identity to 1es pool

### DIFF
--- a/.pipelines/templates/stages/testing_servicing/testing-template.yml
+++ b/.pipelines/templates/stages/testing_servicing/testing-template.yml
@@ -225,6 +225,7 @@ jobs:
                 --ssh-private-key-path $(SSH_PRIVATE_KEY_PATH) \
                 --ssh-public-key-path $(SSH_PUBLIC_KEY_PATH) \
                 --retry-count ${{ parameters.updateIterationCount }} \
+                --update-port-a 8123 --update-port-b 8124 \
                 --build-id $(Build.BuildId) \
                 --force-cleanup
               set +x
@@ -243,7 +244,7 @@ jobs:
               # If platform is azure AND the test failed to finish, run cleanup to
               # ensure there are no azure resources left behind
               if [ "${STORM_SCENARIO_FINISHED}" != "true" ]; then
-                FLAGS=""
+                FLAGS="-a"
                 if [ "${{ parameters.verboseLogging }}" == "True" ]; then
                   FLAGS="$FLAGS --verbose"
                 fi


### PR DESCRIPTION
# 🔍 Description
 
Attaching managed identity to 1es pool is not supported anymore.  Use explicit service-connection instead.

Scale test validation: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=910373&view=results
e2e-pr validation: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=910374&view=results
