### PR TITLE
engineering: retry lab access test in case the vnet is asleep

### DIFF
--- a/.pipelines/templates/stages/testing_baremetal/baremetal-testing.yml
+++ b/.pipelines/templates/stages/testing_baremetal/baremetal-testing.yml
@@ -142,6 +142,7 @@ stages:
               set -xe
               ping -c 3 "${{ variables.BAREMETAL_LAB_CANARY_IP }}"
             displayName: "Validate if the Baremetal lab is up and running"
+            retryCountOnTaskFailure: 10
 
           - bash: |
               set -xe


### PR DESCRIPTION
# 🔍 Description
 
Our lab access validation seems to fail after a period of inactivity and then subsequently succeed.  As if the underlying vnet has some kind of inactivity sleep.  Try using retry to avoid this breaking our tests.
