### PR TITLE
bug: Fix root-verity SELinux failure

### DIFF
--- a/e2e_tests/target-configurations.yaml
+++ b/e2e_tests/target-configurations.yaml
@@ -122,6 +122,7 @@ virtualMachine:
       - raid-mirrored
       - raid-resync-small
       - rerun
+      - root-verity
       - simple
       - split
       - usr-verity

--- a/selinux-policy-trident/trident.te
+++ b/selinux-policy-trident/trident.te
@@ -906,6 +906,7 @@ libs_manage_lib_files(semanage_t)
 
 #============= setfiles_t ==============
 allow setfiles_t proc_t:filesystem getattr;
+allow setfiles_t unlabeled_t:file { map open read };
 
 #============= systemd_generator_t ==============
 allow systemd_generator_t home_root_t:dir read;


### PR DESCRIPTION
# 🔍 Description
 
This PR is a follow-up to https://github.com/microsoft/trident/pull/99, in which setfiles operation now takes place in `setfiles_t` domain. However, `setfiles_t` domain doesn't have access to `unlabeled_t` files which is a special case, so this PR gives this explicit permission.

pr-e2e validation: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=910859&view=results