### PR TITLE
engineering: remove timeouts for netlaunch/netlisten in tests

### DIFF
--- a/tools/cmd/netlaunch/main.go
+++ b/tools/cmd/netlaunch/main.go
@@ -157,9 +157,10 @@ var rootCmd = &cobra.Command{
 		result := make(chan phonehome.PhoneHomeResult)
 		// Create server that does not timeout
 		server := &http.Server{
-			ReadTimeout:  0,
-			WriteTimeout: 0,
-			IdleTimeout:  0,
+			ReadTimeout:       0,
+			ReadHeaderTimeout: 0,
+			WriteTimeout:      0,
+			IdleTimeout:       0,
 		}
 
 		// Create the final address that will be announced to the BMC and Trident.

--- a/tools/cmd/netlisten/main.go
+++ b/tools/cmd/netlisten/main.go
@@ -89,9 +89,10 @@ var rootCmd = &cobra.Command{
 		result := make(chan phonehome.PhoneHomeResult)
 		// Create server that does not timeout
 		server := &http.Server{
-			ReadTimeout:  0,
-			WriteTimeout: 0,
-			IdleTimeout:  0,
+			ReadTimeout:       0,
+			ReadHeaderTimeout: 0,
+			WriteTimeout:      0,
+			IdleTimeout:       0,
 		}
 
 		// Set up listening for phonehome


### PR DESCRIPTION
# 🔍 Description
 
Remove timeouts for netlaunch/netlisten http.Server

# 🤔 Rationale

Reduce deployment failures due to momentary network issues

# Validation

* https://dev.azure.com/mariner-org/ECF/_build/results?buildId=917134&view=results