### PR TITLE
engineering: use azl3 pool

### DIFF
--- a/.pipelines/templates/stages/trident_rpms/build-source.yml
+++ b/.pipelines/templates/stages/trident_rpms/build-source.yml
@@ -96,7 +96,7 @@ stages:
         displayName: Build Trident 3.0 ${{ parameters.targetArchitecture }} RPMs
         pool:
           type: linux
-          name: mariner-hci-ARM64-1es-pool-westcentralus
+          name: azl3-hci-ARM64-1es-pool-westcentralus
           hostArchitecture: arm64
 
         variables:


### PR DESCRIPTION
# 🔍 Description
 
Long-term answer is to use polar pool maritimus-1es-image-azl3-arm64-v2, but use this ecf pool to validate on azl3.

