### PR TITLE
engineering: delete nvram file with sudo

### DIFF
--- a/tools/storm/utils/libvirt.go
+++ b/tools/storm/utils/libvirt.go
@@ -91,7 +91,7 @@ func (vm *LibvirtVm) SetFirmwareVars(boot_url string, secure_boot bool, key_loca
 		return fmt.Errorf("failed to destroy domain '%s': %w", vm.domain.Name, err)
 	}
 
-	args := []string{"--inplace", nvram.NVRam, "--set-boot-uri", boot_url}
+	args := []string{"virt-fw-vars", "--inplace", nvram.NVRam, "--set-boot-uri", boot_url}
 	if secure_boot {
 		args = append(args, "--set-true", "SecureBootEnable")
 	} else {
@@ -105,7 +105,7 @@ func (vm *LibvirtVm) SetFirmwareVars(boot_url string, secure_boot bool, key_loca
 		logrus.Infof("Enrolling key from %s", key_location)
 	}
 
-	cmd := exec.Command("virt-fw-vars", args...)
+	cmd := exec.Command("sudo", args...)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		logrus.Debugf("virt-fw-vars output:\n%s\n", output)
 		return fmt.Errorf("failed to set boot URI: %w", err)


### PR DESCRIPTION
# 🔍 Description
 
Deleting nvram file is failing.  `virt-fw-vars` also fails.  Adding sudo for both.

NVRAM deletion failure: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=928117&view=results
```
FATA[0000] failed to set UEFI variables                  error="failed to remove existing NVRAM file ' /var/lib/libvirt/qemu/nvram/virtdeploy-vm-0_VARS.fd': remove /var/lib/libvirt/qemu/nvram/virtdeploy-vm-0_VARS.fd: permission denied"
```

virt-fw-vars failure (with NVRAM deletion succeeding): https://dev.azure.com/mariner-org/ECF/_build/results?buildId=928148&view=results
```
DEBU[0003] virt-fw-vars output:
/usr/local/lib/python3.10/dist-packages/virt/firmware/efi/certs.py:28: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import resource_filename
Traceback (most recent call last):
  File "/usr/local/bin/virt-fw-vars", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/dist-packages/virt/firmware/vars.py", line 196, in main
    varstore = autodetect.open_varstore(options.input)
  File "/usr/local/lib/python3.10/dist-packages/virt/firmware/varstore/autodetect.py", line 14, in open_varstore
    if edk2.Edk2VarStoreQcow2.probe(filename):
  File "/usr/local/lib/python3.10/dist-packages/virt/firmware/varstore/edk2.py", line 165, in probe
    with open(filename, "rb") as f:
PermissionError: [Errno 13] Permission denied: '/var/lib/libvirt/qemu/nvram/virtdeploy-vm-0_VARS.fd'
```

Validation: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=928168&view=results