### PR TITLE
engineering: migrate to new docusaurus setting

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -76,7 +76,12 @@ const config = {
   projectName: 'trident', // Usually your repo name.
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    },
+  },
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you


### PR DESCRIPTION
# 🔍 Description
 
Fix this warning in docusaurus build:

```
[WARNING] The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4.
Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.
```