### PR TITLE
bug: Fix osmodifier version used in cicd pipeline

### DIFF
--- a/.pipelines/templates/e2e-template.yml
+++ b/.pipelines/templates/e2e-template.yml
@@ -298,6 +298,7 @@ stages:
       - template: stages/testing_functional/functional-testing.yml
         parameters:
           downloadPrebuiltImage: false
+          osModifierBuildType: "dev"
           osModifierBranch: ${{ parameters.osModifierBranch }}
           dependsOnStage: ${{ parameters.baseImageArtifactStage }}
 

--- a/.pipelines/templates/stages/testing_functional/functional-testing.yml
+++ b/.pipelines/templates/stages/testing_functional/functional-testing.yml
@@ -18,6 +18,13 @@ parameters:
     default: 5067 # [GITHUB]-trident-ci
     displayName: Where to download prebuilt image from
 
+  - name: osModifierBuildType
+    type: string
+    values:
+      - dev
+      - preview
+    default: preview
+
   - name: osModifierBranch
     type: string
     default: "main"
@@ -87,6 +94,7 @@ stages:
           - template: ../common_tasks/download-osmodifier.yml
             parameters:
               osModifierBranch: ${{ parameters.osModifierBranch }}
+              osModifierBuildType: ${{ parameters.osModifierBuildType }}
               targetArchitecture: amd64
 
           - bash: |


### PR DESCRIPTION
Previously the FTs would always use the preview version of OS modifier. 

Pipeline run: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=939170&view=logs&j=4ce13d6b-835b-52c0-999f-6017e90e79af&t=4f2af3c0-7754-5a00-265b-43b22938f2d4