### PR TITLE
docs: use npm for validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,6 @@ NETLAUNCH_CONFIG ?= input/netlaunch.yaml
 
 OVERRIDE_RUST_FEED ?= true
 
-PYTHON_CMD ?= python3
-
 SERVER_PORT ?= 8133
 
 .PHONY: all
@@ -792,10 +790,15 @@ validate-pipeline-website-artifact:
 		sudo apt install gh; \
 	fi
 	$(eval STAGING_DIR := $(shell mktemp -d))
+	cp -r ./website/* $(STAGING_DIR)/.
+	rm -rf $(STAGING_DIR)/build && \
+		mkdir -p $(STAGING_DIR)/build
 	$(eval RUN_ID ?= $(shell gh run list --workflow 'Deploy to GitHub Pages' --repo microsoft/trident --json conclusion,databaseId --jq '.[] | select(.conclusion == "success") | .databaseId' | sort -n | tail -n 1))
 	@echo "Downloading GitHub Pages artifact from $(RUN_ID)"
-	gh run download $(RUN_ID) --name github-pages --repo microsoft/trident --dir $(STAGING_DIR)
-	cd $(STAGING_DIR) && \
+	gh run download $(RUN_ID) --name github-pages --repo microsoft/trident --dir $(STAGING_DIR)/build
+	cd $(STAGING_DIR)/build && \
 		tar -xvf ./artifact.tar && \
-		$(PYTHON_CMD) -m http.server $(SERVER_PORT)
+		cd $(STAGING_DIR) && \
+		npm install && \
+			npm run serve -- --port $(SERVER_PORT)
 


### PR DESCRIPTION
# 🔍 Description
 
using `/trident/` as baseurl with public site breaks the local validation.  update validation target to use docusaurus serve.