### PR TITLE
test: use new proxy variable name

### DIFF
--- a/.pipelines/templates/stages/testing_baremetal/baremetal-testing.yml
+++ b/.pipelines/templates/stages/testing_baremetal/baremetal-testing.yml
@@ -208,11 +208,11 @@ stages:
               SERVICE_OVERRIDE=""
               if [ "${{ parameters.runtimeEnv }}" == "host" ]; then 
                 SERVICE_OVERRIDE="[Service]
-                  Environment=\"HTTPS_PROXY=$(baremetal_controller.https_proxy)\""
+                  Environment=\"HTTPS_PROXY=$(baremetal_controller.lab_https_proxy)\""
               else
                 # When running containerized Trident, we must directly embed the proxy in the docker command
                 SERVICE_OVERRIDE="[Service]
-                  Environment=\"HTTPS_PROXY=$(baremetal_controller.https_proxy)\"
+                  Environment=\"HTTPS_PROXY=$(baremetal_controller.lab_https_proxy)\"
                   ExecStart=
                   ExecStart=docker run \\
                     --env HTTPS_PROXY \\
@@ -373,7 +373,7 @@ stages:
               netlistenPort: ${{ variables.NETLAUNCH_PORT }}
               runtimeEnv: ${{ parameters.runtimeEnv }}
               netlistenConfigFile: $(TRIDENT_SOURCE_DIR)/baremetal-netlisten.yaml
-              httpsProxy: "$(baremetal_controller.https_proxy)"
+              httpsProxy: "$(baremetal_controller.lab_https_proxy)"
 
         #   - template: ../common_tasks/remove-from-acr.yml
         #     parameters:


### PR DESCRIPTION
# 🔍 Description
 
bm tests are failing to `git clone` the trident repo.  there was a variable in an ADO variable group called `http_proxy` that should be used on the lab machine, but not the test runner.  adjusted the variable group name, this is the matching change in pipeline code.