### PR TITLE
engineering: Do not clear TPM 2.0 on clean install by default, but introduce `encryption.clearTpmOnInstall` option

### DIFF
--- a/crates/trident/src/engine/storage/encryption.rs
+++ b/crates/trident/src/engine/storage/encryption.rs
@@ -115,10 +115,10 @@ pub(super) fn create_encrypted_devices(
         // Clear the TPM 2.0 device to ensure that it is in a known state. By clearing the lockout
         // value, Trident prevents the TPM 2.0 device from being placed into DA lockout mode due to
         // repeated successive provisioning attempts.
-        Dependency::Tpm2Clear
-            .cmd()
-            .run_and_check()
-            .message("Failed to clear TPM 2.0 device")?;
+        // Dependency::Tpm2Clear
+        //     .cmd()
+        //     .run_and_check()
+        //     .message("Failed to clear TPM 2.0 device")?;
 
         // If this is for a grub ROS, seal against the value of PCR 7; if this is for a UKI ROS,
         // seal against a "bootstrapping" pcrlock policy that exclusively contains PCR 0.

--- a/crates/trident/src/engine/storage/encryption.rs
+++ b/crates/trident/src/engine/storage/encryption.rs
@@ -112,13 +112,15 @@ pub(super) fn create_encrypted_devices(
             .run_and_check()
             .message("Encryption requires access to a TPM 2.0 device but one is not accessible")?;
 
-        // Clear the TPM 2.0 device to ensure that it is in a known state. By clearing the lockout
-        // value, Trident prevents the TPM 2.0 device from being placed into DA lockout mode due to
-        // repeated successive provisioning attempts.
-        // Dependency::Tpm2Clear
-        //     .cmd()
-        //     .run_and_check()
-        //     .message("Failed to clear TPM 2.0 device")?;
+        // If optional flag is set to true, clear the TPM 2.0 device to ensure that it is in a
+        // known state.
+        if encryption.clear_tpm_on_install == Some(true) {
+            debug!("Clearing TPM 2.0 device");
+            Dependency::Tpm2Clear
+                .cmd()
+                .run_and_check()
+                .message("Failed to clear TPM 2.0 device")?;
+        }
 
         // If this is for a grub ROS, seal against the value of PCR 7; if this is for a UKI ROS,
         // seal against a "bootstrapping" pcrlock policy that exclusively contains PCR 0.

--- a/crates/trident/src/subsystems/storage/mod.rs
+++ b/crates/trident/src/subsystems/storage/mod.rs
@@ -332,6 +332,7 @@ mod tests {
                         device_id: "part5".to_owned(),
                     }],
                     pcrs: vec![DEFAULT_PCR],
+                    ..Default::default()
                 }),
                 ..Default::default()
             },

--- a/crates/trident_api/schemas/host-config-schema.json
+++ b/crates/trident_api/schemas/host-config-schema.json
@@ -249,6 +249,11 @@
         "volumes"
       ],
       "properties": {
+        "clearTpmOnInstall": {
+          "description": "Optional parameter that determines whether the TPM 2.0 device will be cleared on clean install. By default, it is set to false. If set to true, Trident will clear the TPM 2.0 device on install. TPM cannot be cleared on A/B updates.\n\nClearing the TPM 2.0 device will remove all keys and data from the TPM 2.0 device. This operation is irreversible and will result in data loss. However, this option might be needed to ensure that the TPM 2.0 is in a known state; to avoid entering the DA (Direct Attack) lockout mode on repetitive provisioning attempts, e.g. during testing and development.",
+          "type": "boolean",
+          "nullable": true
+        },
         "pcrs": {
           "description": "Optional list of PCRs in TPM 2.0 device to seal to. If not specified, Trident will seal encrypted volumes against the following default options: - If doing a clean install of a grub ROS image, seal to PCR 7 while inside the MOS, - If doing a clean install of a UKI ROS image, seal to PCRs 4 and 11 after booting into the ROS A.\n\nEach PCR may be specified either as a digit or a string representation. If specified, at least one PCR must be provided.\n\nWhen doing a clean install of a grub ROS image, the following options are valid: - 7, or `secure-boot-policy`.\n\nWhen doing a clean install of a UKI ROS image, the following options are valid: - 4, or `boot-loader-code`, - 11, or `kernel-boot`, - 4 and 11.\n\nMore encryption flows, with additional PCR options, will be added in the future.",
           "type": "array",

--- a/crates/trident_api/schemas/host-config-schema.json
+++ b/crates/trident_api/schemas/host-config-schema.json
@@ -250,7 +250,7 @@
       ],
       "properties": {
         "clearTpmOnInstall": {
-          "description": "Optional parameter that determines whether the TPM 2.0 device will be cleared on clean install. By default, it is set to false. If set to true, Trident will clear the TPM 2.0 device on install. TPM cannot be cleared on A/B updates.\n\nClearing the TPM 2.0 device will remove all keys and data from the TPM 2.0 device. This operation is irreversible and will result in data loss. However, this option might be needed to ensure that the TPM 2.0 is in a known state; to avoid entering the DA (Direct Attack) lockout mode on repetitive provisioning attempts, e.g. during testing and development.",
+          "description": "Optional parameter that determines whether the TPM 2.0 device will be cleared on clean install. By default, it is set to false. If set to true, Trident will clear the TPM 2.0 device on install. TPM cannot be cleared on A/B updates.\n\nClearing the TPM 2.0 device will remove all keys and data from the TPM 2.0 device. This operation is irreversible and could result in data loss. However, this option might be needed to ensure that the TPM 2.0 is in a known state; to avoid entering the DA (Direct Attack) lockout mode on repetitive provisioning attempts, e.g. during testing and development.",
           "type": "boolean",
           "nullable": true
         },

--- a/crates/trident_api/src/config/host/storage/encryption.rs
+++ b/crates/trident_api/src/config/host/storage/encryption.rs
@@ -101,6 +101,18 @@ pub struct Encryption {
     /// More encryption flows, with additional PCR options, will be added in the future.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pcrs: Vec<Pcr>,
+
+    /// Optional parameter that determines whether the TPM 2.0 device will be cleared on clean
+    /// install. By default, it is set to false. If set to true, Trident will clear the TPM 2.0
+    /// device on install. TPM cannot be cleared on A/B updates.
+    ///
+    /// Clearing the TPM 2.0 device will remove all keys and data from the TPM 2.0 device. This
+    /// operation is irreversible and will result in data loss. However, this option might be
+    /// needed to ensure that the TPM 2.0 is in a known state; to avoid entering the DA (Direct
+    /// Attack) lockout mode on repetitive provisioning attempts, e.g. during testing and
+    /// development.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clear_tpm_on_install: Option<bool>,
 }
 
 /// A LUKS2-encrypted volume configuration.

--- a/crates/trident_api/src/config/host/storage/encryption.rs
+++ b/crates/trident_api/src/config/host/storage/encryption.rs
@@ -107,7 +107,7 @@ pub struct Encryption {
     /// device on install. TPM cannot be cleared on A/B updates.
     ///
     /// Clearing the TPM 2.0 device will remove all keys and data from the TPM 2.0 device. This
-    /// operation is irreversible and will result in data loss. However, this option might be
+    /// operation is irreversible and could result in data loss. However, this option might be
     /// needed to ensure that the TPM 2.0 is in a known state; to avoid entering the DA (Direct
     /// Attack) lockout mode on repetitive provisioning attempts, e.g. during testing and
     /// development.

--- a/docs/Reference/Host-Configuration/API-Reference/Encryption.md
+++ b/docs/Reference/Host-Configuration/API-Reference/Encryption.md
@@ -27,6 +27,16 @@ This parameter is required and must not be empty. Each item is an object that wi
    | Type           | `EncryptedVolume`                       |
    | Link           | [EncryptedVolume](./EncryptedVolume.md) |
 
+### `clearTpmOnInstall` (optional)
+
+Optional parameter that determines whether the TPM 2.0 device will be cleared on clean install. By default, it is set to false. If set to true, Trident will clear the TPM 2.0 device on install. TPM cannot be cleared on A/B updates.
+
+Clearing the TPM 2.0 device will remove all keys and data from the TPM 2.0 device. This operation is irreversible and will result in data loss. However, this option might be needed to ensure that the TPM 2.0 is in a known state; to avoid entering the DA (Direct Attack) lockout mode on repetitive provisioning attempts, e.g. during testing and development.
+
+| Characteristic | Value     |
+| -------------- | --------- |
+| Type           | `boolean` |
+
 ### `pcrs` (optional)
 
 Optional list of PCRs in TPM 2.0 device to seal to. If not specified, Trident will seal encrypted volumes against the following default options: - If doing a clean install of a grub ROS image, seal to PCR 7 while inside the MOS, - If doing a clean install of a UKI ROS image, seal to PCRs 4 and 11 after booting into the ROS A.

--- a/docs/Reference/Host-Configuration/API-Reference/Encryption.md
+++ b/docs/Reference/Host-Configuration/API-Reference/Encryption.md
@@ -31,7 +31,7 @@ This parameter is required and must not be empty. Each item is an object that wi
 
 Optional parameter that determines whether the TPM 2.0 device will be cleared on clean install. By default, it is set to false. If set to true, Trident will clear the TPM 2.0 device on install. TPM cannot be cleared on A/B updates.
 
-Clearing the TPM 2.0 device will remove all keys and data from the TPM 2.0 device. This operation is irreversible and will result in data loss. However, this option might be needed to ensure that the TPM 2.0 is in a known state; to avoid entering the DA (Direct Attack) lockout mode on repetitive provisioning attempts, e.g. during testing and development.
+Clearing the TPM 2.0 device will remove all keys and data from the TPM 2.0 device. This operation is irreversible and could result in data loss. However, this option might be needed to ensure that the TPM 2.0 is in a known state; to avoid entering the DA (Direct Attack) lockout mode on repetitive provisioning attempts, e.g. during testing and development.
 
 | Characteristic | Value     |
 | -------------- | --------- |

--- a/tests/e2e_tests/target-configurations.yaml
+++ b/tests/e2e_tests/target-configurations.yaml
@@ -7,22 +7,22 @@ bareMetal:
       - split
       - usr-verity
     validation:
-      - base
+      #- base
       - combined
       - encrypted-partition
       - encrypted-raid
       - encrypted-swap
       - memory-constraint-combined
-      - misc
-      - raid-big
-      - raid-mirrored
-      - raid-resync-small
+      #- misc
+      #- raid-big
+      #- raid-mirrored
+      #- raid-resync-small
       - rerun
-      - root-verity
-      - simple
-      - split
-      - usr-verity
-      - usr-verity-raid
+      #- root-verity
+      #- simple
+      #- split
+      #- usr-verity
+      #- usr-verity-raid
     weekly:
       - base
       - combined
@@ -50,20 +50,20 @@ bareMetal:
       - rerun
       - root-verity
     validation:
-      - base
+      #- base
       - combined
       - encrypted-partition
       - encrypted-raid
       - encrypted-swap
-      - misc
-      - raid-mirrored
-      - raid-resync-small
-      - raid-small
+      #- misc
+      #- raid-mirrored
+      #- raid-resync-small
+      #- raid-small
       - rerun
-      - root-verity
-      - simple
-      - usr-verity
-      - usr-verity-raid
+      #- root-verity
+      #- simple
+      #- usr-verity
+      #- usr-verity-raid
     weekly:
       - base
       - combined

--- a/tests/e2e_tests/target-configurations.yaml
+++ b/tests/e2e_tests/target-configurations.yaml
@@ -7,22 +7,22 @@ bareMetal:
       - split
       - usr-verity
     validation:
-      #- base
+      - base
       - combined
       - encrypted-partition
       - encrypted-raid
       - encrypted-swap
       - memory-constraint-combined
-      #- misc
-      #- raid-big
-      #- raid-mirrored
-      #- raid-resync-small
+      - misc
+      - raid-big
+      - raid-mirrored
+      - raid-resync-small
       - rerun
-      #- root-verity
-      #- simple
-      #- split
-      #- usr-verity
-      #- usr-verity-raid
+      - root-verity
+      - simple
+      - split
+      - usr-verity
+      - usr-verity-raid
     weekly:
       - base
       - combined
@@ -50,20 +50,20 @@ bareMetal:
       - rerun
       - root-verity
     validation:
-      #- base
+      - base
       - combined
       - encrypted-partition
       - encrypted-raid
       - encrypted-swap
-      #- misc
-      #- raid-mirrored
-      #- raid-resync-small
-      #- raid-small
+      - misc
+      - raid-mirrored
+      - raid-resync-small
+      - raid-small
       - rerun
-      #- root-verity
-      #- simple
-      #- usr-verity
-      #- usr-verity-raid
+      - root-verity
+      - simple
+      - usr-verity
+      - usr-verity-raid
     weekly:
       - base
       - combined


### PR DESCRIPTION
# 🔍 Description
 
This PR changes the current logic for creating encrypted devices, by **not** clearing the TPM 2.0 device by default on clean install, unless `encryption.clearTpmOnInstall` is set to true.

Green E2E runs:
1. BM: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=941820&view=results
2. trident-pr-e2e: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=941328&view=results

# 🤔 Rationale

The ZTP team has a multi-boot scenario, where the TPM 2.0 device is already in use on Azure Local: the TPM is used for disk encryption on the ROE data partitions, and clearing the TPM breaks the transition between the ROE and the Target OS. Considering this, we decided to **not** clear the TPM 2.0 on clean install by default. However, this behavior can still be enabled, by setting `cleanTpmOnInstall: true` in the `storage.encryption` config on clean install. This might be needed for some development or testing scenarios, where the TPM 2.0 needs to be cleared, e.g. to avoid the DA lockout mode on repeated provisioning attempts.

Related ADO items:

1. https://dev.azure.com/mariner-org/polar/_workitems/edit/15420/
3. https://dev.azure.com/mariner-org/polar/_workitems/edit/15443/