### PR TITLE
engineering: fix Makefile osmodifier target 

### DIFF
--- a/.pipelines/templates/stages/validate_makefile/dev-build.yml
+++ b/.pipelines/templates/stages/validate_makefile/dev-build.yml
@@ -27,6 +27,13 @@ stages:
 
         steps:
           - template: ../common_tasks/avoid-pypi-usage.yml
+
+          - bash: |
+              set -eux
+              make artifacts/osmodifier
+              rm -rf artifacts/osmodifier
+            displayName: Invoke make artifacts/osmodifier
+
           - template: ../common_tasks/download-osmodifier.yml
             parameters:
               osModifierBuildType: dev

--- a/packaging/docker/Dockerfile-osmodifier.azl3
+++ b/packaging/docker/Dockerfile-osmodifier.azl3
@@ -2,18 +2,18 @@
 
 FROM mcr.microsoft.com/azurelinux/base/core:3.0
 ARG GOLANG_VERSION=1.25.1
+ARG IMAGE_TOOLS_BRANCH=main
 
 RUN tdnf install -y make awk util-linux git python3 ca-certificates
 
 WORKDIR /work
-
-COPY azure-linux-image-tools ./azure-linux-image-tools
 
 RUN \
     tdnf list golang && \
     tdnf install golang-$(tdnf list golang | grep $GOLANG_VERSION | awk '{print $2}' | tail -n 1) -y
 
 RUN \
+    git clone --branch $IMAGE_TOOLS_BRANCH https://github.com/microsoft/azure-linux-image-tools && \
     mkdir -p ./azure-linux-image-tools/artifacts && \
     mkdir -p ./azure-linux-image-tools/SPECS && \
     rm $(find ./azure-linux-image-tools -name '*_test.go') && \


### PR DESCRIPTION
# 🔍 Description
 
Dockerfile-osmodifier.azl3 assumes submodule. Replace with clone. Add validation in dev-build pipeline.