### PR TITLE
docs: offline-init without selinux

### DIFF
--- a/docs/Tutorials/Onboard-a-VM-to-Trident.md
+++ b/docs/Tutorials/Onboard-a-VM-to-Trident.md
@@ -99,9 +99,6 @@ os:
     resetType: hard-reset
   hostname: update-ready-os
 
-  selinux:
-    mode: enforcing
-
   kernelCommandLine:
     extraCommandLine:
       - log_buf_len=1M


### PR DESCRIPTION
offline-init tests do not use selinux, leave selinux enablement for later.