### PR TITLE
engineering: Add job attempt to Test azl-installer artifact to allow reruns

### DIFF
--- a/.pipelines/templates/stages/trident_usb_iso/trident-usb-iso.yml
+++ b/.pipelines/templates/stages/trident_usb_iso/trident-usb-iso.yml
@@ -34,7 +34,7 @@ stages:
 
     variables:
       ob_outputDirectory: $(Pipeline.Workspace)/s/test-images/output
-      ob_artifactBaseName: azl-installer
+      ob_artifactBaseName: azl-installer_$(System.JobAttempt)
 
     steps:
     - checkout: test-images


### PR DESCRIPTION
# 🔍 Description
 
Add job attempt to the artifact name for the validation job on Test azl-installer stage. 

# 🤔 Rationale

No two artifacts with the same name can be published in the pipeline. When rerunning a failed job in a pipeline, if the previous failed run already published the artifact, new runs won't be able to publish, and a successful pipeline run can never be achieved (even when in theory it already succeeded). The artifact is not used by other stages, so inconsistent naming isn't a problem.

