### PR TITLE
engineering: Enable `SecureBoot` on all E2E VM tests

### DIFF
--- a/.pipelines/templates/stages/testing_vm/netlaunch-testing.yml
+++ b/.pipelines/templates/stages/testing_vm/netlaunch-testing.yml
@@ -175,23 +175,17 @@ stages:
                 MAX_FAILURES_FLAG="--max-failures 1"
               fi
 
-              # Enable SecureBoot for E2E tests that use usr-verity image.
-              # TODO: Enable SecureBoot for all E2E tests.
-              SECURE_BOOT=""
+              # Enable SecureBoot for all E2E tests.
+              SECURE_BOOT="--secure-boot"
+
+              # If this is a usr-verity image; a signing certificate must be
+              # set via --signing-cert; otherwise, set it to an empty string.
+              # This can also be used for sysext signing.
               TRIDENT_CONFIG="$(tridentConfigPath)/trident-config.yaml"
               IMAGE_URL=$(sudo yq '.image.url' "$TRIDENT_CONFIG")
-              if [[ "$IMAGE_URL" == *usrverity.cosi ]]; then
-                SECURE_BOOT="--secure-boot"
-              fi
-
-              # If a signing certificate exists, set --signing-cert to use it;
-              # otherwise, set it to an empty string. This can be used for
-              # SecureBoot and sysext signing.
-              # TODO: This needs to be updated to enable SecureBoot for all E2E
-              # tests.
               CERT_SEARCH_PATH="$(System.ArtifactsDirectory)/usrverity-testimage"
               CA_CERT_PATH="$CERT_SEARCH_PATH/ca_cert.pem"
-              if [ -f "$CA_CERT_PATH" ]; then
+              if [ "$IMAGE_URL" == *usrverity.cosi ] && [ -f "$CA_CERT_PATH" ]; then
                 SIGNING_CERT="--signing-cert $CA_CERT_PATH"
               else
                 SIGNING_CERT=""

--- a/.pipelines/templates/stages/testing_vm/netlaunch-testing.yml
+++ b/.pipelines/templates/stages/testing_vm/netlaunch-testing.yml
@@ -185,7 +185,7 @@ stages:
               IMAGE_URL=$(sudo yq '.image.url' "$TRIDENT_CONFIG")
               CERT_SEARCH_PATH="$(System.ArtifactsDirectory)/usrverity-testimage"
               CA_CERT_PATH="$CERT_SEARCH_PATH/ca_cert.pem"
-              if [ "$IMAGE_URL" == *usrverity.cosi ] && [ -f "$CA_CERT_PATH" ]; then
+              if [[ "$IMAGE_URL" == *usrverity.cosi ]] && [ -f "$CA_CERT_PATH" ]; then
                 SIGNING_CERT="--signing-cert $CA_CERT_PATH"
               else
                 SIGNING_CERT=""

--- a/tools/cmd/netlaunch/main.go
+++ b/tools/cmd/netlaunch/main.go
@@ -290,11 +290,6 @@ var rootCmd = &cobra.Command{
 			file.Close()
 		}
 
-		// Validate that if SecureBoot is enabled, a signing certificate is provided
-		if secureBoot && signingCert == "" {
-			log.Fatal("SecureBoot is enabled, but no signing certificate was provided")
-		}
-
 		if config.Netlaunch.LocalVmUuid != nil {
 			startLocalVm(*config.Netlaunch.LocalVmUuid, iso_location, secureBoot, signingCert)
 		} else {


### PR DESCRIPTION
# 🔍 Description
 
This PR enables `SecureBoot` on all E2E VM tests, including those using grub images. grub is already signed by Microsoft, so no signing certificate is provided.
