### PR TITLE
engineering: Remove stale KeyLocation

### DIFF
--- a/tools/pkg/config/config.go
+++ b/tools/pkg/config/config.go
@@ -8,7 +8,6 @@ type NetLaunchConfig struct {
 		AnnouncePort *uint16
 		Bmc          *bmc.Bmc
 		LocalVmUuid  *string
-		KeyLocation  *string
 	}
 	Iso struct {
 		PreTridentScript *string


### PR DESCRIPTION
# 🔍 Description
 
This PR removes the stale `KeyLocation` component of the `Netlaunch` struct. A signing certificate is now passed into Netlaunch as `--signing-cert` flag: https://github.com/microsoft/trident/blob/99499e0b76ea264562b5fe52fc07f8fd0969a5b4/tools/cmd/netlaunch/main.go#L403.
