### PR TITLE
Attended Installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,6 +435,27 @@ bin/virtdeploy: tools/cmd/virtdeploy/* tools/go.sum tools/pkg/* tools/pkg/virtde
 	@mkdir -p bin
 	cd tools && go build -o ../bin/virtdeploy ./cmd/virtdeploy
 
+# Installer tools
+
+INSTALLER_OUT_DIR := bin
+INSTALLER_DIR := tools/installer
+
+bin/manualrun: \
+	$(shell find $(INSTALLER_DIR)/imagegen/ -type f) \
+	$(INSTALLER_DIR)/go.sum
+	@mkdir -p bin
+	cd $(INSTALLER_DIR)/imagegen/attendedinstaller/_manualrun && \
+		CGO_ENABLED=0 go build -o ../../../../../$(INSTALLER_OUT_DIR)/manualrun
+
+# Copy End-User License Agreement example file to execution directory
+bin/EULA.txt: $(INSTALLER_DIR)/imagegen/attendedinstaller/_manualrun/EULA.txt
+	@mkdir -p bin
+	@cp $< $@
+
+.PHONY: run-manualrun
+run-manualrun: bin/manualrun bin/EULA.txt
+	@cd bin && ./manualrun && cd -
+
 .PHONY: validate
 validate: $(TRIDENT_CONFIG) bin/trident
 	@bin/trident validate $(TRIDENT_CONFIG)

--- a/tools/installer/imagegen/attendedinstaller/_manualrun/EULA.txt
+++ b/tools/installer/imagegen/attendedinstaller/_manualrun/EULA.txt
@@ -1,0 +1,1 @@
+SAMPLE EULA

--- a/tools/installer/imagegen/attendedinstaller/_manualrun/manualrun.go
+++ b/tools/installer/imagegen/attendedinstaller/_manualrun/manualrun.go
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"fmt"
+	"installer/imagegen/attendedinstaller"
+	"installer/internal/logger"
+	"os"
+	"path/filepath"
+
+	"github.com/alecthomas/kingpin/v2"
+)
+
+const passwordScriptName = "user-password.sh"
+
+var (
+	app           = kingpin.New("manualrun", "A tool to test the attendedinstaller without performing an installation.")
+	hostconfigDir = app.Flag("output-dir", "Directory where the generated Host Configuration file will be saved.").Default("").String()
+	logLevel      = app.Flag("log-level", "Set the log level.").Default("warn").String()
+)
+
+// manualrun is a tool to test the attendedinstaller in the current terminal window.
+// It will simply run the UI and print out the generated Host Configuration.
+func main() {
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+
+	// Set log-level
+	logger.InitStderrLog()
+	logger.SetStderrLogLevel(*logLevel)
+
+	// Create a temporary directory for test setup
+	tmpDir, err := os.MkdirTemp("", "trident-manualrun-*")
+	if err != nil {
+		logger.PanicOnError(fmt.Errorf("failed to create temp dir: %w", err))
+	}
+	// Clean up the entire temp directory when the program exits
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			logger.Log.Warnf("Could not delete temp directory: %v", err)
+		}
+	}()
+
+	// Create a fake .cosi files for testing
+	imagesDir, err := prepareTestDirectory(tmpDir)
+	if err != nil {
+		logger.PanicOnError(fmt.Errorf("failed to create fake COSI files: %w", err))
+	}
+
+	hostconfigPath := filepath.Join(tmpDir, "config.yaml")
+	passwordScriptPath := filepath.Join(tmpDir, "scripts", passwordScriptName)
+
+	attendedInstaller, err := attendedinstaller.New(imagesDir, hostconfigPath)
+	if err != nil {
+		logger.PanicOnError(err)
+	}
+	installationQuit, err := attendedInstaller.Run()
+	if err != nil {
+		logger.Log.Error(err)
+	}
+	if installationQuit {
+		logger.Log.Error("User quit installation")
+	}
+
+	displayContent(hostconfigPath, passwordScriptPath)
+
+	if *hostconfigDir != "" {
+		err = os.MkdirAll(*hostconfigDir, 0755)
+		if err != nil {
+			logger.Log.Warnf("Failed to create directory %s: %v", *hostconfigDir, err)
+		} else {
+			targetPath := filepath.Join(*hostconfigDir, "config.yaml")
+			err = os.Rename(hostconfigPath, targetPath)
+			if err != nil {
+				logger.Log.Errorf("Failed to move config file to %s: %v", targetPath, err)
+			} else {
+				logger.Log.Infof("Host configuration saved to: %s", targetPath)
+			}
+		}
+	}
+
+}
+
+// Shows the contents of the generated Host Configuration and the script to add the user's password
+func displayContent(hostconfigPath, passwordScriptPath string) {
+	fmt.Println("\n--- Generated Host Configuration: ---")
+	if data, err := os.ReadFile(hostconfigPath); err == nil {
+		fmt.Println(string(data))
+	} else {
+		logger.Log.Warnf("Could not read Host Configuration file: %v", err)
+	}
+	fmt.Println("\n--- Generated Password Script (", passwordScriptPath, ") ---")
+	if data, err := os.ReadFile(passwordScriptPath); err == nil {
+		fmt.Println(string(data))
+	} else {
+		logger.Log.Warnf("Could not read generated script to add user's password: %v", err)
+	}
+}
+
+// prepareTestDirectory creates the necessary files and directories for testing the attendedinstaller
+// and returns the path to the images directory containing the fake .cosi files.
+func prepareTestDirectory(testDir string) (string, error) {
+	// Create a directory for images and a fake .cosi file
+	imagesDir := filepath.Join(testDir, "images")
+	err := os.MkdirAll(imagesDir, 0755)
+	if err != nil {
+		return "", fmt.Errorf("failed to create images directory: %w", err)
+	}
+
+	fakeFiles := []string{
+		filepath.Join(imagesDir, "azure-linux-core.cosi"),
+		filepath.Join(imagesDir, "azure-linux-full.cosi"),
+	}
+
+	for _, filePath := range fakeFiles {
+		err := os.WriteFile(filePath, []byte("# Fake COSI file for testing\n"), 0644)
+		if err != nil {
+			return "", fmt.Errorf("failed to create fake COSI file %s: %w", filePath, err)
+		}
+	}
+
+	return imagesDir, nil
+}

--- a/tools/installer/imagegen/attendedinstaller/attendedinstaller.go
+++ b/tools/installer/imagegen/attendedinstaller/attendedinstaller.go
@@ -1,0 +1,446 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package attendedinstaller
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"installer/imagegen/attendedinstaller/speakuputils"
+	"installer/imagegen/attendedinstaller/uitext"
+	"installer/imagegen/attendedinstaller/views"
+	"installer/imagegen/attendedinstaller/views/confirmview"
+	"installer/imagegen/attendedinstaller/views/diskview"
+	"installer/imagegen/attendedinstaller/views/eulaview"
+	"installer/imagegen/attendedinstaller/views/hostnameview"
+	"installer/imagegen/attendedinstaller/views/imageselectorview"
+	"installer/imagegen/attendedinstaller/views/installerview"
+	"installer/imagegen/attendedinstaller/views/userview"
+	"installer/imagegen/configuration"
+	"installer/imagegen/imageutils"
+	"installer/internal/logger"
+
+	"github.com/bendahl/uinput"
+	"github.com/gdamore/tcell"
+	"github.com/rivo/tview"
+)
+
+// UI constants.
+const (
+	defaultGridWeight = 1
+
+	textRow        = 3
+	textColumn     = 0
+	textRowSpan    = 1
+	textColumnSpan = 1
+	textMinSize    = 0
+
+	helpTextPadding       = 2
+	helpTextProportion    = 0
+	versionTextMinSize    = 0
+	versionTextProportion = 1
+
+	titleTextProportion = 1
+	titleRow            = 0
+	titleColumn         = 0
+	titleRowSpan        = 1
+	titleColumnSpan     = 1
+
+	primaryContentRow        = 1
+	primaryContentColumn     = 0
+	primaryContentRowSpan    = 1
+	primaryContentColumnSpan = 1
+	primaryContentMinSize    = 0
+	primaryContentGridWeight = -100
+)
+
+// AttendedInstaller contains the attended installer configuration
+type AttendedInstaller struct {
+	app               *tview.Application
+	exitModal         *tview.Modal
+	grid              *tview.Grid
+	pauseCustomInput  bool
+	pauseSpeakupInput bool
+	currentView       int
+	allViews          []views.View
+	backdropStyle     tview.Theme
+	titleText         *tview.TextView
+	keyboard          uinput.Keyboard
+
+	installationError    error
+	installationTime     time.Duration
+	userQuitInstallation bool
+	hostconfigPath       string
+	hostConfigData       *configuration.TridentConfigData
+	availableImages      []imageutils.SystemImage
+}
+
+// New creates and returns a new AttendedInstaller.
+func New(imagedirectory string, hostConfigPath string) (attendedInstaller *AttendedInstaller, err error) {
+	attendedInstaller = &AttendedInstaller{}
+	attendedInstaller.hostConfigData = configuration.NewTridentConfigData()
+	attendedInstaller.hostconfigPath = hostConfigPath
+	attendedInstaller.availableImages, err = imageutils.DiscoverSystemImages(imagedirectory)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover system images: %w", err)
+	}
+
+	err = attendedInstaller.initializeUI()
+	return
+}
+
+// Run shows the attended installer UI on the current thread.
+// When the user completes the installer, the function will return.
+// When producing the Host configuration, it would be best to return it from this function.
+func (ai *AttendedInstaller) Run() (installationQuit bool, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("unexpected failure: %v", r)
+		}
+	}()
+
+	// Close virtual keyboard when installer exits, if we have a keyboard
+	if ai.keyboard != nil {
+		defer ai.keyboard.Close()
+	}
+
+	// Backup the original stderr writer and replace it will a null writer.
+	// If the logger prints to the console while the UI is shown, it will conflict
+	// with the TUI (terminal UI) and result in undefined behavior.
+	// The log hooks that enable file logging will remain intact and still record
+	// logs.
+	originalStderrWriter := logger.ReplaceStderrWriter(io.Discard)
+	defer func() {
+		logger.ReplaceStderrWriter(originalStderrWriter)
+	}()
+
+	err = ai.app.SetRoot(ai.grid, true).Run()
+	if err != nil {
+		return
+	}
+
+	installationQuit = ai.userQuitInstallation
+	if ai.userQuitInstallation {
+		return
+	}
+
+	err = ai.installationError
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (ai *AttendedInstaller) nextPage() {
+	ai.app.QueueUpdateDraw(func() {
+		err := ai.switchToView(ai.currentView + 1)
+		logger.PanicOnError(err, "Failed to go to next page")
+	})
+}
+
+func (ai *AttendedInstaller) previousPage() {
+	ai.app.QueueUpdateDraw(func() {
+		err := ai.switchToView(ai.currentView - 1)
+		logger.PanicOnError(err, "Failed to go to previous page")
+	})
+}
+
+func (ai *AttendedInstaller) switchToView(newView int) (err error) {
+	if newView == len(ai.allViews) {
+		ai.app.Stop()
+		return
+	} else if newView == -1 {
+		ai.quit()
+		return
+	}
+
+	ai.grid.RemoveItem(ai.allViews[ai.currentView].Primitive())
+	err = ai.showView(newView)
+	return
+}
+
+func (ai *AttendedInstaller) showView(newView int) (err error) {
+	view := ai.allViews[newView]
+
+	logger.Log.Debugf("Showing view: %s", view.Name())
+
+	// Clear the text-to-speech buffer when we change pages
+	// Pause TUI input while input to clear the buffer is sent
+	ai.pauseSpeakupInput = true
+	err = speakuputils.ClearSpeakupBuffer(ai.keyboard)
+	if err != nil {
+		logger.Log.Warnf("Error clearing speakup buffer, signal was not sent")
+		ai.pauseSpeakupInput = false
+		err = nil
+	}
+
+	err = view.Reset()
+	if err != nil {
+		return
+	}
+
+	ai.grid.AddItem(view.Primitive(), primaryContentRow, primaryContentColumn, primaryContentRowSpan, primaryContentColumnSpan, primaryContentMinSize, primaryContentMinSize, true)
+	ai.app.SetFocus(ai.grid)
+	ai.currentView = newView
+	view.OnShow()
+	ai.refreshTitle()
+
+	return
+}
+
+func (ai *AttendedInstaller) refreshTitle() {
+	ai.titleText.SetText(ai.allViews[ai.currentView].Title())
+}
+
+func (ai *AttendedInstaller) quit() {
+	ai.pauseCustomInput = true
+	// Set focus on the cancel option
+	ai.exitModal.SetFocus(1)
+	ai.grid.AddItem(ai.exitModal, primaryContentRow, primaryContentColumn, primaryContentRowSpan, primaryContentColumnSpan, primaryContentMinSize, primaryContentMinSize, true)
+	ai.app.SetFocus(ai.exitModal)
+}
+
+func (ai *AttendedInstaller) globalInputCapture(event *tcell.EventKey) *tcell.EventKey {
+	// If we're clearing the speakup buffer, don't process keypresses
+	// tcell has no easy way of differentiating between keypad enter (speakup clear) and enter
+	if ai.pauseSpeakupInput && event.Key() == tcell.KeyEnter {
+		// Resume TUI input, input intended to clear the buffer has been ignored
+		ai.pauseSpeakupInput = false
+		return nil
+	}
+	if !ai.pauseCustomInput {
+		event = ai.allViews[ai.currentView].HandleInput(event)
+		if event == nil {
+			return nil
+		}
+	}
+
+	switch event.Key() {
+	case tcell.KeyCtrlC:
+		event = nil
+		ai.app.QueueUpdateDraw(func() {
+			ai.quit()
+		})
+	}
+
+	return event
+}
+
+func (ai *AttendedInstaller) initializeUI() (err error) {
+	ai.keyboard, err = speakuputils.CreateVirtualKeyboard()
+	if err != nil {
+		// Non-fatal - results in a slightlydegraded experience due to the lack of a
+		// text-to-speech buffer clear between views, but not bad enough to exit outright
+		logger.Log.Warnf("Failed to initialize virtual keyboard via uinput")
+		err = nil
+	}
+	err = speakuputils.SetHighlightTrackingMode(ai.keyboard)
+	if err != nil {
+		logger.Log.Warnf("Error setting highlight tracking mode for speakup")
+		err = nil
+	}
+
+	const osReleaseFile = "/etc/os-release"
+
+	// For "bright" colors, we need to manually specify RGB values
+	// As they do not have them by default
+	ai.backdropStyle = tview.Theme{
+		PrimitiveBackgroundColor:    tcell.ColorBlack,
+		ContrastBackgroundColor:     tcell.ColorWhite,
+		MoreContrastBackgroundColor: tcell.ColorDarkBlue,
+		BorderColor:                 tcell.ColorBlack,
+		TitleColor:                  tcell.ColorWhite,
+		GraphicsColor:               tcell.ColorWhite,
+		PrimaryTextColor:            tcell.ColorWhite,
+		SecondaryTextColor:          tcell.ColorBlack,
+		TertiaryTextColor:           tcell.ColorRed,
+		InverseTextColor:            tcell.ColorGreen,
+		ContrastSecondaryTextColor:  tcell.ColorWhite,
+	}
+
+	tview.Styles = tview.Theme{
+		PrimitiveBackgroundColor:    tcell.ColorBlack,
+		ContrastBackgroundColor:     tcell.ColorBlack,
+		MoreContrastBackgroundColor: tcell.ColorGreen,
+		BorderColor:                 tcell.ColorRed,
+		TitleColor:                  tcell.ColorWhite,
+		GraphicsColor:               tcell.ColorGreen,
+		PrimaryTextColor:            tcell.ColorWhite,
+		SecondaryTextColor:          tcell.ColorDarkCyan,
+		TertiaryTextColor:           tcell.ColorRed,
+		InverseTextColor:            tcell.ColorBlack,
+		ContrastSecondaryTextColor:  tcell.ColorGreen,
+	}
+
+	ai.app = tview.NewApplication()
+
+	helpText := tview.NewTextView().
+		SetTextColor(ai.backdropStyle.PrimaryTextColor).
+		SetText(uitext.NavigationHelp).
+		SetChangedFunc(func() {
+			ai.app.Draw()
+		})
+
+	releaseVer, err := releaseVersion(osReleaseFile)
+	if err != nil {
+		return
+	}
+
+	osVersionText := tview.NewTextView().
+		SetTextAlign(tview.AlignRight).
+		SetTextColor(ai.backdropStyle.PrimaryTextColor).
+		SetText(releaseVer).
+		SetChangedFunc(func() {
+			ai.app.Draw()
+		})
+
+	ai.titleText = tview.NewTextView().
+		SetTextColor(ai.backdropStyle.PrimaryTextColor).
+		SetTextAlign(tview.AlignCenter).
+		SetChangedFunc(func() {
+			ai.app.Draw()
+		})
+
+	err = ai.initializeViews()
+	if err != nil {
+		return
+	}
+
+	// Create a flex box to hold all global text in the same grid space
+	helpTextMinSize := tview.TaggedStringWidth(helpText.GetText(false)) + helpTextPadding
+	textFlex := tview.NewFlex().
+		SetDirection(tview.FlexColumn).
+		AddItem(helpText, helpTextMinSize, helpTextProportion, false).
+		AddItem(osVersionText, versionTextMinSize, versionTextProportion, false)
+
+	titleFlex := tview.NewFlex().
+		SetDirection(tview.FlexColumn).
+		AddItem(ai.titleText, textMinSize, titleTextProportion, false)
+
+	ai.grid = tview.NewGrid().
+		SetRows(defaultGridWeight, primaryContentGridWeight, defaultGridWeight).
+		SetColumns(primaryContentGridWeight).
+		AddItem(titleFlex, titleRow, titleColumn, titleRowSpan, titleColumnSpan, textMinSize, helpTextMinSize, false).
+		AddItem(textFlex, textRow, textColumn, textRowSpan, textColumnSpan, textMinSize, textMinSize, false)
+
+	ai.exitModal = tview.NewModal().
+		SetText(uitext.ExitModalTitle).
+		AddButtons([]string{uitext.ButtonQuitWhiteBold, uitext.ButtonCancelWhiteBold}).
+		SetBackgroundColor(ai.backdropStyle.TertiaryTextColor).
+		SetButtonBackgroundColor(ai.backdropStyle.TertiaryTextColor).
+		SetTextColor(ai.backdropStyle.ContrastSecondaryTextColor).
+		SetButtonTextColor(ai.backdropStyle.PrimitiveBackgroundColor).
+		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+			if buttonLabel == uitext.ButtonQuitWhiteBold {
+				ai.userQuitInstallation = true
+				ai.app.Stop()
+			} else {
+				ai.grid.RemoveItem(ai.exitModal)
+				ai.app.SetFocus(ai.grid)
+				ai.pauseCustomInput = false
+			}
+		})
+
+	helpText.SetBackgroundColor(ai.backdropStyle.ContrastBackgroundColor)
+	osVersionText.SetBackgroundColor(ai.backdropStyle.ContrastBackgroundColor)
+	textFlex.SetBackgroundColor(ai.backdropStyle.ContrastBackgroundColor)
+	titleFlex.SetBackgroundColor(ai.backdropStyle.ContrastBackgroundColor)
+	ai.titleText.SetBackgroundColor(ai.backdropStyle.ContrastBackgroundColor)
+
+	helpText.SetTextColor(ai.backdropStyle.SecondaryTextColor)
+	osVersionText.SetTextColor(ai.backdropStyle.SecondaryTextColor)
+	ai.titleText.SetTextColor(ai.backdropStyle.SecondaryTextColor)
+
+	ai.showView(ai.currentView)
+	// Initialize input capture and custom input handling for TUI.
+	ai.pauseSpeakupInput = false
+	ai.app.SetInputCapture(ai.globalInputCapture)
+
+	return
+}
+
+func (ai *AttendedInstaller) initializeViews() (err error) {
+	installerView := installerview.New()
+	if installerView.NeedsToPrompt() {
+		ai.allViews = append(ai.allViews, installerView)
+	}
+
+	imageselectorView := imageselectorview.New(ai.availableImages, ai.hostConfigData)
+	if imageselectorView.NeedsToPrompt() {
+		ai.allViews = append(ai.allViews, imageselectorView)
+	} else {
+		logger.Log.Infof("Single image detected, automatically selected")
+	}
+
+	ai.allViews = append(ai.allViews, eulaview.New())
+	ai.allViews = append(ai.allViews, diskview.New())
+	ai.allViews = append(ai.allViews, hostnameview.New())
+	ai.allViews = append(ai.allViews, userview.New())
+	ai.allViews = append(ai.allViews, confirmview.New(ai.hostconfigPath))
+
+	for i, view := range ai.allViews {
+		var backButtonText string
+
+		if i == 0 {
+			backButtonText = uitext.ButtonCancel
+		} else {
+			backButtonText = uitext.ButtonGoBack
+		}
+
+		err = view.Initialize(ai.hostConfigData, backButtonText, ai.app, ai.nextPage, ai.previousPage, ai.quit, ai.refreshTitle)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func releaseVersion(releaseFile string) (version string, err error) {
+	const attributeName = "VERSION"
+
+	logger.Log.Debug("Searching release file for version")
+	logger.Log.Debugf("releaseFile = %s", releaseFile)
+	logger.Log.Debugf("attributeName = %s", attributeName)
+
+	file, err := os.Open(releaseFile)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		// format: FIELD=VALUE
+		line := strings.TrimSpace(scanner.Text())
+
+		if !strings.HasPrefix(line, attributeName) {
+			continue
+		}
+
+		attribute := strings.Split(line, "=")
+		if len(attribute) != 2 {
+			logger.Log.Warnf("Unexpected format found, skipping: %s", line)
+			continue
+		}
+
+		attributeValue := strings.TrimSpace(attribute[1])
+		// Remove any wrapping double quotes.
+		if len(attributeValue) > 1 && strings.HasPrefix(attributeValue, `"`) {
+			version = attributeValue[1 : len(attributeValue)-1]
+		} else {
+			version = attributeValue
+		}
+
+		return
+	}
+
+	err = fmt.Errorf("unable to find release version in file (%s)", releaseFile)
+	return
+}


### PR DESCRIPTION

**Comparison PR to show the actual changes introduced in: https://github.com/microsoft/trident/pull/260**


# 🔍 Description
 
This PR adds the attended installer, which coordinates the interactive installation process, and manualrun, a tool for testing the attended installer without performing an actual installation. The manualrun tool simulates the installation workflow and displays the generated Host Configuration. Make rules to build and run the manualrun binary are also included.

 Run `make run-manualrun` to test the attended installer locally.

## Changes from the original files

Both `attendedinstaller` and `manualrun` have previous versions in the Azure Linux repository and as such have been previously reviewed. However, both files have undergone significant changes:

**Manualrun**: The `manualrun` tool has been almost completely reimplemented. The main similarity with the original file is its purpose.

**Attendedinstaller**: The `attendedinstaller` has been decoupled from the original imager structure and updated to generate a Host Configuration by saving user input in a new structure (`TridentConfigData`). The logic to perform the GUI interface with Calamares has also been removed. The main changes in this file are:
- The AttendedInstaller struct itself
- The constructor (`New`).
- The initialization of views (`initializeViews`), where the corresponding files responsible for each screen are initialized with different parameters form the original.
Note: Modifications to the individual screens have already been reviewed in previous PRs.
