### PR TITLE
bug: Use cpio to extract Trident binary

### DIFF
--- a/scripts/extract-binary.sh
+++ b/scripts/extract-binary.sh
@@ -11,7 +11,7 @@ RPM=$(find $1 | grep -P 'trident-\d.*\.rpm')
 cp "$RPM" "$TMP_DIR/trident.rpm"
 
 pushd "$TMP_DIR"
-rpm2cpio "$RPM" | cpio -idmv
+rpm2cpio trident.rpm | cpio -idmv
 popd
 
 mv "$TMP_DIR/usr/bin/trident" $2


### PR DESCRIPTION
# 🔍 Description
 
`rpm2cpio` and `cpio` more reliably decompress and extract the Trident binary. 

# 🤔 Rationale

Pipeline was failing for PR https://github.com/microsoft/trident/pull/274

