### PR TITLE
bug: If the datastore has no saved HS, we're in the MOS

### DIFF
--- a/crates/trident/src/datastore.rs
+++ b/crates/trident/src/datastore.rs
@@ -53,7 +53,10 @@ impl DataStore {
             .structured(ServicingError::Datastore {
                 inner: DatastoreError::InitializeDatastore,
             })?
-            .unwrap_or_default();
+            .unwrap_or(HostStatus {
+                is_management_os: true,
+                ..Default::default()
+            });
 
         Ok(Self {
             db: Some(db),


### PR DESCRIPTION
Due to how sqlite works, the datastore file is created when we start staging but we only write a host status to it once staging is done. Thus if Trident is interrupted during the staging process we'll encounter an empty datastore on the next run.

This PR changes things so that we interpret an empty datastore as indicating the MOS.