### PR TITLE
engineering: Increase timeout threshold for PrepareSSHKeys job

### DIFF
--- a/.pipelines/templates/stages/testing_servicing/generate-ssh-keys.yml
+++ b/.pipelines/templates/stages/testing_servicing/generate-ssh-keys.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: PrepareSSHKeys
     displayName: Prepare SSH Keys
-    timeoutInMinutes: 5
+    timeoutInMinutes: 8
     pool:
       type: linux
 


### PR DESCRIPTION
# 🔍 Description
 
Increase timeout threshold for PrepareSSHKeys job

# 🤔 Rationale

The pipeline run failed because the PrepareSSHKeys job timed out after publishing its artifact. Even if the job was rerun, it would fail since an artifact with the same name already exists. This happened because the CodeQL Initialize OneBranch task took longer than usual, as it sometimes does when building the CodeQL database. This means that a new pipeline run is needed, increasing the timeout threshold should avoid most of these cases.

Note: The artifact is consumed by another job, therefore it needs a consistent name so the job attempt can't be added to the artifact name. It could be argued that to cover this type of issues we could always consume the artifact with the job attempt 1 (as that one works and the issue was just a timeout), but that seems like a more convoluted solution to this issue.