### PR TITLE
engineering: capture screenshots

### DIFF
--- a/.pipelines/templates/stages/testing_common/capture-screenshot.yml
+++ b/.pipelines/templates/stages/testing_common/capture-screenshot.yml
@@ -1,0 +1,34 @@
+parameters:
+  - name: deploymentEnvironment
+    type: string
+    default: virtualMachine
+    values:
+      - virtualMachine
+      - bareMetal
+
+  - name: screenshotName
+    type: string
+
+  - name: vmName
+    type: string
+    default: "virtdeploy-vm-0"
+
+  - name: forceRun
+    type: boolean
+    default: false
+
+steps:
+  - ${{ if eq(parameters.deploymentEnvironment, 'virtualMachine') }}:
+    - bash: |
+        sudo apt-get install -y imagemagick
+      displayName: Install image package
+      condition: and(succeededOrFailed(), or(${{ parameters.forceRun }}, ne(variables['abActiveVolume'], 'null')))
+      retryCountOnTaskFailure: 3
+    - bash: |
+        set -eux
+        mkdir -p $(ob_outputDirectory)
+        # Capture screenshot from the VM using virsh and convert it to PNG format
+        sudo virsh screenshot ${{ parameters.vmName }} /tmp/screenshot.ppm
+        convert /tmp/screenshot.ppm $(ob_outputDirectory)/${{ parameters.screenshotName }}.png
+      condition: and(succeededOrFailed(), or(${{ parameters.forceRun }}, ne(variables['abActiveVolume'], 'null')))
+      displayName: "📷 Capture screenshot: ${{ parameters.screenshotName }}"

--- a/.pipelines/templates/stages/testing_common/e2e-ab-update-stage-finalize-test-run.yml
+++ b/.pipelines/templates/stages/testing_common/e2e-ab-update-stage-finalize-test-run.yml
@@ -165,6 +165,11 @@ steps:
     displayName: "🔄 Finalize A/B update into target OS"
     condition: and(succeeded(), ne(variables['abActiveVolume'], 'null'))
 
+  - template: ../testing_common/capture-screenshot.yml
+    parameters:
+      screenshotName: "finalize"
+      deploymentEnvironment: ${{ parameters.deploymentEnvironment }}
+
   - template: ../testing_common/display-serial-logs.yml
     parameters:
       netlistenConfigFile: ${{ parameters.netlistenConfigFile }}

--- a/.pipelines/templates/stages/testing_common/e2e-test-run.yml
+++ b/.pipelines/templates/stages/testing_common/e2e-test-run.yml
@@ -160,6 +160,11 @@ steps:
     displayName: "🅱️🔄 Stage and finalize A/B update into target OS B"
     condition: and(succeeded(), ne(variables['abActiveVolume'], 'null'))
 
+  - template: ../testing_common/capture-screenshot.yml
+    parameters:
+      screenshotName: "update-b"
+      deploymentEnvironment: ${{ parameters.deploymentEnvironment }}
+
   - template: ../testing_common/display-serial-logs.yml
     parameters:
       netlistenConfigFile: ${{ parameters.netlistenConfigFile }}
@@ -268,6 +273,11 @@ steps:
     workingDirectory: $(Build.SourcesDirectory)
     displayName: "🅰️🔄 Stage and finalize A/B update into target OS A"
     condition: and(succeeded(), ne(variables['abActiveVolume'], 'null'))
+
+  - template: ../testing_common/capture-screenshot.yml
+    parameters:
+      screenshotName: "update-a"
+      deploymentEnvironment: ${{ parameters.deploymentEnvironment }}
 
   - template: ../testing_common/display-serial-logs.yml
     parameters:

--- a/.pipelines/templates/stages/testing_vm/netlaunch-testing.yml
+++ b/.pipelines/templates/stages/testing_vm/netlaunch-testing.yml
@@ -217,6 +217,12 @@ stages:
             displayName: "🚀 Run netlaunch for testing"
             timeoutInMinutes: 20
 
+          - template: ../testing_common/capture-screenshot.yml
+            parameters:
+              screenshotName: "install"
+              deploymentEnvironment: virtualMachine
+              forceRun: true
+
           - template: ../testing_common/display-deployment-logs.yml
             parameters:
               deploymentLogPath: $(tridentSourceDirectory)/logstream-full.log


### PR DESCRIPTION
# 🔍 Description
 
Capture VM screenshot after servicing operation. Provides more information if test fails, but no errors show up in logs.

Useful for
* https://github.com/microsoft/trident/pull/127
* https://github.com/microsoft/trident/pull/245