### PR TITLE
engineering: increase bm install timeout

### DIFF
--- a/.pipelines/templates/stages/testing_baremetal/baremetal-testing.yml
+++ b/.pipelines/templates/stages/testing_baremetal/baremetal-testing.yml
@@ -298,7 +298,7 @@ stages:
                   --full-logstream logstream-full.log \
                   --wait-for-provisioned-state \
                   --port ${{ variables.NETLAUNCH_PORT }} 2>&1 | tee ./clean-install-deployment.log
-            timeoutInMinutes: 30
+            timeoutInMinutes: 35
             workingDirectory: ${{ variables.TRIDENT_SOURCE_DIR }}
             displayName: "Run netlaunch for testing"
 


### PR DESCRIPTION
# 🔍 Description
 
BM rerun e2e test often takes ~26 minutes to run, but in the last week:
* 29:58 to successfully run
* 3 timeouts with timeout set to 30 minutes

Increase timeout to 35 minutes.