### PR TITLE
test: Update root-verity to create two partitions for extension images

### DIFF
--- a/tests/e2e_tests/trident_configurations/root-verity/trident-config.yaml
+++ b/tests/e2e_tests/trident_configurations/root-verity/trident-config.yaml
@@ -40,12 +40,18 @@ storage:
         - id: trident
           type: linux-generic
           size: 500M
-        - id: exts-a
+        - id: sysexts-a
           type: linux-generic
           size: 1G
-        - id: exts-b
+        - id: sysexts-b
           type: linux-generic
           size: 1G
+        - id: confexts-a
+          type: linux-generic
+          size: 200M
+        - id: confexts-b
+          type: linux-generic
+          size: 200M
         - id: var
           type: linux-generic
           size: 1G
@@ -67,9 +73,12 @@ storage:
       - id: trident-overlay
         volumeAId: trident-overlay-a
         volumeBId: trident-overlay-b
-      - id: exts
-        volumeAId: exts-a
-        volumeBId: exts-b
+      - id: sysexts
+        volumeAId: sysexts-a
+        volumeBId: sysexts-b
+      - id: confexts
+        volumeAId: confexts-a
+        volumeBId: confexts-b
   verity:
     - id: root
       name: root
@@ -91,8 +100,10 @@ storage:
     - deviceId: trident
       source: new
       mountPoint: /var/lib/trident
-    - deviceId: exts
-      mountPoint: /var/lib
+    - deviceId: sysexts
+      mountPoint: /var/lib/extensions
+    - deviceId: confexts
+      mountPoint: /var/lib/confexts
     - deviceId: var
       mountPoint: /var
     - deviceId: root


### PR DESCRIPTION
# 🔍 Description
 
Mount two filesystems for sysexts and confexts, respectively. 

# 🤔 Rationale

This way we don't mount all of `/var/lib`, but are more selective.

# 📝 Checks

- [ ] Check [dev-docs/manual-validation.md](/dev-docs/manual-validation.md)


# 📌 Follow-ups

TODO:

- #0000

# 🗒️ Notes
