### PR TITLE
engineering: More clippy fixes and update rustc version

### DIFF
--- a/.pipelines/templates/stages/common_tasks/rustup.yml
+++ b/.pipelines/templates/stages/common_tasks/rustup.yml
@@ -3,7 +3,7 @@ steps:
     inputs:
       # Can be any "MSRustup" version, such as ms-stable, ms-1.54 or ms-stable-20210513.5 - for more details see https://mscodehub.visualstudio.com/Rust/_git/rust.msrustup
       # For supported versions see https://mscodehub.visualstudio.com/Rust/_packaging?_a=package&feed=Rust&view=versions&package=rust.tools-x86_64-pc-windows-msvc&protocolType=NuGet
-      rustVersion: ms-1.88
+      rustVersion: ms-prod-1.90
       # Space separated list of additional targets: only the host target is supported with the toolchain by default.
       #additionalTargets: $(additionalRustTargets)
       # URL of an Azure Artifacts feed configured with a crates.io upstream. Must be within the current ADO collection.

--- a/crates/trident/src/osimage/mock.rs
+++ b/crates/trident/src/osimage/mock.rs
@@ -103,7 +103,7 @@ impl MockOsImage {
     }
 
     /// Returns the ESP filesystem image.
-    pub fn esp_filesystem(&self) -> Result<OsImageFileSystem, Error> {
+    pub fn esp_filesystem(&self) -> Result<OsImageFileSystem<'_>, Error> {
         if let Some(esp_img) = self
             .images
             .iter()
@@ -126,7 +126,7 @@ impl MockOsImage {
     }
 
     /// Returns non-ESP filesystems.
-    pub fn filesystems(&self) -> impl Iterator<Item = OsImageFileSystem> {
+    pub fn filesystems(&self) -> impl Iterator<Item = OsImageFileSystem<'_>> {
         self.images
             .iter()
             .filter(|fs| fs.part_type != DiscoverablePartitionType::Esp)


### PR DESCRIPTION
Fixes a few more issues flagged by clippy, and updates to using rustc 1.90 