### PR TITLE
bug: Fix test_get_binary_paths_pcrlock() FT

### DIFF
--- a/crates/trident/src/engine/storage/encryption.rs
+++ b/crates/trident/src/engine/storage/encryption.rs
@@ -677,7 +677,7 @@ mod functional_test {
         efivar::set_efi_variable(&var_name, &efivar::encode_utf16le("")).unwrap();
 
         // Remove all created files
-        expected_paths.extend(expected_paths_mnt.clone());
+        expected_paths.extend(expected_paths_mnt);
         for p in expected_paths {
             if Path::new(&p).exists() {
                 fs::remove_file(p).unwrap();


### PR DESCRIPTION
# 🔍 Description
 
This PR is to fix the following bug: https://dev.azure.com/mariner-org/polar/_workitems/edit/16060

The fix is to remove the binary files created in `test_get_binary_paths_pcrlock()` at the end of the testing func. Otherwise, the FT fails on the second run of the FTs in the `trident-ci` pipeline because in the first test, it expects the files to not be present in the system.