### PR TITLE
engineering: ob_outputdir doesn't seem to exist in CI

### DIFF
--- a/tools/storm/scripts/capture_screenshot/capture_screenshot.go
+++ b/tools/storm/scripts/capture_screenshot/capture_screenshot.go
@@ -32,6 +32,11 @@ func (s *CaptureScreenshotScript) Run() error {
 		return err
 	}
 
+	err = os.MkdirAll(s.ArtifactsFolder, 0755)
+	if err != nil {
+		return err
+	}
+
 	pngPath := filepath.Join(s.ArtifactsFolder, s.ScreenshotFilename)
 	if err := convertPpmToPng(ppmFilename.Name(), pngPath); err != nil {
 		return err


### PR DESCRIPTION
# 🔍 Description
 
CI pipelines are failing to capture screenshots (only the first call to the helper)