### PR TITLE
engineering: onebranch does not create ob_outputDirectory

### DIFF
--- a/.pipelines/templates/MockOB.yml
+++ b/.pipelines/templates/MockOB.yml
@@ -112,7 +112,7 @@ stages:
                   - bash: |
                       set -eux
                       mkdir -p "${{ variables.ob_outputDirectory }}"
-                    displayName: "Create output directory"
+                    displayName: "Ensure output directory exists before publishing artifacts"
                   - publish: ${{ variables.ob_outputDirectory }}
                     artifact: ${{ variables.ob_customArtifactName }}
                     condition: succeeded()


### PR DESCRIPTION
# 🔍 Description
 
OneBranch does not create ob_outputDirectory, MockOB should not.

Validation: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=979084&view=results