### PR TITLE
engineering: Servicing images, extend timeout

### DIFF
--- a/.pipelines/templates/stages/testing_servicing/build-image.yml
+++ b/.pipelines/templates/stages/testing_servicing/build-image.yml
@@ -40,7 +40,7 @@ parameters:
 jobs:
   - job: PrepareImage_${{ replace(parameters.label, '-', '_') }}
     displayName: Prepare Image ${{ parameters.label }}
-    timeoutInMinutes: 15
+    timeoutInMinutes: 20
     pool:
       type: linux
 


### PR DESCRIPTION
# 🔍 Description

Increasing timeout to build Servicing Test Images.

# 🤔 Rationale

The [CodeQL ](https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/codeql/codeql-semmle) OB task performs static analysis for security on the codebase. Occasionally, it needs to build a database (it’s triggered intermittently). As building and uploading the CodeQL database can take significant time, [they recommend increasing the timeout](https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/codeql/snippets/codeql-3000-other-issues#timeouts). As the code base grows, the task also takes longer, that is why we have seen more failures recently:

- https://dev.azure.com/mariner-org/polar/_workitems/edit/16181
- https://dev.azure.com/mariner-org/polar/_workitems/edit/16186

For context:
In passing runs, CodeQL completes in <40 seconds.
On runs where the database build occurs, it takes 5–9 minutes.
When the job fails due to timeout, it typically runs for about 16 minutes (it would be slightly more because some of the final tasks are skipped after failure, but those are quick tasks anyway).

We are increasing the timeout to 20 minutes to accommodate these longer runs and prevent unnecessary failures.
