### PR TITLE
engineering: run rollback tests on a few bare metal tests

### DIFF
--- a/.pipelines/templates/stages/testing_common/e2e-test-abupdate-scenario.yml
+++ b/.pipelines/templates/stages/testing_common/e2e-test-abupdate-scenario.yml
@@ -177,9 +177,9 @@ steps:
     displayName: "🔄${{ parameters.updateEmoji }} Stage and finalize A/B update into target OS ${{ parameters.updateScenarioTargetOs }} testing ${{ parameters.updateScenarioName }}"
     condition: and(succeeded(), ne(variables['abActiveVolume'], 'null'))
     ${{ if eq(parameters.deploymentEnvironment, 'bareMetal') }}:
-      timeoutInMinutes: 30
+      timeoutInMinutes: 22
     ${{ else }}:
-      timeoutInMinutes: 15
+      timeoutInMinutes: 12
 
   - ${{ if eq(parameters.deploymentEnvironment, 'virtualMachine') }}:
     - bash: |


### PR DESCRIPTION
# 🔍 Description
 
Rollback tests add about 10 minutes to BM test runs.  The rollback tests run on most VM e2e ab update tests, enabling for the weekly (full-validation) BM pipeline and for the 'combined' BM e2e tests on prerelease.

