### PR TITLE
WIP: engineering: allow rerun of update that has failed health check

### DIFF
--- a/crates/trident/src/lib.rs
+++ b/crates/trident/src/lib.rs
@@ -604,7 +604,7 @@ impl Trident {
                             Ok(ExitKind::Done)
                         }
                     }
-                    ServicingState::AbUpdateFinalized | ServicingState::Provisioned => {
+                    ServicingState::AbUpdateHealthCheckFailed | ServicingState::AbUpdateFinalized | ServicingState::Provisioned => {
                         // Need to either re-execute the failed update OR inform the user that no update
                         // is needed.
                         engine::update(&host_config, datastore, &allowed_operations, image, #[cfg(feature = "grpc-dangerous")] sender).message("Failed to update host")


### PR DESCRIPTION
# 🔍 Description
 
Trident currently has special casing to allow rerun of `trident udpate` for failed update in AbUpdateFinalized state. Enable similar for AbUpdateHealthCheckFailed state.