### PR TITLE
engineering: Do not clear TPM on rerun E2E test

### DIFF
--- a/tests/e2e_tests/trident_configurations/rerun/trident-config.yaml
+++ b/tests/e2e_tests/trident_configurations/rerun/trident-config.yaml
@@ -119,7 +119,6 @@ storage:
       - boot-loader-code # 4
       - secure-boot-policy # 7
       - kernel-boot # 11
-    clearTpmOnInstall: true
   abUpdate:
     volumePairs:
       - id: boot


### PR DESCRIPTION
# 🔍 Description
 
This PR modifies the `rerun` HC so that the TPM 2.0 is not cleared on clean install, which is the default.
