### PR TITLE
tests: Extend timeout on Prepare SSH Keys job

### DIFF
--- a/.pipelines/templates/stages/testing_servicing/generate-ssh-keys.yml
+++ b/.pipelines/templates/stages/testing_servicing/generate-ssh-keys.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: PrepareSSHKeys
     displayName: Prepare SSH Keys
-    timeoutInMinutes: 8
+    timeoutInMinutes: 10
     pool:
       type: linux
 


### PR DESCRIPTION
# 🔍 Description
 
This PR extends the timeout on Prepare SSH Keys job from 8 to 10 minutes. We've been seeing this step time out in the past few months:

- https://dev.azure.com/mariner-org/polar/_workitems/edit/16268
- https://dev.azure.com/mariner-org/polar/_workitems/edit/15415
- https://dev.azure.com/mariner-org/polar/_workitems/edit/15673