### PR TITLE
engineering: log collection is failing, sudo required

### DIFF
--- a/.pipelines/templates/stages/testing_baremetal/baremetal-testing.yml
+++ b/.pipelines/templates/stages/testing_baremetal/baremetal-testing.yml
@@ -305,7 +305,7 @@ stages:
 
           - bash: |
               set -eux
-              sudo ./bin/storm-trident helper display-logs \
+              sudo ./bin/storm-trident helper display-logs -a \
                   --serial-log-path "${{ variables.TRIDENT_SOURCE_DIR }}/baremetal-serial.log" \
                   --serial-log-artifact-file-name "clean-install-target-os-A-serial.log" \
                   --trident-trace-log-file "${{ variables.TRIDENT_SOURCE_DIR }}/logstream-full.log" \

--- a/.pipelines/templates/stages/testing_common/e2e-ab-update-stage-finalize-test-run.yml
+++ b/.pipelines/templates/stages/testing_common/e2e-ab-update-stage-finalize-test-run.yml
@@ -95,7 +95,7 @@ steps:
 
   - bash: |
       set -eux
-      ./bin/storm-trident helper display-logs \
+      sudo ./bin/storm-trident helper display-logs -a \
           --skip-serial-log \
           --trident-log-file "$(Build.SourcesDirectory)/stage-ab-update-deployment.log" \
           --artifacts-folder "$(ob_outputDirectory)"
@@ -181,7 +181,7 @@ steps:
 
   - bash: |
       set -eux
-      ./bin/storm-trident helper display-logs \
+      sudo ./bin/storm-trident helper display-logs -a \
           --netlisten-config "${{ parameters.netlistenConfigFile }}" \
           --serial-log-artifact-file-name "finalize-ab-update-B-serial.log" \
           --trident-log-file "$(Build.SourcesDirectory)/finalize-ab-update.log" \


### PR DESCRIPTION
# 🔍 Description
 
sudo is needed to handle serial log.  

missed with PR because pr-e2e and ci don't run e2e-ab-update-stage-finalize-test-run.yml which has bug, but prerelease and full-validation does.

validating with prerelease (with BM stages skipped): https://dev.azure.com/mariner-org/ECF/_build/results?buildId=984316&view=results