### PR TITLE
engineering: create HealthChecksError and move health check errors out of ServicingError

### DIFF
--- a/crates/trident/src/engine/rollback.rs
+++ b/crates/trident/src/engine/rollback.rs
@@ -9,7 +9,10 @@ use osutils::{block_devices, container, efivar, lsblk, pcrlock, veritysetup, vir
 use trident_api::{
     constants::internal_params::VIRTDEPLOY_BOOT_ORDER_WORKAROUND,
     constants::ROOT_MOUNT_POINT_PATH,
-    error::{InternalError, ReportError, ServicingError, TridentError, TridentResultExt},
+    error::{
+        HealthChecksError, InternalError, ReportError, ServicingError, TridentError,
+        TridentResultExt,
+    },
     status::{AbVolumeSelection, ServicingState, ServicingType},
     BlockDeviceId,
 };
@@ -152,7 +155,7 @@ pub fn validate_boot(datastore: &mut DataStore) -> Result<BootValidationResult, 
             })?;
 
             return Err(TridentError::new(
-                ServicingError::AbUpdateHealthCheckCommitCheck {
+                HealthChecksError::AbUpdateHealthCheckCommitCheck {
                     expected_device_path: current_root_path.to_string_lossy().to_string(),
                 },
             ));

--- a/crates/trident/src/health/mod.rs
+++ b/crates/trident/src/health/mod.rs
@@ -11,7 +11,7 @@ use osutils::dependencies::Dependency;
 use trident_api::{
     config::{Check, SystemdCheck},
     constants::ROOT_MOUNT_POINT_PATH,
-    error::{ServicingError, TridentError},
+    error::{HealthChecksError, ServicingError, TridentError},
 };
 
 use crate::{engine::EngineContext, subsystems::hooks};
@@ -96,7 +96,7 @@ pub fn execute_health_checks(ctx: &EngineContext) -> Result<(), TridentError> {
             "Health checks completed with errors:\n{}",
             health_check_errors_message
         );
-        return Err(TridentError::new(ServicingError::HealthChecksFailed {
+        return Err(TridentError::new(HealthChecksError::HealthChecksFailed {
             details: health_check_errors_message,
             servicing_type: format!("{:?}", ctx.servicing_type),
         }));


### PR DESCRIPTION
# 🔍 Description
 
Health check failures should not be ServicingError, which represents "something may be wrong with Trident".  Create HealthChecksError kind for TridentError.