### PR TITLE
engineering: Inline Host Configuration template into COSI metadata

### DIFF
--- a/crates/trident/src/osimage/cosi/metadata.rs
+++ b/crates/trident/src/osimage/cosi/metadata.rs
@@ -68,7 +68,7 @@ pub(crate) struct CosiMetadata {
 
     /// Template for a host configuration embedded within the image.
     #[serde(default)]
-    pub host_configuration_template: Option<AuxiliaryFile>,
+    pub host_configuration_template: Option<String>,
 }
 
 impl CosiMetadata {
@@ -299,13 +299,6 @@ pub(crate) struct BootloaderEntry {
 
     #[allow(dead_code)]
     pub cmdline: String,
-}
-
-#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub(crate) struct AuxiliaryFile {
-    pub path: PathBuf,
-    pub sha384: Sha384Hash,
 }
 
 #[cfg(test)]

--- a/crates/trident/src/osimage/cosi/mod.rs
+++ b/crates/trident/src/osimage/cosi/mod.rs
@@ -37,7 +37,6 @@ pub(super) struct Cosi {
     entries: HashMap<PathBuf, CosiEntry>,
     pub metadata: CosiMetadata,
     pub metadata_sha384: Sha384Hash,
-    pub host_configuration_template: Option<Vec<u8>>,
     reader: FileReader,
 }
 
@@ -65,26 +64,6 @@ impl Cosi {
         let (metadata, sha384) = read_cosi_metadata(&cosi_reader, &entries, source.sha384.clone())
             .context("Failed to read COSI file metadata.")?;
 
-        let host_configuration_template =
-            if let Some(ref file) = metadata.host_configuration_template {
-                let entry = entries.get(&file.path).context(
-                    "COSI metadata corrupt: host configuration template referenced but missing",
-                )?;
-
-                let mut contents = Vec::new();
-                let mut reader =
-                    HashingReader384::new(cosi_reader.section_reader(entry.offset, entry.size)?);
-                reader.read_to_end(&mut contents)?;
-
-                if file.sha384 != reader.hash() {
-                    bail!("COSI host configuration template hash does not match expected hash");
-                }
-
-                Some(contents)
-            } else {
-                None
-            };
-
         // Create a new COSI instance.
         Ok(Cosi {
             metadata,
@@ -92,7 +71,6 @@ impl Cosi {
             source: source.url.clone(),
             reader: cosi_reader,
             metadata_sha384: sha384,
-            host_configuration_template,
         })
     }
 
@@ -819,7 +797,6 @@ mod tests {
             },
             reader: FileReader::Buffer(data),
             metadata_sha384: Sha384Hash::from("0".repeat(96)),
-            host_configuration_template: None,
         }
     }
 
@@ -841,7 +818,6 @@ mod tests {
             },
             reader: FileReader::Buffer(Cursor::new(Vec::<u8>::new())),
             metadata_sha384: Sha384Hash::from("0".repeat(96)),
-            host_configuration_template: None,
         };
 
         // Weird behavior with none/multiple ESPs is primarily tested by the

--- a/crates/trident/src/osimage/mod.rs
+++ b/crates/trident/src/osimage/mod.rs
@@ -180,9 +180,9 @@ impl OsImage {
         }
     }
 
-    pub(crate) fn host_configuration_template(&self) -> Option<&[u8]> {
+    pub(crate) fn host_configuration_template(&self) -> Option<&str> {
         match &self.0 {
-            OsImageInner::Cosi(cosi) => cosi.host_configuration_template.as_deref(),
+            OsImageInner::Cosi(cosi) => cosi.metadata.host_configuration_template.as_deref(),
             #[cfg(test)]
             OsImageInner::Mock(_) => None,
         }

--- a/crates/trident/src/stream.rs
+++ b/crates/trident/src/stream.rs
@@ -30,13 +30,7 @@ pub fn config_from_image_url(
         })
         .message("Image file does not contain a Host Configuration template")?;
 
-    let template_data = String::from_utf8(template.to_vec())
-        .structured(InvalidInputError::LoadCosi {
-            url: image_url.clone(),
-        })
-        .message("Host Configuration template is not valid UTF-8")?;
-
-    let expanded = expand_template(&template_data)
+    let expanded = expand_template(template)
         .structured(InvalidInputError::LoadCosi {
             url: image_url.clone(),
         })

--- a/tools/cmd/mkcosi/builder/builder.go
+++ b/tools/cmd/mkcosi/builder/builder.go
@@ -33,18 +33,6 @@ func BuildCosi(output io.Writer, cosiMetadata *metadata.MetadataJson) error {
 		return fmt.Errorf("failed to add metadata file: %w", err)
 	}
 
-	if cosiMetadata.HostConfigurationTemplate != nil {
-		file, err := os.ReadFile(cosiMetadata.HostConfigurationTemplate.SourceFile)
-		if err != nil {
-			return fmt.Errorf("failed to open Host Configuration template file: %w", err)
-		}
-
-		err = addFile(tw, cosiMetadata.HostConfigurationTemplate.Path, uint64(len(file)), bytes.NewReader(file))
-		if err != nil {
-			return fmt.Errorf("failed to add Host Configuration template file: %w", err)
-		}
-	}
-
 	for _, img := range cosiMetadata.Images {
 
 		err = addImage(tw, &img.Image)

--- a/tools/cmd/mkcosi/cmd/insert_template.go
+++ b/tools/cmd/mkcosi/cmd/insert_template.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"tridenttools/cmd/mkcosi/builder"
 	"tridenttools/cmd/mkcosi/cosi"
-	"tridenttools/cmd/mkcosi/metadata"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -29,16 +28,12 @@ func (t *InsertTemplate) Run() error {
 	}
 	defer cosi.Close()
 
-	// Add the template to the COSI.
-	sha384, err := builder.Sha384SumFile(t.Template)
+	// Read the template file
+	template, err := os.ReadFile(t.Template)
 	if err != nil {
-		return fmt.Errorf("failed to calculate sha384 of %s: %w", t.Template, err)
+		return fmt.Errorf("failed to read template file: %w", err)
 	}
-	cosi.Metadata.HostConfigurationTemplate = &metadata.AuxiliaryFile{
-		Path:       HostConfigurationTemplateFilename,
-		Sha384:     sha384,
-		SourceFile: t.Template,
-	}
+	cosi.Metadata.HostConfigurationTemplate = string(template)
 
 	// Write the new COSI file.
 	outFile, err := os.Create(t.Output)

--- a/tools/cmd/mkcosi/metadata/metadata.go
+++ b/tools/cmd/mkcosi/metadata/metadata.go
@@ -8,7 +8,7 @@ type MetadataJson struct {
 	OsPackages                []map[string]interface{} `json:"osPackages"`
 	Id                        string                   `json:"id"`
 	Bootloader                map[string]interface{}   `json:"bootloader"`
-	HostConfigurationTemplate *AuxiliaryFile           `json:"hostConfigurationTemplate,omitempty"`
+	HostConfigurationTemplate string                   `json:"hostConfigurationTemplate,omitempty"`
 }
 
 type Image struct {
@@ -39,17 +39,6 @@ type ImageFile struct {
 }
 
 type PartitionType string
-
-type AuxiliaryFile struct {
-	Path   string `json:"path"`
-	Sha384 string `json:"sha384"`
-
-	// Used internally when building/extracting a COSI file to store the
-	// location of the source file outside of the COSI file. This is NOT part
-	// of the COSI spec, just an implementation detail for convenience. This
-	// field is not serialized to JSON.
-	SourceFile string `json:"-"`
-}
 
 const (
 	PartitionTypeEsp                PartitionType = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b"


### PR DESCRIPTION
This simplifies including the Host Configuration template into a COSI image file by just including it directly in the metadata 