### PR TITLE
engineering: pin ovmf and qemu-efi to 2022.02-3ubuntu0.22.04.3

### DIFF
--- a/.pipelines/templates/stages/azl_installer/validate-azl-installer-iso.yml
+++ b/.pipelines/templates/stages/azl_installer/validate-azl-installer-iso.yml
@@ -23,13 +23,13 @@ steps:
           swtpm-tools \
           bridge-utils \
           virt-manager \
-          qemu-efi \
+          qemu-efi=2022.02-3ubuntu0.22.04.3 \
           qemu-kvm \
           libtpms0 \
           libvirt-daemon-system \
           libvirt-clients \
           python3-libvirt \
-          ovmf \
+          ovmf=2022.02-3ubuntu0.22.04.3 \
           openssl \
           python3-netifaces \
           python3-docker \

--- a/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
+++ b/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
@@ -39,13 +39,13 @@ steps:
           swtpm-tools \
           bridge-utils \
           virt-manager \
-          qemu-efi \
+          qemu-efi=2022.02-3ubuntu0.22.04.3 \
           qemu-kvm \
           libtpms0 \
           libvirt-daemon-system \
           libvirt-clients \
           python3-libvirt \
-          ovmf \
+          ovmf=2022.02-3ubuntu0.22.04.3 \
           openssl \
           python3-netifaces \
           python3-docker \

--- a/tools/virtdeploy/README.md
+++ b/tools/virtdeploy/README.md
@@ -89,9 +89,9 @@ sudo apt-get update
 ```bash
 sudo NEEDRESTART_MODE=a apt-get install -y \
     virt-manager \
-    qemu-efi \
+    qemu-efi=2022.02-3ubuntu0.22.04.3 \
     python3-libvirt \
-    ovmf \
+    ovmf=2022.02-3ubuntu0.22.04.3 \
     openssl \
     python3-netifaces \
     python3-docker \


### PR DESCRIPTION
# 🔍 Description
 
ovmf and qemu-efi updated and the new version breaks netlaunch.  Pin version to previous until we get fix.