### PR TITLE
bug: Remove usage of /dev/disk/by-path/

### DIFF
--- a/crates/osutils/src/block_devices.rs
+++ b/crates/osutils/src/block_devices.rs
@@ -29,12 +29,7 @@ pub struct ResolvedDisk {
     pub spec: Disk,
 
     /// Path to the disk in /dev.
-    /// Will probably be used in the future.
-    #[allow(dead_code)]
     pub dev_path: PathBuf,
-
-    /// Path to the disk in /dev/disk/by-path.
-    pub bus_path: PathBuf,
 }
 
 /// Resolves the disk paths in the Host Configuration to their real paths in `/dev`.
@@ -50,26 +45,14 @@ pub fn get_resolved_disks(host_config: &HostConfiguration) -> Result<Vec<Resolve
                 disk.device.display()
             ))?;
 
-            // Find the symlink path of the disk in /dev/disk/by-path.
-            let bus_path = block_device_by_path(&dev_path).context(format!(
-                "Failed to find bus path of '{}'",
-                dev_path.display()
-            ))?;
-
             Ok(ResolvedDisk {
                 id: disk.id.clone(),
                 spec: disk.clone(),
                 dev_path,
-                bus_path,
             })
         })
         .collect::<Result<Vec<_>, Error>>()
         .context("Failed to resolve disk paths")
-}
-
-/// Retrieves the symlink for a given block device in '/dev/disk/by-path'.
-pub fn block_device_by_path(path: impl AsRef<Path>) -> Result<PathBuf, Error> {
-    find_symlink_for_target(path.as_ref(), Path::new("/dev/disk/by-path"))
 }
 
 /// Returns the path of the first symlink in directory whose canonical path is target.

--- a/crates/trident/src/engine/bootentries.rs
+++ b/crates/trident/src/engine/bootentries.rs
@@ -544,15 +544,13 @@ fn get_esp_metadata(
         format!("Failed to find device path for ESP partition with device ID '{esp_device_id}'",)
     })?;
 
-    let esp_disk_path = block_devices::block_device_by_path(
+    let esp_disk_path =
         block_devices::get_disk_for_partition(device_path.as_path()).with_context(|| {
             format!(
                 "Failed to get disk for ESP partition '{esp_device_id}' with device path '{}'",
                 device_path.display()
             )
-        })?,
-    )
-    .context("Failed to get by-path symlink for disk")?;
+        })?;
     debug!(
         "Found disk for ESP partition '{esp_device_id}' with device path '{}'",
         esp_disk_path.display()


### PR DESCRIPTION
In Azure, disks don't necessarily show up under /dev/disk/by-path/* so we shouldn't look for them there. Device paths like /dev/sda aren't always stable across reboots, but that's OK because none of these uses get saved anywhere.

Fixes #343