### PR TITLE
engineering: remove dom0 bot group

### DIFF
--- a/.pipelines/pipeline-tester.yml
+++ b/.pipelines/pipeline-tester.yml
@@ -28,7 +28,6 @@ variables:
   # OUTPUTROOT: $(REPOROOT)\out
   - name: DEBIAN_FRONTEND
     value: noninteractive
-  - group: bot # added for access to dom0 RPMs
 
 resources:
   repositories:

--- a/.pipelines/trident-ci.yml
+++ b/.pipelines/trident-ci.yml
@@ -57,9 +57,6 @@ resources:
       type: git
       ref: refs/heads/main
 
-variables:
-  - group: bot # added for access to dom0 RPMs
-
 extends:
   template: v2/OneBranch.Official.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
   parameters:

--- a/.pipelines/trident-pr-e2e-azure.yml
+++ b/.pipelines/trident-pr-e2e-azure.yml
@@ -41,9 +41,6 @@ resources:
       type: git
       ref: refs/heads/main
 
-variables:
-  - group: bot # added for access to dom0 RPMs
-
 extends:
   template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
   parameters:

--- a/.pipelines/trident-pr-e2e.yml
+++ b/.pipelines/trident-pr-e2e.yml
@@ -31,9 +31,6 @@ resources:
       type: git
       ref: refs/heads/main
 
-variables:
-  - group: bot # added for access to dom0 RPMs
-
 extends:
   template: templates/MockOB.yml
   parameters:


### PR DESCRIPTION
# 🔍 Description
 
Dom0 is not built.  Remove the group added for dom0.

Validated: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=994191&view=results