### PR TITLE
bug: Fix runtime logic

### DIFF
--- a/crates/trident/src/engine/runtime_update.rs
+++ b/crates/trident/src/engine/runtime_update.rs
@@ -59,8 +59,8 @@ pub(crate) fn stage_update(
     );
     state.with_host_status(|hs| {
         hs.servicing_state = ServicingState::RuntimeUpdateStaged;
-        // Update spec inside the Host Status with the newly input Host
-        // Configuration (stored in ctx.spec).
+        // Update spec inside the Host Status with the new Host Configuration
+        // (stored in ctx.spec).
         hs.spec = ctx.spec;
         // Update spec_old to the previous spec (ctx.spec_old == hs.spec)
         hs.spec_old = ctx.spec_old;


### PR DESCRIPTION
# 🔍 Description
 
`spec` and `spec_old` need to updated in the Host Status at the end of `stage`, because `ctx.spec` contains the new Host Configuration, which is different from `spec` inside the Host Status.

