### PR TITLE
engineering: Reconfigure OSConfig subsystem for runtime updates

### DIFF
--- a/crates/trident/src/subsystems/osconfig/mod.rs
+++ b/crates/trident/src/subsystems/osconfig/mod.rs
@@ -616,7 +616,7 @@ mod tests {
             sha384: Sha384Hash::from("a".repeat(96)),
             path: Some(PathBuf::from("/var/lib/confexts/test.raw")),
         }];
-        // Sysext removed in new spec so OS Modifier is not required
+        // Confext removed in new spec so OS Modifier is not required
         assert!(!os_changes_required(&ctx));
 
         ctx.spec.os.confexts = vec![Extension {
@@ -625,7 +625,7 @@ mod tests {
             path: Some(PathBuf::from("/var/lib/confexts/test.raw")),
         }];
         ctx.spec_old.os.confexts = vec![];
-        // confexts newly added so OS Modifier is required
+        // Confexts newly added so OS Modifier is required
         assert!(os_changes_required(&ctx));
     }
 


### PR DESCRIPTION
# 🔍 Description
 
Split the `configure()` behavior of the OsConfig subsystem by whether or not the servicing type boots into a new volume.

# 🤔 Rationale

For a runtime update, we only need to use OS modifier if a sysext and confext is present in the new HC while there were no sysexts or confexts in the previous HC. In this case, we want to enable `systemd-sysext` or `systemd-confext`.

Meanwhile for A/B updates and clean installs, we care about more elements of the OS config. As a result, it is useful for this subsystem to differentiate its logic based on the servicing type.