### PR TITLE
infra: add proper context to netlaunch

### DIFF
--- a/tools/cmd/netlaunch/main.go
+++ b/tools/cmd/netlaunch/main.go
@@ -4,6 +4,7 @@ Copyright © 2023 Microsoft Corporation
 package main
 
 import (
+	"context"
 	"tridenttools/pkg/netlaunch"
 	"tridenttools/pkg/phonehome"
 
@@ -90,7 +91,10 @@ var rootCmd = &cobra.Command{
 		config.WaitForProvisioning = waitForProvisioned
 		config.MaxPhonehomeFailures = maxFailures
 
-		err := netlaunch.RunNetlaunch(&config)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err := netlaunch.RunNetlaunch(ctx, &config)
 
 		// Get an exit code based on the error and log it
 		var exitCode int = phonehome.GetExitCodeFromErrorAndLog(err)

--- a/tools/storm/e2e/scenario/install.go
+++ b/tools/storm/e2e/scenario/install.go
@@ -51,7 +51,7 @@ func (s *TridentE2EScenario) installOs(tc storm.TestCase) error {
 		MaxPhonehomeFailures: s.configParams.MaxExpectedFailures,
 	}
 
-	nlErr := netlaunch.RunNetlaunch(&config)
+	nlErr := netlaunch.RunNetlaunch(tc.Context(), &config)
 	if nlErr != nil {
 		// If this is a phonehome error, log the details and fail the test case
 		// immediately.


### PR DESCRIPTION
# 🔍 Description
 
Add a `context.Context` parameter to the netlaunch core function so that it may be externally cancelled.
