### PR TITLE
engineering: Suppress CodeQL warning SM04242

### DIFF
--- a/tests/functional_tests/ssh_node.py
+++ b/tests/functional_tests/ssh_node.py
@@ -7,6 +7,9 @@ from threading import Thread
 from typing import Any, Dict, List, Optional, Union
 
 from assertpy.assertpy import AssertionBuilder, assert_that  # type: ignore
+
+# CodeQL [SM04242] Paramiko is used exclusively in testing, not in production. We can suppress this
+# warning as the Trident releases are not affected.
 from paramiko import SSHClient
 from paramiko.channel import ChannelFile, ChannelStderrFile
 


### PR DESCRIPTION
# 🔍 Description
 
This PR suppresses CodeQL warning SM04242 because the `paramiko` library is used exclusively in test code: https://codeql.microsoft.com/issues/b0aec23a-7e49-44de-b8e4-41830f73a454?copilot_promptid=E91B0CE9-0C1B-4AC2-8A46-33F49B67E058