### PR TITLE
engineering: Update nix to 0.30.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,17 @@ members = [
 ]
 
 [workspace.dependencies]
-anyhow = {version = "1.0.94", features = ["backtrace"]}
-bitflags = {version = "2.6.0", features = ["serde"]}
-chrono = {version = "0.4.38", features = ["serde"]}
-clap = {version = "4.4.18", features = ["derive", "wrap_help"]}
-configparser = {version = "3.1.0", features = ["indexmap"]}
+anyhow = { version = "1.0.94", features = ["backtrace"] }
+bitflags = { version = "2.6.0", features = ["serde"] }
+chrono = { version = "0.4.38", features = ["serde"] }
+clap = { version = "4.4.18", features = ["derive", "wrap_help"] }
+configparser = { version = "3.1.0", features = ["indexmap"] }
 const_format = "0.2.33"
 derive_more = "0.99.19"
 docker_credential = "1.0.1"
 documented = "0.6.0"
 duct = "0.13.7"
-enumflags2 = {version = "0.7", features = ["serde"]}
+enumflags2 = { version = "0.7", features = ["serde"] }
 env_logger = "0.11.5"
 glob = "0.3.1"
 goblin = "0.10.0"
@@ -39,7 +39,10 @@ libc = "0.2.167"
 log = "0.4.22"
 maplit = "1.0.2"
 netplan-types = "0.5.0"
-nix = {version = "0.29.0", features = ["fs", "user"], default-features = false}
+nix = { version = "0.30.1", features = [
+    "fs",
+    "user",
+], default-features = false }
 oci-client = "0.15.0"
 once_cell = "1.19"
 openssl = "0.10.72"
@@ -53,10 +56,14 @@ quote = "1.0.37"
 rand = "0.9.0"
 rayon = "1.10"
 regex = "1.11.1"
-reqwest = {version = "0.12.9", features = ["blocking", "charset", "default-tls"], default-features = false}
-schemars = {version = "0.8.21", features = ["url", "uuid1"]}
+reqwest = { version = "0.12.9", features = [
+    "blocking",
+    "charset",
+    "default-tls",
+], default-features = false }
+schemars = { version = "0.8.21", features = ["url", "uuid1"] }
 semver = "1.0.23"
-serde = {version = "1.0.215", features = ["derive"]}
+serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 serde_yaml = "0.9.34"
 sha2 = "0.10.8"
@@ -64,8 +71,8 @@ sqlite = "0.36.1"
 strum = "0.26.3"
 strum_macros = "0.26.4"
 svg = "0.18.0"
-syn = {version = "2.0.90", features = ["full"]}
-sys-mount = {version = "3.0.1", default-features = false}
+syn = { version = "2.0.90", features = ["full"] }
+sys-mount = { version = "3.0.1", default-features = false }
 sysinfo = "0.30.13"
 systemd-journal-logger = "2.2.2"
 tar = "0.4.43"
@@ -73,13 +80,13 @@ tempfile = "3.14.0"
 tera = "1.20.0"
 textwrap = "0.16.2"
 thiserror = "1.0.69"
-tokio = {version = "1.47.1", features = ["full", "rt-multi-thread"]}
+tokio = { version = "1.47.1", features = ["full", "rt-multi-thread"] }
 tonic = "0.14.2"
 tonic-prost = "0.14.2"
 tracing = "0.1.41"
-tracing-subscriber = {version = "0.3.19", features = ["json"]}
-url = {version = "2.5.4", features = ["serde"]}
-uuid = {version = "1.11.0", features = ["serde", "v4"]}
+tracing-subscriber = { version = "0.3.19", features = ["json"] }
+url = { version = "2.5.4", features = ["serde"] }
+uuid = { version = "1.11.0", features = ["serde", "v4"] }
 which = "6.0.3"
 zstd = "0.13.3"
 mockito = "1.6.1"

--- a/crates/osutils/src/chroot.rs
+++ b/crates/osutils/src/chroot.rs
@@ -1,9 +1,6 @@
 use std::{
     fs, mem,
-    os::{
-        fd::{IntoRawFd, RawFd},
-        unix,
-    },
+    os::{fd::OwnedFd, unix},
     path::Path,
     thread,
     time::Duration,
@@ -18,7 +15,7 @@ use trident_api::error::{ReportError, ServicingError, TridentError, TridentResul
 ///
 /// Note: Dropping this object does *not* exit the chroot. You must call `exit()` manually.
 pub struct Chroot {
-    rootfd: RawFd,
+    rootfd: OwnedFd,
     mounts: Vec<UnmountDrop<Mount>>,
 }
 impl Chroot {
@@ -61,7 +58,7 @@ impl Chroot {
         debug!("Entering chroot");
         let rootfd = fs::File::open("/")
             .structured(ServicingError::EnterChroot)?
-            .into_raw_fd();
+            .into();
         unix::fs::chroot(path).structured(ServicingError::EnterChroot)?;
         std::env::set_current_dir("/").structured(ServicingError::EnterChroot)?;
 

--- a/crates/trident/src/subsystems/extensions/utils.rs
+++ b/crates/trident/src/subsystems/extensions/utils.rs
@@ -238,7 +238,7 @@ mod tests {
         let hash1 = Sha384Hash::from("a".repeat(96));
         let hash2 = Sha384Hash::from("b".repeat(96));
 
-        let internal_exts = vec![
+        let internal_exts = [
             ExtensionData {
                 id: "ext1".to_string(),
                 name: "ext1".to_string(),


### PR DESCRIPTION
# 🔍 Description
 
Small nice to have update that avoids having to deal with `RawFds`, updating as part of gRPC, but separated into standalone PR for convenience.

Also there is a small unrelated clippy update.