### PR TITLE
engineering: make trident.spec sharable with azurelinux

### DIFF
--- a/packaging/docker/Dockerfile.azl3
+++ b/packaging/docker/Dockerfile.azl3
@@ -7,13 +7,9 @@ RUN tdnf install -y rpmdevtools openssl-devel clang-devel protobuf-devel rust se
 WORKDIR /work
 
 COPY packaging/rpm/trident.spec .
-COPY packaging/systemd ./systemd
+COPY packaging ./packaging
 COPY bin/trident ./target/release/trident
 COPY artifacts/osmodifier /usr/src/azl/SOURCES/osmodifier
-COPY packaging/selinux-policy-trident/trident.te /usr/src/azl/SOURCES/trident.te
-COPY packaging/selinux-policy-trident/trident.fc /usr/src/azl/SOURCES/trident.fc
-COPY packaging/selinux-policy-trident/trident.if /usr/src/azl/SOURCES/trident.if
-COPY packaging/static-pcrlock-files/ /usr/src/azl/SOURCES/static-pcrlock-files/
 
 ARG TRIDENT_VERSION=dev-build
 ARG RPM_VER=0.1.0

--- a/packaging/docker/Dockerfile.full
+++ b/packaging/docker/Dockerfile.full
@@ -7,12 +7,8 @@ RUN tdnf install -y rpmdevtools openssl-devel clang-devel protobuf-devel rust-1.
 WORKDIR /work
 
 COPY packaging/rpm/trident.spec .
-COPY packaging/systemd ./systemd
+COPY packaging ./packaging
 COPY artifacts/osmodifier /usr/src/azl/SOURCES/osmodifier
-COPY packaging/selinux-policy-trident/trident.te /usr/src/azl/SOURCES/trident.te
-COPY packaging/selinux-policy-trident/trident.fc /usr/src/azl/SOURCES/trident.fc
-COPY packaging/selinux-policy-trident/trident.if /usr/src/azl/SOURCES/trident.if
-COPY packaging/static-pcrlock-files/ /usr/src/azl/SOURCES/static-pcrlock-files/
 
 COPY .cargo/config.toml ./.cargo/config.toml
 COPY Cargo.toml .

--- a/packaging/docker/Dockerfile.full.public
+++ b/packaging/docker/Dockerfile.full.public
@@ -7,12 +7,8 @@ RUN tdnf install -y rpmdevtools openssl-devel clang-devel protobuf-devel rust se
 WORKDIR /work
 
 COPY trident.spec .
-COPY systemd ./systemd
+COPY packaging ./packaging
 COPY artifacts/osmodifier /usr/src/azl/SOURCES/osmodifier
-COPY selinux-policy-trident/trident.te /usr/src/azl/SOURCES/trident.te
-COPY selinux-policy-trident/trident.fc /usr/src/azl/SOURCES/trident.fc
-COPY selinux-policy-trident/trident.if /usr/src/azl/SOURCES/trident.if
-COPY packaging/static-pcrlock-files/ /usr/src/azl/SOURCES/static-pcrlock-files/
 
 COPY .cargo/config ./.cargo/config
 COPY Cargo.toml .

--- a/packaging/rpm/trident.spec
+++ b/packaging/rpm/trident.spec
@@ -6,6 +6,11 @@
 
 %global selinuxtype targeted
 
+%define our_gopath %{_topdir}/.gopath
+%define osmodifier_packagename azurelinux-image-tools
+%define osmodifier_version 1.0.0
+%define osmodifier_foldername azure-linux-image-tools
+
 Summary:        Declarative, security-first OS lifecycle agent designed primarily for Azure Linux
 Name:           trident
 %if %{undefined rpm_ver}
@@ -34,6 +39,9 @@ Source0:        https://github.com/microsoft/trident/archive/refs/tags/v%{versio
 #   tar -czf %%{name}-%%{version}-cargo.tar.gz vendor/
 #
 Source1:        %{name}-%{version}-cargo.tar.gz
+# Define osmodifier sources
+Source2:        %{osmodifier_packagename}-%{osmodifier_version}.tar.gz
+Source3:        %{osmodifier_packagename}-%{osmodifier_version}-vendor.tar.gz
 %else
 Source1:        osmodifier
 %endif
@@ -43,9 +51,11 @@ BuildRequires:  systemd-units
 BuildRequires:  rust
 
 %if %{undefined rpm_ver}
-# For distro build, require cargo to build and osmodifier
+# For distro build, require cargo to build trident
 BuildRequires:  cargo
-Requires:       azurelinux-image-tools-osmodifier
+# For distro build, require go to build osmodifier
+BuildRequires:  golang < 1.25
+BuildRequires:  systemd-udev
 %endif
 
 Requires:       e2fsprogs
@@ -81,10 +91,7 @@ and its dependencies for managing the lifecycle of Azure Linux hosts.
 %files
 %{_bindir}/%{name}
 %dir /etc/%{name}
-%if %{defined rpm_ver}
-# For Trident repo build, package osmodifier included via `Source1`
 %{_bindir}/osmodifier
-%endif
 
 # ------------------------------------------------------------------------------
 
@@ -230,14 +237,27 @@ be removed once the fix is merged in AZL 4.0.
 %if %{undefined rpm_ver}
 # Use cargo with source and vendor tarballs for distro build
 %prep
-%autosetup -n %{name}-%{version} -p1
+# Create 2 source directories, 1 for trident and 1 for azurelinux-image-tools
+# Use %setup for more control:
+#  -q: quietly
+#  -c: create source directory before unpacking
+#  -T: do not unpack Source0 automatically
+#  -D: do not delete source directory before operation
+#  -n: specify name of source directory
+#  -b: unpack source tarball before changing to source directory
+#  -a: unpack vendor tarball after changing to source directory
 
-# Do vendor expansion here manually by
-# calling `tar x` and setting up
-# .cargo/config to use it.
-tar fx %{SOURCE1}
+# Set up azurelinux-image-tools source directory
+%setup -q -c -T -D -n %{osmodifier_foldername}-%{osmodifier_version} -b 2
+tar -xf %{SOURCE3} --no-same-owner -C toolkit/tools
+cd %{_builddir}
+
+# Set up trident source directory
+%setup -q -c -T -D -n %{name}-%{version} -b 0
+%setup -q -c -T -D -n %{name}-%{version} -a 1
+cd %{_builddir}/%{name}-%{version}
+
 mkdir -p .cargo
-
 cat >.cargo/config << EOF
 [source.crates-io]
 replace-with = "vendored-sources"
@@ -248,6 +268,14 @@ EOF
 %endif
 
 %build
+%if %{undefined rpm_ver}
+pushd %{_builddir}/%{osmodifier_foldername}-%{osmodifier_version}
+export GOPATH=%{our_gopath}
+export GOFLAGS="-mod=vendor"
+make -C toolkit go-osmodifier REBUILD_TOOLS=y SKIP_LICENSE_SCAN=y
+popd
+%endif
+
 export TRIDENT_VERSION="%{trident_version}"
 cargo build --release
 
@@ -270,11 +298,14 @@ cargo test --all --no-fail-fast -- --skip test_run_systemd_check --skip test_pre
 %endif
 
 %install
-%if %{defined rpm_ver}
+%if %{undefined rpm_ver}
+# For distro RPM use osmodifier built from osmodifier source/vendor tarballs.
+install -D -m 755 %{_builddir}/%{osmodifier_foldername}-%{osmodifier_version}/toolkit/out/tools/osmodifier %{buildroot}%{_bindir}/osmodifier
+%else
 # For Trident repo build, package osmodifier included via `Source1`.
-# Distro RPM will use distro osmodifier RPM via Requires directive.
 install -D -m 755 %{SOURCE1} %{buildroot}%{_bindir}/osmodifier
 %endif
+
 install -D -m 755 target/release/%{name} %{buildroot}/%{_bindir}/%{name}
 
 # Copy Trident SELinux policy module to /usr/share/selinux/packages

--- a/packaging/rpm/trident.spec
+++ b/packaging/rpm/trident.spec
@@ -9,6 +9,7 @@
 Summary:        Declarative, security-first OS lifecycle agent designed primarily for Azure Linux
 Name:           trident
 %if %{undefined rpm_ver}
+# Use hard-coded versions for distro build
 Version:        0.20.0
 Release:        1%{?dist}
 %else
@@ -21,6 +22,7 @@ Group:          Applications/System
 Distribution:   Azure Linux
 
 %if %{undefined rpm_ver}
+# Use source and vendor tarballs for distro build
 URL:            https://github.com/microsoft/trident/
 Source0:        https://github.com/microsoft/trident/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 # Below is a manually created tarball, no download link.
@@ -32,16 +34,19 @@ Source0:        https://github.com/microsoft/trident/archive/refs/tags/v%{versio
 #   tar -czf %%{name}-%%{version}-cargo.tar.gz vendor/
 #
 Source1:        %{name}-%{version}-cargo.tar.gz
-
-BuildRequires:  cargo >= 1.85.0
-Requires:       azurelinux-image-tools-osmodifier
 %else
-Source2:        osmodifier
+Source1:        osmodifier
 %endif
 
-BuildRequires:  rust >= 1.85.0
 BuildRequires:  openssl-devel
 BuildRequires:  systemd-units
+BuildRequires:  rust
+
+%if %{undefined rpm_ver}
+# For distro build, require cargo to build and osmodifier
+BuildRequires:  cargo
+Requires:       azurelinux-image-tools-osmodifier
+%endif
 
 Requires:       e2fsprogs
 Requires:       util-linux
@@ -76,7 +81,10 @@ and its dependencies for managing the lifecycle of Azure Linux hosts.
 %files
 %{_bindir}/%{name}
 %dir /etc/%{name}
+%if %{defined rpm_ver}
+# For Trident repo build, package osmodifier included via `Source1`
 %{_bindir}/osmodifier
+%endif
 
 # ------------------------------------------------------------------------------
 
@@ -220,6 +228,7 @@ be removed once the fix is merged in AZL 4.0.
 # ------------------------------------------------------------------------------
 
 %if %{undefined rpm_ver}
+# Use cargo with source and vendor tarballs for distro build
 %prep
 %autosetup -n %{name}-%{version} -p1
 
@@ -252,12 +261,17 @@ bzip2 -9 %{name}.pp
 
 %check
 test "$(./target/release/trident --version)" = "trident %{trident_version}"
+%if %{undefined rpm_ver}
+# Run unit tests as part of check for distro build, skip 2 tests that do not work
+# in RPM chroot environment
+cargo test --all --no-fail-fast -- --skip test_run_systemd_check --skip test_prepare_mount_directory --skip test_read
+%endif
 
 %install
-%if %{undefined rpm_ver}
-install -D -m 755 osmodifier %{buildroot}%{_bindir}/osmodifier
-%else
-install -D -m 755 %{SOURCE2} %{buildroot}%{_bindir}/osmodifier
+%if %{defined rpm_ver}
+# For Trident repo build, package osmodifier included via `Source1`.
+# Distro RPM will use distro osmodifier RPM via Requires directive.
+install -D -m 755 %{SOURCE1} %{buildroot}%{_bindir}/osmodifier
 %endif
 install -D -m 755 target/release/%{name} %{buildroot}/%{_bindir}/%{name}
 

--- a/packaging/rpm/trident.spec
+++ b/packaging/rpm/trident.spec
@@ -262,9 +262,11 @@ bzip2 -9 %{name}.pp
 %check
 test "$(./target/release/trident --version)" = "trident %{trident_version}"
 %if %{undefined rpm_ver}
-# Run unit tests as part of check for distro build, skip 2 tests that do not work
+%ifarch x86_64
+# Run unit tests as part of check for distro build, skip 3 tests that do not work
 # in RPM chroot environment
 cargo test --all --no-fail-fast -- --skip test_run_systemd_check --skip test_prepare_mount_directory --skip test_read
+%endif
 %endif
 
 %install

--- a/packaging/rpm/trident.spec
+++ b/packaging/rpm/trident.spec
@@ -1,8 +1,14 @@
+# This spec file is used for both the Trident repo builds and as the
+# basis for the azurelinux build. For the Trident repo builds, `rpm_ver`
+# is defined, dictating the build version. If `rpm_ver` is undefined,
+# the spec defines the azurelinux distro build (using source and vendor
+# tarballs, etc)
+
 %global selinuxtype targeted
 
 Summary:        Declarative, security-first OS lifecycle agent designed primarily for Azure Linux
 Name:           trident
-%if !0%{?azl}
+%if %{undefined rpm_ver}
 Version:        0.20.0
 Release:        1%{?dist}
 %else
@@ -14,7 +20,7 @@ Vendor:         Microsoft Corporation
 Group:          Applications/System
 Distribution:   Azure Linux
 
-%if !0%{?azl}
+%if %{undefined rpm_ver}
 URL:            https://github.com/microsoft/trident/
 Source0:        https://github.com/microsoft/trident/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 # Below is a manually created tarball, no download link.
@@ -26,12 +32,13 @@ Source0:        https://github.com/microsoft/trident/archive/refs/tags/v%{versio
 #   tar -czf %%{name}-%%{version}-cargo.tar.gz vendor/
 #
 Source1:        %{name}-%{version}-cargo.tar.gz
-Requires:       azurelinux-image-tools-osmodifier
-%else
-Source1:        osmodifier
-%endif
 
 BuildRequires:  cargo >= 1.85.0
+Requires:       azurelinux-image-tools-osmodifier
+%else
+Source2:        osmodifier
+%endif
+
 BuildRequires:  rust >= 1.85.0
 BuildRequires:  openssl-devel
 BuildRequires:  systemd-units
@@ -63,7 +70,8 @@ Suggests:       ntfsprogs
 
 
 %description
-Agent for bare metal platform
+Trident. This package provides the Trident tool
+and its dependencies for managing the lifecycle of Azure Linux hosts.
 
 %files
 %{_bindir}/%{name}
@@ -211,6 +219,25 @@ be removed once the fix is merged in AZL 4.0.
 
 # ------------------------------------------------------------------------------
 
+%if %{undefined rpm_ver}
+%prep
+%autosetup -n %{name}-%{version} -p1
+
+# Do vendor expansion here manually by
+# calling `tar x` and setting up
+# .cargo/config to use it.
+tar fx %{SOURCE1}
+mkdir -p .cargo
+
+cat >.cargo/config << EOF
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"
+EOF
+%endif
+
 %build
 export TRIDENT_VERSION="%{trident_version}"
 cargo build --release
@@ -227,8 +254,11 @@ bzip2 -9 %{name}.pp
 test "$(./target/release/trident --version)" = "trident %{trident_version}"
 
 %install
-install -D -m 755 %{SOURCE1} %{buildroot}%{_bindir}/osmodifier
-
+%if %{undefined rpm_ver}
+install -D -m 755 osmodifier %{buildroot}%{_bindir}/osmodifier
+%else
+install -D -m 755 %{SOURCE2} %{buildroot}%{_bindir}/osmodifier
+%endif
 install -D -m 755 target/release/%{name} %{buildroot}/%{_bindir}/%{name}
 
 # Copy Trident SELinux policy module to /usr/share/selinux/packages


### PR DESCRIPTION
# 🔍 Description
 
As part of creating trident spec for github.com/microsoft/azurelinux, make trident.spec applicable to both Trident repo local/pipeline builds and azurelinux distro RPM builds.

Related azurelinux PR: https://github.com/microsoft/azurelinux/pull/15450