### PR TITLE
engineering: invoke systemd-pcrlock lock-pe for each uki addon

### DIFF
--- a/crates/osutils/src/lib.rs
+++ b/crates/osutils/src/lib.rs
@@ -40,6 +40,7 @@ pub mod systemd;
 pub mod tabfile;
 pub mod tune2fs;
 pub mod udevadm;
+pub mod uki;
 pub mod uname;
 pub mod veritysetup;
 pub mod virt;

--- a/crates/osutils/src/pcrlock.rs
+++ b/crates/osutils/src/pcrlock.rs
@@ -765,12 +765,16 @@ where
             }
 
             // Get addon name
-            let Ok(addon_name) = uki::get_uki_name_from_addon_file(&path) else {
-                warn!(
-                    "Failed to get addon name from UKI addon file at '{}', skipping generating .pcrlock file for it",
-                    path.display()
-                );
-                continue;
+            let addon_name = match uki::get_uki_name_from_addon_file(&path) {
+                Ok(addon_name) => addon_name,
+                Err(e) => {
+                    warn!(
+                        "Failed to get addon name from UKI addon file at '{}': {}, skipping generating .pcrlock file for it",
+                        path.display(),
+                        e,
+                    );
+                    continue;
+                }
             };
             // Create pcrlock component name
             let pcrlock_addon_name = {

--- a/crates/osutils/src/pcrlock.rs
+++ b/crates/osutils/src/pcrlock.rs
@@ -978,6 +978,7 @@ mod tests {
         // Test struct
         struct PcrlockTest {
             uki_path: PathBuf,
+            _temp_dir: TempDir,
         }
         impl PcrlockTest {
             fn new(uki_file: &str, addon_files: Vec<String>) -> Self {
@@ -995,7 +996,10 @@ mod tests {
                         std::fs::write(&addon_path, "mock addon binary").unwrap();
                     }
                 }
-                Self { uki_path }
+                Self {
+                    uki_path,
+                    _temp_dir: temp_dir,
+                }
             }
         }
 
@@ -1029,11 +1033,6 @@ mod tests {
                         .unwrap()
                         .strip_suffix(UKI_ADDON_FILE_SUFFIX)
                         .unwrap();
-                    assert!(
-                        addon_names.contains(&addon_name),
-                        "Addon name '{}' should be in the list of expected addon names",
-                        addon_name
-                    );
                     assert!(
                         addon_names.contains(&addon_name),
                         "Addon name '{}' should be in the list of expected addon names",

--- a/crates/osutils/src/pcrlock.rs
+++ b/crates/osutils/src/pcrlock.rs
@@ -22,8 +22,7 @@ use crate::{
     dependencies::Dependency,
     efivar,
     exe::RunAndCheck,
-    path,
-    uki::{self, UKI_ADDON_FILE_SUFFIX},
+    path, uki,
 };
 
 /// Path to the pcrlock directory where .pcrlock files are located.
@@ -565,104 +564,12 @@ fn generate_pcrlock_files(
         }
     }
 
-    // Run 'lock-uki' when PCRs 4/11 are requested
+    // Run 'lock-uki' for UKI and 'lock-pe' for UKI add-ons when PCRs 4/11 are requested
     if !(pcrs & (Pcr::Pcr4 | Pcr::Pcr11)).is_empty() {
         for (index, uki_path) in uki_binaries.clone().into_iter().enumerate() {
-            // Generate .pcrlock file for the UKI binary, which covers both PCR 4 and PCR 11 measurements for that UKI binary
-            let pcrlock_file = generate_pcrlock_output_path(UKI_PCRLOCK_DIR, index);
-            let cmd = LockCommand::Uki {
-                path: uki_path.clone(),
-                pcrlock_file: pcrlock_file.clone(),
-            };
-            cmd.run().context(format!(
-                "Failed to generate .pcrlock file via 'lock-uki' at '{}'",
-                uki_path.display()
-            ))?;
-
-            trace!(
-                "Contents of .pcrlock file at '{}':\n{}",
-                pcrlock_file.display(),
-                fs::read_to_string(&pcrlock_file).context(format!(
-                    "Failed to read .pcrlock file at {}",
-                    pcrlock_file.display()
-                ))?
-            );
-
-            // Check the UKI addon path (`uki_path` + 'extra.d') for existence, and if it exists, generate a .pcrlock file for it as well,
-            // to cover the case where firmware measures the UKI addons into PCR 4.
-            let uki_addon_path = uki::uki_addon_dir(&uki_path);
-
-            // For each *.addon.efi file in the UKI addons dir, generate a .pcrlock file to measure it as well.
-            if uki_addon_path.exists() {
-                trace!(
-                    "UKI addon path '{}' exists, so generating .pcrlock file to measure it as well",
-                    uki_addon_path.display()
-                );
-                for entry in
-                    fs::read_dir(&uki_addon_path).context("Failed to read UKI addons directory")?
-                {
-                    let entry = entry.context("Failed to get entry in UKI addons directory")?;
-                    let path = entry.path();
-
-                    // Skip directories, only process files in the UKI addons dir.
-                    if path.is_dir() {
-                        trace!(
-                            "Skipping path '{}' in UKI addons directory as it is a directory, expected files only",
-                            path.display()
-                        );
-                        continue;
-                    }
-                    // Only process files with correct suffix.
-                    if !path
-                        .as_os_str()
-                        .as_encoded_bytes()
-                        .ends_with(UKI_ADDON_FILE_SUFFIX.as_bytes())
-                    {
-                        trace!(
-                            "Skipping file '{}' in UKI addons directory as it does not end with expected suffix '{UKI_ADDON_FILE_SUFFIX}'",
-                            path.display()
-                        );
-                        continue;
-                    }
-
-                    // Get addon name
-                    let addon_name = path.file_name().with_context(|| format!(
-                        "Expected a file but found a directory at path '{}' in UKI addons directory.",
-                        path.display()
-                    ))?.to_str().with_context(|| format!(
-                        "Failed to get file name for path '{}' in UKI addons directory.",
-                        path.display()
-                    ))?.strip_suffix(UKI_ADDON_FILE_SUFFIX).with_context(|| format!(
-                        "File '{}' in UKI addons directory does not end with expected suffix '{UKI_ADDON_FILE_SUFFIX}'.",
-                        path.display(),
-                    ))?;
-
-                    // Create pcrlock component name
-                    let pcrlock_addon_name = format!(
-                        "{UKI_ADDONS_PCRLOCK_DIR_PREFIX}{addon_name}{UKI_ADDONS_PCRLOCK_DIR_SUFFIX}"
-                    );
-                    // Generate .pcrlock file path for this addon
-                    let addon_pcrlock_file =
-                        generate_pcrlock_output_path(&pcrlock_addon_name, index);
-                    // Run lock-pe for this addon
-                    let lock_addon_cmd = LockCommand::Pe {
-                        path: path.clone(),
-                        pcrlock_file: addon_pcrlock_file.clone(),
-                    };
-                    lock_addon_cmd.run().context(format!(
-                        "Failed to generate .pcrlock file via 'lock-pe' at '{}'",
-                        path.display()
-                    ))?;
-                    trace!(
-                        "Contents of .pcrlock file at '{}':\n{}",
-                        addon_pcrlock_file.display(),
-                        fs::read_to_string(&addon_pcrlock_file).context(format!(
-                            "Failed to read .pcrlock file at {}",
-                            addon_pcrlock_file.display()
-                        ))?
-                    );
-                }
-            }
+            // Generate .pcrlock file(s) for the UKI binary, which covers both PCR 4 and PCR 11 measurements for that UKI binary
+            generate_uki_pcrlock_files(uki_path, index)
+                .context("Failed to generate .pcrlock files for UKI binary")?;
         }
     } else {
         debug!("Skipping running 'systemd-pcrlock lock-uki' as PCRs 4 and 11 are not requested");
@@ -752,6 +659,89 @@ fn generate_pcrlock_files(
     Ok(())
 }
 
+/// Generates .pcrlock files for a UKI file and any addons.
+fn generate_uki_pcrlock_files(uki_path: PathBuf, index: usize) -> Result<(), Error> {
+    // Generate .pcrlock file for the UKI binary, which covers both PCR 4 and PCR 11 measurements for that UKI binary
+    let pcrlock_file = generate_pcrlock_output_path(UKI_PCRLOCK_DIR, index);
+    let cmd = LockCommand::Uki {
+        path: uki_path.clone(),
+        pcrlock_file: pcrlock_file.clone(),
+    };
+    cmd.run().context(format!(
+        "Failed to generate .pcrlock file via 'lock-uki' at '{}'",
+        uki_path.display()
+    ))?;
+
+    trace!(
+        "Contents of .pcrlock file at '{}':\n{}",
+        pcrlock_file.display(),
+        fs::read_to_string(&pcrlock_file).context(format!(
+            "Failed to read .pcrlock file at {}",
+            pcrlock_file.display()
+        ))?
+    );
+
+    // Check the UKI addon path (`uki_path` + 'extra.d') for existence, and if it exists, generate a .pcrlock file for it as well,
+    // to cover the case where firmware measures the UKI addons into PCR 4.
+    let uki_addon_path = uki::uki_addon_dir(&uki_path);
+    // Generate .pcrlock.d files for any addons found for this UKI binary.
+    generate_uki_addon_pcrlock_files(uki_addon_path, index)
+        .context("Failed to generate .pcrlock files for UKI addon")?;
+    Ok(())
+}
+
+/// Generates .pcrlock files for any UKI addons that exist.
+fn generate_uki_addon_pcrlock_files(uki_addon_path: PathBuf, index: usize) -> Result<(), Error> {
+    // For each *.addon.efi file in the UKI addons dir, generate a .pcrlock file to measure it as well.
+    if uki_addon_path.exists() && uki_addon_path.is_dir() {
+        trace!(
+            "UKI addon path '{}' exists, so generating .pcrlock file to measure it as well",
+            uki_addon_path.display()
+        );
+        for entry in fs::read_dir(&uki_addon_path).context("Failed to read UKI addons directory")? {
+            let entry = entry.context("Failed to get entry in UKI addons directory")?;
+            let path = entry.path();
+
+            // Ensure that only files following the correct naming convention are processed.
+            if !uki::is_uki_addon_file(&path) {
+                trace!(
+                    "Skipping path '{}' in UKI addons directory as it does not meet the expected naming convention",
+                    path.display()
+                );
+                continue;
+            }
+
+            // Get addon name
+            // TODO: should failures here bail or log+continue?
+            let addon_name = uki::get_uki_name_from_addon_file(&path)?;
+            // Create pcrlock component name
+            let pcrlock_addon_name = format!(
+                "{UKI_ADDONS_PCRLOCK_DIR_PREFIX}{addon_name}{UKI_ADDONS_PCRLOCK_DIR_SUFFIX}"
+            );
+            // Generate .pcrlock file path for this addon
+            let addon_pcrlock_file = generate_pcrlock_output_path(&pcrlock_addon_name, index);
+            // Run lock-pe for this addon
+            let lock_addon_cmd = LockCommand::Pe {
+                path: path.clone(),
+                pcrlock_file: addon_pcrlock_file.clone(),
+            };
+            lock_addon_cmd.run().context(format!(
+                "Failed to generate .pcrlock file via 'lock-pe' at '{}'",
+                path.display()
+            ))?;
+            trace!(
+                "Contents of .pcrlock file at '{}':\n{}",
+                addon_pcrlock_file.display(),
+                fs::read_to_string(&addon_pcrlock_file).context(format!(
+                    "Failed to read .pcrlock file at {}",
+                    addon_pcrlock_file.display()
+                ))?
+            );
+        }
+    }
+    Ok(())
+}
+
 /// Generates a full .pcrlock file path under PCRLOCK_DIR, given the sub-dir, and the index of the
 /// .pcrlock file. This is needed so that each image, current and update, gets its own .pcrlock
 /// file.
@@ -831,6 +821,910 @@ mod tests {
             generate_pcrlock_output_path(BOOT_LOADER_CODE_SHIM_PCRLOCK_DIR, index),
             expected_path
         );
+    }
+
+    /// Tests for generate_uki_addon_pcrlock_files function
+    mod generate_uki_addon_pcrlock_files_tests {
+        use super::*;
+        use tempfile::TempDir;
+
+        /// Test that generate_uki_addon_pcrlock_files handles valid UKI addon directories correctly
+        #[test]
+        fn test_generate_uki_addon_pcrlock_files_with_valid_addons() {
+            let temp_dir = TempDir::new().unwrap();
+            let addon_dir = temp_dir.path().join("test.efi.extra.d");
+            std::fs::create_dir_all(&addon_dir).unwrap();
+
+            // Create valid addon files
+            let addon_files = [
+                "driver1.addon.efi",
+                "driver2.addon.efi",
+                "complex-name_123.addon.efi",
+            ];
+            for addon_file in &addon_files {
+                let addon_path = addon_dir.join(addon_file);
+                std::fs::write(&addon_path, "mock addon binary").unwrap();
+            }
+
+            // Test parameter validation and path generation logic
+            let index = 0;
+
+            // Verify the function would attempt to process these files
+            // (actual execution will fail due to missing systemd-pcrlock, but we can validate parameters)
+            let result = generate_uki_addon_pcrlock_files(addon_dir.clone(), index);
+
+            // Expect failure due to systemd-pcrlock dependency, but this validates the function accepts the parameters
+            assert!(
+                result.is_err(),
+                "Function should fail due to missing systemd-pcrlock dependency"
+            );
+
+            // Verify the directory exists and contains the expected files
+            assert!(addon_dir.exists() && addon_dir.is_dir());
+
+            let entries: Vec<_> = std::fs::read_dir(&addon_dir)
+                .unwrap()
+                .filter_map(|entry| {
+                    let entry = entry.ok()?;
+                    let path = entry.path();
+                    if uki::is_uki_addon_file(&path) {
+                        Some(path)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            assert_eq!(entries.len(), 3, "Should find 3 valid addon files");
+
+            // Test addon name extraction and pcrlock path generation for each file
+            for entry in &entries {
+                let addon_name = uki::get_uki_name_from_addon_file(entry).unwrap();
+                assert!(
+                    addon_name == "driver1"
+                        || addon_name == "driver2"
+                        || addon_name == "complex-name_123",
+                    "Unexpected addon name: {}",
+                    addon_name
+                );
+
+                // Test pcrlock directory name generation
+                let pcrlock_addon_name = format!(
+                    "{}{}{}",
+                    UKI_ADDONS_PCRLOCK_DIR_PREFIX, addon_name, UKI_ADDONS_PCRLOCK_DIR_SUFFIX
+                );
+                assert!(pcrlock_addon_name.starts_with("670-uki-addons-"));
+                assert!(pcrlock_addon_name.ends_with(".pcrlock.d"));
+
+                // Test pcrlock file path generation
+                let addon_pcrlock_file = generate_pcrlock_output_path(&pcrlock_addon_name, index);
+                assert!(addon_pcrlock_file
+                    .to_str()
+                    .unwrap()
+                    .contains(&pcrlock_addon_name));
+                assert!(addon_pcrlock_file
+                    .to_str()
+                    .unwrap()
+                    .ends_with("generated-0.pcrlock"));
+            }
+        }
+
+        /// Test that generate_uki_addon_pcrlock_files handles non-existent directories correctly
+        #[test]
+        fn test_generate_uki_addon_pcrlock_files_nonexistent_directory() {
+            let temp_dir = TempDir::new().unwrap();
+            let non_existent_dir = temp_dir.path().join("nonexistent.efi.extra.d");
+
+            // Should succeed without error when directory doesn't exist
+            let result = generate_uki_addon_pcrlock_files(non_existent_dir, 0);
+            assert!(
+                result.is_ok(),
+                "Function should succeed when directory doesn't exist"
+            );
+        }
+
+        /// Test that generate_uki_addon_pcrlock_files handles empty directories correctly
+        #[test]
+        fn test_generate_uki_addon_pcrlock_files_empty_directory() {
+            let temp_dir = TempDir::new().unwrap();
+            let empty_dir = temp_dir.path().join("empty.efi.extra.d");
+            std::fs::create_dir_all(&empty_dir).unwrap();
+
+            // Should succeed without error when directory is empty
+            let result = generate_uki_addon_pcrlock_files(empty_dir, 0);
+            assert!(
+                result.is_ok(),
+                "Function should succeed when directory is empty"
+            );
+        }
+
+        /// Test that generate_uki_addon_pcrlock_files handles directories with invalid files correctly
+        #[test]
+        fn test_generate_uki_addon_pcrlock_files_invalid_files() {
+            let temp_dir = TempDir::new().unwrap();
+            let addon_dir = temp_dir.path().join("invalid.efi.extra.d");
+            std::fs::create_dir_all(&addon_dir).unwrap();
+
+            // Create invalid files that should be ignored
+            std::fs::write(addon_dir.join("invalid.txt"), "text file").unwrap();
+            std::fs::write(addon_dir.join("wrong.efi"), "wrong suffix").unwrap();
+            std::fs::create_dir_all(addon_dir.join("subdir")).unwrap();
+
+            // Should succeed without processing any files
+            let result = generate_uki_addon_pcrlock_files(addon_dir.clone(), 0);
+            assert!(
+                result.is_ok(),
+                "Function should succeed when no valid addon files exist"
+            );
+
+            // Verify that no valid addon files are found
+            let valid_entries: Vec<_> = std::fs::read_dir(&addon_dir)
+                .unwrap()
+                .filter_map(|entry| {
+                    let entry = entry.ok()?;
+                    let path = entry.path();
+                    if uki::is_uki_addon_file(&path) {
+                        Some(path)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            assert_eq!(valid_entries.len(), 0, "Should find no valid addon files");
+        }
+
+        /// Test addon name extraction and pcrlock path generation logic
+        #[test]
+        fn test_addon_name_and_path_generation() {
+            let temp_dir = TempDir::new().unwrap();
+            let addon_dir = temp_dir.path().join("test.extra.d");
+            std::fs::create_dir_all(&addon_dir).unwrap();
+
+            let test_cases = vec![
+                ("simple.addon.efi", "simple"),
+                ("complex-name_123.addon.efi", "complex-name_123"),
+                ("a.addon.efi", "a"),
+                ("with.dots.in.name.addon.efi", "with.dots.in.name"),
+            ];
+
+            for (file_name, expected_name) in test_cases {
+                let file_path = addon_dir.join(file_name);
+                std::fs::write(&file_path, "mock content").unwrap();
+
+                // Verify file is recognized as addon file
+                assert!(
+                    uki::is_uki_addon_file(&file_path),
+                    "File {} should be recognized as addon file",
+                    file_name
+                );
+
+                // Test name extraction
+                let extracted_name = uki::get_uki_name_from_addon_file(&file_path).unwrap();
+                assert_eq!(
+                    extracted_name, expected_name,
+                    "Name extraction failed for {}",
+                    file_name
+                );
+
+                // Test pcrlock directory name generation
+                let pcrlock_addon_name = format!(
+                    "{}{}{}",
+                    UKI_ADDONS_PCRLOCK_DIR_PREFIX, extracted_name, UKI_ADDONS_PCRLOCK_DIR_SUFFIX
+                );
+                assert!(pcrlock_addon_name.starts_with("670-uki-addons-"));
+                assert!(pcrlock_addon_name.ends_with(".pcrlock.d"));
+                assert!(pcrlock_addon_name.contains(extracted_name));
+
+                // Test pcrlock file path generation
+                let addon_pcrlock_file = generate_pcrlock_output_path(&pcrlock_addon_name, 0);
+                let path_str = addon_pcrlock_file.to_str().unwrap();
+                assert!(
+                    path_str.contains(&pcrlock_addon_name),
+                    "Path should contain pcrlock addon name"
+                );
+                assert!(
+                    path_str.ends_with("generated-0.pcrlock"),
+                    "Path should end with generated-0.pcrlock"
+                );
+                assert!(
+                    path_str.starts_with(PCRLOCK_DIR),
+                    "Path should start with pcrlock directory"
+                );
+            }
+        }
+
+        /// Test file filtering logic used by generate_uki_addon_pcrlock_files
+        #[test]
+        fn test_file_filtering_functionality() {
+            let temp_dir = TempDir::new().unwrap();
+            let addon_dir = temp_dir.path().join("test.extra.d");
+            std::fs::create_dir_all(&addon_dir).unwrap();
+
+            // Valid files that should be processed
+            let valid_files = ["valid1.addon.efi", "valid2.addon.efi"];
+            for file in &valid_files {
+                let path = addon_dir.join(file);
+                std::fs::write(&path, "mock content").unwrap();
+                assert!(
+                    uki::is_uki_addon_file(&path),
+                    "File {} should be recognized as valid addon file",
+                    file
+                );
+            }
+
+            // Invalid files that should be ignored
+            let invalid_files = [
+                "invalid.txt",
+                "wrong.efi",
+                "no_extension",
+                "addon.efi.wrong",
+            ];
+            for file in &invalid_files {
+                let path = addon_dir.join(file);
+                std::fs::write(&path, "mock content").unwrap();
+                assert!(
+                    !uki::is_uki_addon_file(&path),
+                    "File {} should NOT be recognized as addon file",
+                    file
+                );
+            }
+
+            // Directories should be ignored
+            let subdir = addon_dir.join("subdir");
+            std::fs::create_dir_all(&subdir).unwrap();
+            assert!(
+                !uki::is_uki_addon_file(&subdir),
+                "Directory should not be recognized as addon file"
+            );
+        }
+
+        /// Test error handling in generate_uki_addon_pcrlock_files
+        #[test]
+        fn test_generate_uki_addon_pcrlock_files_error_handling() {
+            let temp_dir = TempDir::new().unwrap();
+            let addon_dir = temp_dir.path().join("error_test.efi.extra.d");
+            std::fs::create_dir_all(&addon_dir).unwrap();
+
+            // Create a valid addon file
+            let addon_path = addon_dir.join("test_addon.addon.efi");
+            std::fs::write(&addon_path, "mock addon binary").unwrap();
+
+            // The function should fail when trying to execute systemd-pcrlock lock-pe
+            // but should get to that point, indicating the file was properly processed
+            let result = generate_uki_addon_pcrlock_files(addon_dir, 0);
+            assert!(
+                result.is_err(),
+                "Function should fail due to missing systemd-pcrlock"
+            );
+
+            // Verify the error is related to systemd-pcrlock execution, not file processing
+            let error_msg = result.unwrap_err().to_string();
+            assert!(
+                error_msg.contains("lock-pe")
+                    || error_msg.contains("systemd-pcrlock")
+                    || error_msg.contains("Failed to generate"),
+                "Error should be related to pcrlock execution: {}",
+                error_msg
+            );
+        }
+
+        /// Test different index values in generate_uki_addon_pcrlock_files
+        #[test]
+        fn test_generate_uki_addon_pcrlock_files_with_different_indices() {
+            let temp_dir = TempDir::new().unwrap();
+            let addon_dir = temp_dir.path().join("index_test.efi.extra.d");
+            std::fs::create_dir_all(&addon_dir).unwrap();
+
+            // Create a valid addon file
+            let addon_path = addon_dir.join("test_addon.addon.efi");
+            std::fs::write(&addon_path, "mock addon binary").unwrap();
+
+            // Test different index values
+            for index in [0, 1, 5, 10] {
+                let result = generate_uki_addon_pcrlock_files(addon_dir.clone(), index);
+                assert!(
+                    result.is_err(),
+                    "Function should fail due to missing systemd-pcrlock for index {}",
+                    index
+                );
+
+                // Verify the generated path would include the correct index
+                let pcrlock_addon_name = format!(
+                    "{}{}{}",
+                    UKI_ADDONS_PCRLOCK_DIR_PREFIX, "test_addon", UKI_ADDONS_PCRLOCK_DIR_SUFFIX
+                );
+                let expected_path = generate_pcrlock_output_path(&pcrlock_addon_name, index);
+                let expected_filename = format!("generated-{}.pcrlock", index);
+                assert!(
+                    expected_path
+                        .to_str()
+                        .unwrap()
+                        .ends_with(&expected_filename),
+                    "Generated path should end with correct index: {}",
+                    expected_filename
+                );
+            }
+        }
+
+        /// Test directory path edge cases
+        #[test]
+        fn test_directory_path_edge_cases() {
+            let temp_dir = TempDir::new().unwrap();
+
+            // Test with file instead of directory
+            let file_path = temp_dir.path().join("not_a_directory.txt");
+            std::fs::write(&file_path, "file content").unwrap();
+            let result = generate_uki_addon_pcrlock_files(file_path, 0);
+            assert!(
+                result.is_ok(),
+                "Function should succeed when path is not a directory"
+            );
+
+            // Test with permission-denied scenario would require special setup
+            // but we can test that the function handles basic path validation correctly
+
+            // Test with empty path components
+            let weird_path = temp_dir.path().join("");
+            let result = generate_uki_addon_pcrlock_files(weird_path, 0);
+            assert!(
+                result.is_ok(),
+                "Function should handle empty path gracefully"
+            );
+        }
+    }
+
+    /// Tests for generate_uki_pcrlock_files function
+    mod generate_uki_pcrlock_files_tests {
+        use super::*;
+        use tempfile::TempDir;
+
+        /// Test that generate_uki_pcrlock_files handles path generation correctly
+        #[test]
+        fn test_generate_uki_pcrlock_files_path_generation() {
+            let temp_dir = TempDir::new().unwrap();
+            let uki_path = temp_dir.path().join("test.efi");
+            std::fs::write(&uki_path, "mock uki binary").unwrap();
+
+            // Test that the function would attempt to create correct paths
+            // (execution will fail due to missing systemd-pcrlock, but validates path logic)
+            let result = generate_uki_pcrlock_files(uki_path.clone(), 0);
+            assert!(
+                result.is_err(),
+                "Function should fail due to missing systemd-pcrlock dependency"
+            );
+
+            // Verify main UKI pcrlock path generation
+            let expected_uki_pcrlock_file = generate_pcrlock_output_path(UKI_PCRLOCK_DIR, 0);
+            let expected_path_str = expected_uki_pcrlock_file.to_str().unwrap();
+            assert!(
+                expected_path_str.contains("650-uki.pcrlock.d"),
+                "Path should contain UKI pcrlock directory"
+            );
+            assert!(
+                expected_path_str.ends_with("generated-0.pcrlock"),
+                "Path should end with generated-0.pcrlock"
+            );
+
+            // Verify UKI addon directory path generation
+            let expected_addon_dir = uki::uki_addon_dir(&uki_path);
+            let expected_addon_str = expected_addon_dir.to_str().unwrap();
+            assert!(
+                expected_addon_str.ends_with(".extra.d"),
+                "Addon directory should end with .extra.d"
+            );
+            assert!(
+                expected_addon_str.contains("test"),
+                "Addon directory should be derived from UKI name"
+            );
+        }
+
+        /// Test generate_uki_pcrlock_files with different UKI paths
+        #[test]
+        fn test_generate_uki_pcrlock_files_different_uki_paths() {
+            let temp_dir = TempDir::new().unwrap();
+
+            let test_cases = vec![
+                "simple.efi",
+                "complex-name_123.efi",
+                "with.dots.in.name.efi",
+                "UPPERCASE.EFI",
+                "mixed_Case-Name.efi",
+            ];
+
+            for uki_name in test_cases {
+                let uki_path = temp_dir.path().join(uki_name);
+                std::fs::write(&uki_path, "mock uki binary").unwrap();
+
+                // Function should fail at systemd-pcrlock execution, not path validation
+                let result = generate_uki_pcrlock_files(uki_path.clone(), 0);
+                assert!(
+                    result.is_err(),
+                    "Function should fail due to missing systemd-pcrlock for {}",
+                    uki_name
+                );
+
+                // Verify addon directory path is correctly derived
+                let addon_dir = uki::uki_addon_dir(&uki_path);
+                let addon_str = addon_dir.to_str().unwrap();
+                assert!(
+                    addon_str.ends_with(".extra.d"),
+                    "Addon directory for {} should end with .extra.d",
+                    uki_name
+                );
+                assert!(
+                    addon_str.contains(uki_path.parent().unwrap().to_str().unwrap()),
+                    "Addon directory should be in same parent directory as UKI"
+                );
+            }
+        }
+
+        /// Test generate_uki_pcrlock_files with different indices
+        #[test]
+        fn test_generate_uki_pcrlock_files_different_indices() {
+            let temp_dir = TempDir::new().unwrap();
+            let uki_path = temp_dir.path().join("test.efi");
+            std::fs::write(&uki_path, "mock uki binary").unwrap();
+
+            for index in [0, 1, 5, 10] {
+                let result = generate_uki_pcrlock_files(uki_path.clone(), index);
+                assert!(
+                    result.is_err(),
+                    "Function should fail due to missing systemd-pcrlock for index {}",
+                    index
+                );
+
+                // Verify the generated path includes the correct index
+                let expected_path = generate_pcrlock_output_path(UKI_PCRLOCK_DIR, index);
+                let expected_filename = format!("generated-{}.pcrlock", index);
+                assert!(
+                    expected_path
+                        .to_str()
+                        .unwrap()
+                        .ends_with(&expected_filename),
+                    "Generated path should end with correct index: {}",
+                    expected_filename
+                );
+            }
+        }
+
+        /// Test generate_uki_pcrlock_files integration with addon processing
+        #[test]
+        fn test_generate_uki_pcrlock_files_addon_integration() {
+            let temp_dir = TempDir::new().unwrap();
+            let uki_path = temp_dir.path().join("test.efi");
+            std::fs::write(&uki_path, "mock uki binary").unwrap();
+
+            // Create UKI addon directory and files
+            let addon_dir = uki::uki_addon_dir(&uki_path);
+            std::fs::create_dir_all(&addon_dir).unwrap();
+
+            let addon_files = ["addon1.addon.efi", "addon2.addon.efi"];
+            for addon_file in &addon_files {
+                let addon_path = addon_dir.join(addon_file);
+                std::fs::write(&addon_path, "mock addon binary").unwrap();
+            }
+
+            // Function should fail at systemd-pcrlock execution but reach addon processing
+            let result = generate_uki_pcrlock_files(uki_path.clone(), 0);
+            assert!(
+                result.is_err(),
+                "Function should fail due to missing systemd-pcrlock"
+            );
+
+            // Verify addon directory was created and contains expected files
+            assert!(addon_dir.exists() && addon_dir.is_dir());
+            let addon_entries: Vec<_> = std::fs::read_dir(&addon_dir)
+                .unwrap()
+                .filter_map(|entry| {
+                    let entry = entry.ok()?;
+                    let path = entry.path();
+                    if uki::is_uki_addon_file(&path) {
+                        Some(path)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            assert_eq!(addon_entries.len(), 2, "Should find 2 valid addon files");
+        }
+
+        /// Test generate_uki_pcrlock_files with non-existent UKI file
+        #[test]
+        fn test_generate_uki_pcrlock_files_nonexistent_uki() {
+            let temp_dir = TempDir::new().unwrap();
+            let nonexistent_uki = temp_dir.path().join("nonexistent.efi");
+
+            // Function should fail when trying to process non-existent UKI
+            let result = generate_uki_pcrlock_files(nonexistent_uki, 0);
+            assert!(
+                result.is_err(),
+                "Function should fail when UKI file doesn't exist"
+            );
+        }
+
+        /// Test generate_uki_pcrlock_files error propagation from addon processing
+        #[test]
+        fn test_generate_uki_pcrlock_files_addon_error_propagation() {
+            let temp_dir = TempDir::new().unwrap();
+            let uki_path = temp_dir.path().join("test.efi");
+            std::fs::write(&uki_path, "mock uki binary").unwrap();
+
+            // Create addon directory with valid addon file
+            let addon_dir = uki::uki_addon_dir(&uki_path);
+            std::fs::create_dir_all(&addon_dir).unwrap();
+            let addon_path = addon_dir.join("test.addon.efi");
+            std::fs::write(&addon_path, "mock addon binary").unwrap();
+
+            // Function should fail and error should mention either UKI processing or addon processing
+            let result = generate_uki_pcrlock_files(uki_path, 0);
+            assert!(
+                result.is_err(),
+                "Function should fail due to systemd-pcrlock dependency"
+            );
+
+            let error_msg = result.unwrap_err().to_string();
+            assert!(
+                error_msg.contains("lock-uki")
+                    || error_msg.contains("lock-pe")
+                    || error_msg.contains("systemd-pcrlock")
+                    || error_msg.contains("Failed to generate"),
+                "Error should be related to pcrlock execution: {}",
+                error_msg
+            );
+        }
+
+        /// Test generate_uki_pcrlock_files without addon directory
+        #[test]
+        fn test_generate_uki_pcrlock_files_no_addon_directory() {
+            let temp_dir = TempDir::new().unwrap();
+            let uki_path = temp_dir.path().join("test.efi");
+            std::fs::write(&uki_path, "mock uki binary").unwrap();
+
+            // Don't create addon directory - function should still attempt UKI processing
+            let result = generate_uki_pcrlock_files(uki_path.clone(), 0);
+            assert!(
+                result.is_err(),
+                "Function should fail due to missing systemd-pcrlock"
+            );
+
+            // Verify addon directory path would be correct even if it doesn't exist
+            let addon_dir = uki::uki_addon_dir(&uki_path);
+            assert!(
+                !addon_dir.exists(),
+                "Addon directory should not exist in this test"
+            );
+            assert!(
+                addon_dir.to_str().unwrap().ends_with(".extra.d"),
+                "Addon directory path should still be correctly formed"
+            );
+        }
+
+        /// Test path validation and UKI name extraction logic used by generate_uki_pcrlock_files
+        #[test]
+        fn test_uki_path_processing_logic() {
+            let temp_dir = TempDir::new().unwrap();
+
+            let test_cases = vec![
+                ("simple.efi", "simple.efi.extra.d"),
+                ("complex-name_123.efi", "complex-name_123.efi.extra.d"),
+                ("path/to/nested.efi", "nested.efi.extra.d"),
+            ];
+
+            for (uki_file, expected_addon_suffix) in test_cases {
+                let path_parts: Vec<&str> = uki_file.split('/').collect();
+                let full_uki_path = if path_parts.len() > 1 {
+                    let nested_dir = temp_dir.path().join("path").join("to");
+                    std::fs::create_dir_all(&nested_dir).unwrap();
+                    nested_dir.join(path_parts.last().unwrap())
+                } else {
+                    temp_dir.path().join(uki_file)
+                };
+
+                std::fs::write(&full_uki_path, "mock uki binary").unwrap();
+
+                // Test addon directory path generation
+                let addon_dir = uki::uki_addon_dir(&full_uki_path);
+                let addon_str = addon_dir.to_str().unwrap();
+                assert!(
+                    addon_str.ends_with(expected_addon_suffix),
+                    "Addon directory for {} should end with {}, got: {}",
+                    uki_file,
+                    expected_addon_suffix,
+                    addon_str
+                );
+
+                // Test main UKI pcrlock path generation
+                let uki_pcrlock_path = generate_pcrlock_output_path(UKI_PCRLOCK_DIR, 0);
+                let uki_path_str = uki_pcrlock_path.to_str().unwrap();
+                assert!(
+                    uki_path_str.contains("650-uki.pcrlock.d"),
+                    "UKI pcrlock path should contain correct directory"
+                );
+                assert!(
+                    uki_path_str.ends_with("generated-0.pcrlock"),
+                    "UKI pcrlock path should have correct filename"
+                );
+            }
+        }
+
+        /// Test that generate_uki_pcrlock_files uses correct constants and paths
+        #[test]
+        fn test_generate_uki_pcrlock_files_constants_usage() {
+            let temp_dir = TempDir::new().unwrap();
+            let uki_path = temp_dir.path().join("test.efi");
+            std::fs::write(&uki_path, "mock uki binary").unwrap();
+
+            // Verify that the function would use the correct constants
+            // by testing the path generation functions it calls
+
+            // Test UKI_PCRLOCK_DIR usage
+            let uki_pcrlock_path = generate_pcrlock_output_path(UKI_PCRLOCK_DIR, 0);
+            assert_eq!(UKI_PCRLOCK_DIR, "650-uki.pcrlock.d");
+            assert!(
+                uki_pcrlock_path.to_str().unwrap().contains(UKI_PCRLOCK_DIR),
+                "UKI pcrlock path should use UKI_PCRLOCK_DIR constant"
+            );
+
+            // Test PCRLOCK_DIR usage
+            assert_eq!(PCRLOCK_DIR, "/var/lib/pcrlock.d");
+            assert!(
+                uki_pcrlock_path.to_str().unwrap().starts_with(PCRLOCK_DIR),
+                "UKI pcrlock path should start with PCRLOCK_DIR"
+            );
+
+            // Test that addon path generation would use correct suffixes
+            let addon_dir = uki::uki_addon_dir(&uki_path);
+            assert!(
+                addon_dir.to_str().unwrap().ends_with(".extra.d"),
+                "Addon directory should use .extra.d suffix"
+            );
+        }
+    }
+
+    /// Integration tests for generate_uki_pcrlock_files and generate_uki_addon_pcrlock_files
+    mod integration_tests {
+        use super::*;
+        use tempfile::TempDir;
+
+        /// Test the integration between generate_uki_pcrlock_files and generate_uki_addon_pcrlock_files
+        #[test]
+        fn test_uki_and_addon_pcrlock_integration() {
+            let temp_dir = TempDir::new().unwrap();
+            let uki_path = temp_dir.path().join("integration_test.efi");
+            std::fs::write(&uki_path, "mock uki binary").unwrap();
+
+            // Create addon directory and files
+            let addon_dir = uki::uki_addon_dir(&uki_path);
+            std::fs::create_dir_all(&addon_dir).unwrap();
+
+            let addon_files = [
+                "driver1.addon.efi",
+                "driver2.addon.efi",
+                "complex-name_123.addon.efi",
+            ];
+            for addon_file in &addon_files {
+                let addon_path = addon_dir.join(addon_file);
+                std::fs::write(&addon_path, "mock addon binary").unwrap();
+            }
+
+            // Test that the main function processes both UKI and addons
+            let result = generate_uki_pcrlock_files(uki_path.clone(), 1);
+            assert!(
+                result.is_err(),
+                "Function should fail due to missing systemd-pcrlock"
+            );
+
+            // Verify all expected paths would be generated correctly
+
+            // Main UKI pcrlock path
+            let uki_pcrlock_path = generate_pcrlock_output_path(UKI_PCRLOCK_DIR, 1);
+            assert!(
+                uki_pcrlock_path
+                    .to_str()
+                    .unwrap()
+                    .ends_with("generated-1.pcrlock"),
+                "UKI pcrlock should use index 1"
+            );
+
+            // Addon pcrlock paths
+            for addon_file in &addon_files {
+                let addon_path = addon_dir.join(addon_file);
+                let addon_name = uki::get_uki_name_from_addon_file(&addon_path).unwrap();
+                let pcrlock_addon_name = format!(
+                    "{}{}{}",
+                    UKI_ADDONS_PCRLOCK_DIR_PREFIX, addon_name, UKI_ADDONS_PCRLOCK_DIR_SUFFIX
+                );
+                let addon_pcrlock_path = generate_pcrlock_output_path(&pcrlock_addon_name, 1);
+
+                assert!(
+                    addon_pcrlock_path.to_str().unwrap().contains(addon_name),
+                    "Addon pcrlock path should contain addon name for {}",
+                    addon_file
+                );
+                assert!(
+                    addon_pcrlock_path
+                        .to_str()
+                        .unwrap()
+                        .ends_with("generated-1.pcrlock"),
+                    "Addon pcrlock should use same index as main UKI"
+                );
+            }
+        }
+
+        /// Test error handling in the integration between UKI and addon processing
+        #[test]
+        fn test_integration_error_handling() {
+            let temp_dir = TempDir::new().unwrap();
+            let uki_path = temp_dir.path().join("error_test.efi");
+            std::fs::write(&uki_path, "mock uki binary").unwrap();
+
+            // Test cases with different addon directory states
+            let test_scenarios = vec![
+                ("no_addon_dir", false, false),   // No addon directory
+                ("empty_addon_dir", true, false), // Empty addon directory
+                ("with_addons", true, true),      // Directory with valid addons
+            ];
+
+            for (scenario, create_dir, create_files) in test_scenarios {
+                let scenario_uki_path = temp_dir.path().join(format!("{}.efi", scenario));
+                std::fs::write(&scenario_uki_path, "mock uki binary").unwrap();
+
+                if create_dir {
+                    let addon_dir = uki::uki_addon_dir(&scenario_uki_path);
+                    std::fs::create_dir_all(&addon_dir).unwrap();
+
+                    if create_files {
+                        std::fs::write(addon_dir.join("test.addon.efi"), "mock addon").unwrap();
+                    }
+                }
+
+                // All scenarios should fail at systemd-pcrlock execution
+                let result = generate_uki_pcrlock_files(scenario_uki_path, 0);
+                assert!(
+                    result.is_err(),
+                    "Scenario '{}' should fail due to missing systemd-pcrlock",
+                    scenario
+                );
+
+                // Error should be related to command execution, not path processing
+                let error_msg = result.unwrap_err().to_string();
+                assert!(
+                    error_msg.contains("lock-")
+                        || error_msg.contains("systemd-pcrlock")
+                        || error_msg.contains("Failed to generate"),
+                    "Scenario '{}' should have pcrlock-related error: {}",
+                    scenario,
+                    error_msg
+                );
+            }
+        }
+
+        /// Test path consistency between UKI and addon pcrlock file generation
+        #[test]
+        fn test_path_consistency() {
+            let temp_dir = TempDir::new().unwrap();
+            let uki_path = temp_dir.path().join("consistency_test.efi");
+            std::fs::write(&uki_path, "mock uki binary").unwrap();
+
+            // Test multiple indices to ensure consistency
+            for index in [0, 2, 5] {
+                // Main UKI path
+                let uki_pcrlock_path = generate_pcrlock_output_path(UKI_PCRLOCK_DIR, index);
+
+                // Addon paths
+                let test_addon_names = ["driver1", "driver2", "complex-name"];
+                for addon_name in &test_addon_names {
+                    let pcrlock_addon_name = format!(
+                        "{}{}{}",
+                        UKI_ADDONS_PCRLOCK_DIR_PREFIX, addon_name, UKI_ADDONS_PCRLOCK_DIR_SUFFIX
+                    );
+                    let addon_pcrlock_path =
+                        generate_pcrlock_output_path(&pcrlock_addon_name, index);
+
+                    // Both should use same base directory
+                    assert!(
+                        uki_pcrlock_path.starts_with(PCRLOCK_DIR)
+                            && addon_pcrlock_path.starts_with(PCRLOCK_DIR),
+                        "Both UKI and addon paths should start with PCRLOCK_DIR"
+                    );
+
+                    // Both should use same index in filename
+                    let expected_filename = format!("generated-{}.pcrlock", index);
+                    assert!(
+                        uki_pcrlock_path
+                            .to_str()
+                            .unwrap()
+                            .ends_with(&expected_filename),
+                        "UKI path should end with correct filename for index {}",
+                        index
+                    );
+                    assert!(
+                        addon_pcrlock_path
+                            .to_str()
+                            .unwrap()
+                            .ends_with(&expected_filename),
+                        "Addon path should end with correct filename for index {}",
+                        index
+                    );
+
+                    // Addon path should contain addon-specific directory
+                    assert!(
+                        addon_pcrlock_path
+                            .to_str()
+                            .unwrap()
+                            .contains(&format!("670-uki-addons-{}", addon_name)),
+                        "Addon path should contain addon-specific directory name"
+                    );
+                }
+            }
+        }
+
+        /// Test that both functions correctly handle the same addon directory
+        #[test]
+        fn test_shared_addon_directory_handling() {
+            let temp_dir = TempDir::new().unwrap();
+            let uki_path = temp_dir.path().join("shared_test.efi");
+            std::fs::write(&uki_path, "mock uki binary").unwrap();
+
+            // Create addon directory and files
+            let addon_dir = uki::uki_addon_dir(&uki_path);
+            std::fs::create_dir_all(&addon_dir).unwrap();
+
+            // Mix of valid and invalid files
+            std::fs::write(addon_dir.join("valid1.addon.efi"), "valid addon").unwrap();
+            std::fs::write(addon_dir.join("valid2.addon.efi"), "valid addon").unwrap();
+            std::fs::write(addon_dir.join("invalid.txt"), "invalid file").unwrap();
+            std::fs::create_dir_all(addon_dir.join("subdir")).unwrap();
+
+            // Test generate_uki_pcrlock_files (which calls generate_uki_addon_pcrlock_files)
+            let result1 = generate_uki_pcrlock_files(uki_path, 0);
+            assert!(
+                result1.is_err(),
+                "generate_uki_pcrlock_files should fail due to systemd-pcrlock"
+            );
+
+            // Test generate_uki_addon_pcrlock_files directly
+            let result2 = generate_uki_addon_pcrlock_files(addon_dir.clone(), 0);
+            assert!(
+                result2.is_err(),
+                "generate_uki_addon_pcrlock_files should fail due to systemd-pcrlock"
+            );
+
+            // Both should process the same valid addon files
+            let valid_addons: Vec<_> = std::fs::read_dir(&addon_dir)
+                .unwrap()
+                .filter_map(|entry| {
+                    let entry = entry.ok()?;
+                    let path = entry.path();
+                    if uki::is_uki_addon_file(&path) {
+                        Some(path)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            assert_eq!(
+                valid_addons.len(),
+                2,
+                "Should find exactly 2 valid addon files"
+            );
+
+            // Verify both valid files are properly named
+            let mut found_valid1 = false;
+            let mut found_valid2 = false;
+            for path in &valid_addons {
+                let addon_name = uki::get_uki_name_from_addon_file(path).unwrap();
+                if addon_name == "valid1" {
+                    found_valid1 = true;
+                }
+                if addon_name == "valid2" {
+                    found_valid2 = true;
+                }
+            }
+            assert!(found_valid1, "Should find valid1 addon");
+            assert!(found_valid2, "Should find valid2 addon");
+        }
     }
 }
 

--- a/crates/osutils/src/pcrlock.rs
+++ b/crates/osutils/src/pcrlock.rs
@@ -651,7 +651,7 @@ fn generate_pcrlock_files(
                     };
                     lock_addon_cmd.run().context(format!(
                         "Failed to generate .pcrlock file via 'lock-pe' at '{}'",
-                        uki_path.display()
+                        path.display()
                     ))?;
                     trace!(
                         "Contents of .pcrlock file at '{}':\n{}",

--- a/crates/osutils/src/uki.rs
+++ b/crates/osutils/src/uki.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use anyhow::{Context, Error, Result};
+
 /// UKI Addon directory suffix.
 pub const UKI_ADDON_DIR_SUFFIX: &str = ".extra.d";
 /// UKI Addon file suffix.
@@ -15,6 +17,36 @@ pub fn uki_addon_dir(uki_path: &Path) -> PathBuf {
     PathBuf::from(addon_dir)
 }
 
+/// Determines if the given path corresponds to a UKI addon file, which is
+/// expected to be a regular file with a name that ends with `.addon.efi`. For
+/// example, `vmlinuz-1-azla1.efi.addon.efi` would be considered a UKI addon
+/// file, while `vmlinuz-1-azla1.efi` would not.
+pub fn is_uki_addon_file(path: &Path) -> bool {
+    path.is_file()
+        && path
+            .file_name()
+            .is_some_and(|name| name.to_string_lossy().ends_with(UKI_ADDON_FILE_SUFFIX))
+}
+
+pub fn get_uki_name_from_addon_file(addon_file: &Path) -> Result<&str, Error> {
+    addon_file
+        .file_name()
+        .with_context(|| format!(
+            "Expected a file but found a directory at path '{}' in UKI addons directory.",
+            addon_file.display()
+        ))?
+        .to_str()
+        .with_context(|| format!(
+            "Failed to get file name for path '{}' in UKI addons directory.",
+            addon_file.display()
+        ))?
+        .strip_suffix(UKI_ADDON_FILE_SUFFIX)
+        .with_context(|| format!(
+            "File '{}' in UKI addons directory does not end with expected suffix '{UKI_ADDON_FILE_SUFFIX}'.",
+            addon_file.display(),
+        ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -23,8 +55,710 @@ mod tests {
     /// UKI file path to form the addon directory path.
     #[test]
     fn test_uki_addon_dir() {
-        let uki_path = PathBuf::from("/some/path/vmlinuz-1-azla1.efi");
-        let expected_addon_dir = PathBuf::from("/some/path/vmlinuz-1-azla1.efi.extra.d");
-        assert_eq!(uki_addon_dir(&uki_path), expected_addon_dir);
+        let test_cases = vec![
+            (
+                "/some/path/vmlinuz-1-azla1.efi",
+                "/some/path/vmlinuz-1-azla1.efi.extra.d",
+            ),
+            (
+                "/different/path/kernel.efi",
+                "/different/path/kernel.efi.extra.d",
+            ),
+            ("relative/path/uki.efi", "relative/path/uki.efi.extra.d"),
+            ("simple.efi", "simple.efi.extra.d"),
+            (
+                "/root/complex-name_123.efi",
+                "/root/complex-name_123.efi.extra.d",
+            ),
+            (
+                "/path/with spaces/file name.efi",
+                "/path/with spaces/file name.efi.extra.d",
+            ),
+            (
+                "/path/with.dots.in.name.efi",
+                "/path/with.dots.in.name.efi.extra.d",
+            ),
+            ("", ".extra.d"),
+        ];
+
+        for (input_path, expected_path) in test_cases {
+            let uki_path = PathBuf::from(input_path);
+            let expected_addon_dir = PathBuf::from(expected_path);
+            let actual_addon_dir = uki_addon_dir(&uki_path);
+
+            assert_eq!(
+                actual_addon_dir, expected_addon_dir,
+                "Failed for input path: '{}'",
+                input_path
+            );
+
+            // Verify the result always ends with the correct suffix
+            assert!(
+                actual_addon_dir
+                    .to_string_lossy()
+                    .ends_with(UKI_ADDON_DIR_SUFFIX),
+                "Result should always end with UKI_ADDON_DIR_SUFFIX for path: '{}'",
+                input_path
+            );
+        }
+    }
+
+    /// Validates that `is_uki_addon_file` correctly identifies addon files.
+    #[test]
+    fn test_is_uki_addon_file() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+
+        // Test cases: (filename, should_be_addon_file, description)
+        let test_cases = vec![
+            ("vmlinuz-1-azla1.addon.efi", true, "standard addon file"),
+            ("driver.addon.efi", true, "simple addon file"),
+            (
+                "complex-name_123.addon.efi",
+                true,
+                "complex addon file name",
+            ),
+            (
+                "with.dots.in.name.addon.efi",
+                true,
+                "addon file with dots in name",
+            ),
+            (
+                "very-long-name-with-many-components-123_456.addon.efi",
+                true,
+                "long addon file name",
+            ),
+            (
+                "unicode-ä-ü-ñ.addon.efi",
+                true,
+                "unicode characters in name",
+            ),
+            ("123456.addon.efi", true, "numeric addon file name"),
+            (".addon.efi", true, "minimal addon file name"),
+            (
+                "file.addon.efi.backup.addon.efi",
+                true,
+                "multiple suffix patterns",
+            ),
+            // Invalid cases
+            ("vmlinuz-1-azla1.efi", false, "regular EFI file"),
+            ("driver.efi", false, "simple EFI file without addon"),
+            ("file.txt", false, "text file"),
+            ("no_extension", false, "file without extension"),
+            ("wrong.suffix", false, "wrong file suffix"),
+            ("file.addon", false, "addon without efi extension"),
+            ("file.addonx.efi", false, "similar but wrong addon suffix"),
+            ("file.addon.efix", false, "similar but wrong efi suffix"),
+            ("", false, "empty filename"),
+        ];
+
+        for (filename, should_be_addon, description) in test_cases {
+            let file_path = temp_dir.path().join(filename);
+
+            // Only create file if filename is not empty
+            if !filename.is_empty() {
+                std::fs::write(&file_path, "mock content").unwrap();
+            }
+
+            let result = is_uki_addon_file(&file_path);
+            assert_eq!(
+                result, should_be_addon,
+                "Failed for {}: '{}'",
+                description, filename
+            );
+        }
+
+        // Test directory handling
+        let addon_dir = temp_dir.path().join("directory.addon.efi");
+        std::fs::create_dir_all(&addon_dir).unwrap();
+        assert!(
+            !is_uki_addon_file(&addon_dir),
+            "Directory should not be identified as addon file even with correct suffix"
+        );
+
+        // Test non-existent file
+        let nonexistent = temp_dir.path().join("nonexistent.addon.efi");
+        assert!(
+            !is_uki_addon_file(&nonexistent),
+            "Non-existent file should not be identified as addon file"
+        );
+
+        // Test symlink behavior (if supported on platform)
+        #[cfg(unix)]
+        {
+            let real_file = temp_dir.path().join("real.addon.efi");
+            std::fs::write(&real_file, "content").unwrap();
+            let symlink_file = temp_dir.path().join("symlink.addon.efi");
+
+            if std::os::unix::fs::symlink(&real_file, &symlink_file).is_ok() {
+                assert!(
+                    is_uki_addon_file(&symlink_file),
+                    "Symlink to addon file should be identified as addon file"
+                );
+            }
+        }
+    }
+
+    /// Tests for get_uki_name_from_addon_file function
+    mod get_uki_name_from_addon_file_tests {
+        use super::*;
+        use tempfile::TempDir;
+
+        /// Test successful name extraction from valid addon files
+        #[test]
+        fn test_get_uki_name_from_addon_file_valid() {
+            let temp_dir = TempDir::new().unwrap();
+
+            let test_cases = vec![
+                ("simple.addon.efi", "simple"),
+                ("complex-name_123.addon.efi", "complex-name_123"),
+                ("driver.addon.efi", "driver"),
+                ("with.dots.in.name.addon.efi", "with.dots.in.name"),
+                (
+                    "with-dashes-and_underscores.addon.efi",
+                    "with-dashes-and_underscores",
+                ),
+                ("a.addon.efi", "a"),
+                (
+                    "very-long-name-with-many-components-123_456.addon.efi",
+                    "very-long-name-with-many-components-123_456",
+                ),
+            ];
+
+            for (file_name, expected_name) in test_cases {
+                let file_path = temp_dir.path().join(file_name);
+                std::fs::write(&file_path, "mock addon content").unwrap();
+
+                let result = get_uki_name_from_addon_file(&file_path);
+                assert!(
+                    result.is_ok(),
+                    "Should successfully extract name from {}",
+                    file_name
+                );
+
+                let extracted_name = result.unwrap();
+                assert_eq!(
+                    extracted_name, expected_name,
+                    "Extracted name should match expected for {}",
+                    file_name
+                );
+            }
+        }
+
+        /// Test error cases for get_uki_name_from_addon_file
+        #[test]
+        fn test_get_uki_name_from_addon_file_errors() {
+            let temp_dir = TempDir::new().unwrap();
+
+            // Test with file that doesn't have correct suffix
+            let wrong_suffix_file = temp_dir.path().join("wrong.suffix.efi");
+            std::fs::write(&wrong_suffix_file, "content").unwrap();
+
+            let result = get_uki_name_from_addon_file(&wrong_suffix_file);
+            assert!(
+                result.is_err(),
+                "Should fail for file without correct suffix"
+            );
+            let error_msg = result.unwrap_err().to_string();
+            assert!(
+                error_msg.contains("does not end with expected suffix"),
+                "Error should mention suffix mismatch"
+            );
+            assert!(
+                error_msg.contains(".addon.efi"),
+                "Error should mention expected suffix"
+            );
+
+            // Test with file that has no extension at all
+            let no_extension_file = temp_dir.path().join("no_extension");
+            std::fs::write(&no_extension_file, "content").unwrap();
+
+            let result = get_uki_name_from_addon_file(&no_extension_file);
+            assert!(result.is_err(), "Should fail for file without extension");
+
+            // Test with file that ends with .efi but not .addon.efi
+            let wrong_efi_file = temp_dir.path().join("wrong.efi");
+            std::fs::write(&wrong_efi_file, "content").unwrap();
+
+            let result = get_uki_name_from_addon_file(&wrong_efi_file);
+            assert!(
+                result.is_err(),
+                "Should fail for .efi file without .addon prefix"
+            );
+        }
+
+        /// Test with directory paths (should fail)
+        #[test]
+        fn test_get_uki_name_from_addon_file_directory() {
+            let temp_dir = TempDir::new().unwrap();
+            let subdir = temp_dir.path().join("some_directory");
+            std::fs::create_dir_all(&subdir).unwrap();
+
+            let result = get_uki_name_from_addon_file(&subdir);
+            assert!(result.is_err(), "Should fail when path is a directory");
+
+            let error_msg = result.unwrap_err().to_string();
+            // Directory will fail because it doesn't end with .addon.efi suffix
+            assert!(
+                error_msg.contains("does not end with expected suffix")
+                    || error_msg.contains(".addon.efi"),
+                "Error should mention suffix issue, got: {}",
+                error_msg
+            );
+        }
+
+        /// Test edge cases with special characters and empty names
+        #[test]
+        fn test_get_uki_name_from_addon_file_edge_cases() {
+            let temp_dir = TempDir::new().unwrap();
+
+            // Test with Unicode characters (should work)
+            let unicode_file = temp_dir.path().join("test-ä-ü-ñ.addon.efi");
+            std::fs::write(&unicode_file, "content").unwrap();
+
+            let result = get_uki_name_from_addon_file(&unicode_file);
+            assert!(
+                result.is_ok(),
+                "Should handle Unicode characters in filename"
+            );
+            assert_eq!(result.unwrap(), "test-ä-ü-ñ");
+
+            // Test with numbers only
+            let numbers_file = temp_dir.path().join("123456.addon.efi");
+            std::fs::write(&numbers_file, "content").unwrap();
+
+            let result = get_uki_name_from_addon_file(&numbers_file);
+            assert!(result.is_ok(), "Should handle numeric-only names");
+            assert_eq!(result.unwrap(), "123456");
+
+            // Test minimum valid case - just the suffix
+            let minimal_file = temp_dir.path().join(".addon.efi");
+            std::fs::write(&minimal_file, "content").unwrap();
+
+            let result = get_uki_name_from_addon_file(&minimal_file);
+            assert!(result.is_ok(), "Should handle minimal case with empty name");
+            assert_eq!(result.unwrap(), "");
+        }
+
+        /// Test with files containing the suffix multiple times
+        #[test]
+        fn test_get_uki_name_from_addon_file_multiple_suffixes() {
+            let temp_dir = TempDir::new().unwrap();
+
+            // Test with name that contains the suffix pattern
+            let multiple_suffix_file = temp_dir.path().join("driver.addon.efi.backup.addon.efi");
+            std::fs::write(&multiple_suffix_file, "content").unwrap();
+
+            let result = get_uki_name_from_addon_file(&multiple_suffix_file);
+            assert!(
+                result.is_ok(),
+                "Should handle file with multiple suffix patterns"
+            );
+            assert_eq!(
+                result.unwrap(),
+                "driver.addon.efi.backup",
+                "Should strip only the final suffix"
+            );
+        }
+
+        /// Test non-existent files (should still work for name extraction if path has correct suffix)
+        #[test]
+        fn test_get_uki_name_from_addon_file_nonexistent() {
+            let temp_dir = TempDir::new().unwrap();
+            let nonexistent_file = temp_dir.path().join("nonexistent.addon.efi");
+            // Don't create the file
+
+            let result = get_uki_name_from_addon_file(&nonexistent_file);
+            // This should work because the function only checks the path string, not file existence
+            assert!(
+                result.is_ok(),
+                "Should extract name from path even if file doesn't exist"
+            );
+            assert_eq!(result.unwrap(), "nonexistent");
+        }
+
+        /// Test integration with is_uki_addon_file function
+        #[test]
+        fn test_integration_with_is_uki_addon_file() {
+            let temp_dir = TempDir::new().unwrap();
+
+            let test_files = [
+                ("valid.addon.efi", true, Some("valid")),
+                ("invalid.txt", false, None),
+                ("wrong.efi", false, None),
+            ];
+
+            for (file_name, should_be_addon, expected_name) in test_files {
+                let file_path = temp_dir.path().join(file_name);
+                std::fs::write(&file_path, "content").unwrap();
+
+                let is_addon = is_uki_addon_file(&file_path);
+                assert_eq!(
+                    is_addon, should_be_addon,
+                    "is_uki_addon_file result for {}",
+                    file_name
+                );
+
+                if should_be_addon {
+                    let name_result = get_uki_name_from_addon_file(&file_path);
+                    assert!(
+                        name_result.is_ok(),
+                        "get_uki_name_from_addon_file should succeed for valid addon file"
+                    );
+                    assert_eq!(name_result.unwrap(), expected_name.unwrap());
+                } else {
+                    let name_result = get_uki_name_from_addon_file(&file_path);
+                    assert!(
+                        name_result.is_err(),
+                        "get_uki_name_from_addon_file should fail for non-addon file"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Additional comprehensive tests for uki_addon_dir function
+    mod uki_addon_dir_tests {
+        use super::*;
+
+        /// Test path handling edge cases
+        #[test]
+        fn test_uki_addon_dir_edge_cases() {
+            // Test with various path formats
+            let test_cases = vec![
+                // Absolute paths
+                ("/usr/lib/kernel.efi", "/usr/lib/kernel.efi.extra.d"),
+                ("/", "/.extra.d"),
+                // Relative paths
+                ("./relative.efi", "./relative.efi.extra.d"),
+                ("../parent.efi", "../parent.efi.extra.d"),
+                // Paths with multiple extensions
+                ("file.tar.gz.efi", "file.tar.gz.efi.extra.d"),
+                ("file.backup.old.efi", "file.backup.old.efi.extra.d"),
+                // Paths ending with directories
+                ("/path/to/dir/", "/path/to/dir/.extra.d"),
+            ];
+
+            for (input, expected) in test_cases {
+                let uki_path = PathBuf::from(input);
+                let result = uki_addon_dir(&uki_path);
+                let expected_path = PathBuf::from(expected);
+
+                assert_eq!(result, expected_path, "Failed for input: '{}'", input);
+            }
+        }
+
+        /// Test that the function works correctly with different file extensions
+        #[test]
+        fn test_uki_addon_dir_various_extensions() {
+            let extensions = vec![".efi", ".EFI", "", ".bin", ".img", ".kernel"];
+
+            for ext in extensions {
+                let filename = format!("kernel{}", ext);
+                let expected = format!("{}{}", filename, UKI_ADDON_DIR_SUFFIX);
+
+                let uki_path = PathBuf::from(&filename);
+                let result = uki_addon_dir(&uki_path);
+
+                assert_eq!(
+                    result.to_string_lossy(),
+                    expected,
+                    "Failed for extension: '{}'",
+                    ext
+                );
+            }
+        }
+
+        /// Test that the function preserves the original path structure
+        #[test]
+        fn test_uki_addon_dir_path_preservation() {
+            let base_path = PathBuf::from("/complex/path/with/multiple/components");
+            let uki_filename = "kernel-5.15.0-azl.efi";
+            let uki_path = base_path.join(uki_filename);
+
+            let result = uki_addon_dir(&uki_path);
+
+            // Should preserve the directory structure
+            assert_eq!(result.parent().unwrap(), base_path);
+
+            // Should have correct filename with suffix
+            let result_filename = result.file_name().unwrap().to_string_lossy();
+            let expected_filename = format!("{}{}", uki_filename, UKI_ADDON_DIR_SUFFIX);
+            assert_eq!(result_filename, expected_filename);
+        }
+
+        /// Test with Unicode and special characters in paths
+        #[test]
+        fn test_uki_addon_dir_unicode_and_special_chars() {
+            let test_paths = vec![
+                "kernel-ñ-ü-ä.efi",
+                "kernel with spaces.efi",
+                "kernel-123_456.efi",
+                "kernel@host.efi",
+                "kernel#hash.efi",
+                "kernel$dollar.efi",
+                "kernel&ampersand.efi",
+            ];
+
+            for path_str in test_paths {
+                let uki_path = PathBuf::from(path_str);
+                let result = uki_addon_dir(&uki_path);
+
+                // Should always end with the correct suffix
+                assert!(
+                    result.to_string_lossy().ends_with(UKI_ADDON_DIR_SUFFIX),
+                    "Result should end with suffix for path: '{}'",
+                    path_str
+                );
+
+                // Should contain the original filename
+                assert!(
+                    result.to_string_lossy().contains(path_str),
+                    "Result should contain original path: '{}'",
+                    path_str
+                );
+            }
+        }
+    }
+
+    /// Additional comprehensive tests for is_uki_addon_file function
+    mod is_uki_addon_file_tests {
+        use super::*;
+        use tempfile::TempDir;
+
+        /// Test file permission scenarios
+        #[test]
+        #[cfg(unix)]
+        fn test_is_uki_addon_file_permissions() {
+            use std::os::unix::fs::PermissionsExt;
+
+            let temp_dir = TempDir::new().unwrap();
+
+            // Test with different file permissions
+            let test_cases = vec![
+                (0o644, true, "read-write for owner, read for others"),
+                (0o755, true, "executable file"),
+                (0o400, true, "read-only for owner"),
+                (0o000, true, "no permissions (file still exists)"),
+            ];
+
+            for (mode, should_succeed, description) in test_cases {
+                let file_path = temp_dir.path().join(format!("test_{:o}.addon.efi", mode));
+                std::fs::write(&file_path, "content").unwrap();
+
+                let mut perms = std::fs::metadata(&file_path).unwrap().permissions();
+                perms.set_mode(mode);
+                std::fs::set_permissions(&file_path, perms).unwrap();
+
+                let result = is_uki_addon_file(&file_path);
+                assert_eq!(
+                    result, should_succeed,
+                    "Failed for {}: mode {:o}",
+                    description, mode
+                );
+            }
+        }
+
+        /// Test with very long filenames
+        #[test]
+        fn test_is_uki_addon_file_long_names() {
+            let temp_dir = TempDir::new().unwrap();
+
+            // Create a very long but valid addon filename
+            let long_name = format!("{}.addon.efi", "a".repeat(200));
+            let file_path = temp_dir.path().join(&long_name);
+
+            // Only test if the filesystem supports this length
+            if std::fs::write(&file_path, "content").is_ok() {
+                assert!(
+                    is_uki_addon_file(&file_path),
+                    "Should handle long addon filenames"
+                );
+            }
+        }
+
+        /// Test case sensitivity
+        #[test]
+        fn test_is_uki_addon_file_case_sensitivity() {
+            let temp_dir = TempDir::new().unwrap();
+
+            let test_cases = vec![
+                ("file.addon.efi", true, "lowercase (correct)"),
+                ("file.ADDON.EFI", false, "uppercase addon and efi"),
+                ("file.Addon.Efi", false, "mixed case"),
+                ("file.addon.EFI", false, "uppercase efi only"),
+                ("file.ADDON.efi", false, "uppercase addon only"),
+            ];
+
+            for (filename, should_be_addon, description) in test_cases {
+                let file_path = temp_dir.path().join(filename);
+                std::fs::write(&file_path, "content").unwrap();
+
+                let result = is_uki_addon_file(&file_path);
+                assert_eq!(
+                    result, should_be_addon,
+                    "Failed for {}: '{}'",
+                    description, filename
+                );
+            }
+        }
+
+        /// Test behavior with broken symlinks
+        #[test]
+        #[cfg(unix)]
+        fn test_is_uki_addon_file_broken_symlinks() {
+            let temp_dir = TempDir::new().unwrap();
+
+            // Create a symlink to a non-existent file
+            let target_path = temp_dir.path().join("nonexistent.addon.efi");
+            let symlink_path = temp_dir.path().join("broken_symlink.addon.efi");
+
+            if std::os::unix::fs::symlink(&target_path, &symlink_path).is_ok() {
+                // Broken symlink should not be considered a valid addon file
+                assert!(
+                    !is_uki_addon_file(&symlink_path),
+                    "Broken symlink should not be identified as addon file"
+                );
+            }
+        }
+
+        /// Test with empty files and zero-byte files
+        #[test]
+        fn test_is_uki_addon_file_empty_files() {
+            let temp_dir = TempDir::new().unwrap();
+
+            // Empty file should still be valid addon file if named correctly
+            let empty_file = temp_dir.path().join("empty.addon.efi");
+            std::fs::write(&empty_file, "").unwrap();
+
+            assert!(
+                is_uki_addon_file(&empty_file),
+                "Empty file with correct name should be valid addon file"
+            );
+
+            // File with just whitespace
+            let whitespace_file = temp_dir.path().join("whitespace.addon.efi");
+            std::fs::write(&whitespace_file, "   \n  \t  ").unwrap();
+
+            assert!(
+                is_uki_addon_file(&whitespace_file),
+                "File with whitespace should be valid addon file"
+            );
+        }
+    }
+
+    /// Integration and cross-function tests
+    mod integration_tests {
+        use super::*;
+        use tempfile::TempDir;
+
+        /// Test the workflow of creating addon directory and checking addon files
+        #[test]
+        fn test_uki_workflow_integration() {
+            let temp_dir = TempDir::new().unwrap();
+            let uki_path = temp_dir.path().join("kernel.efi");
+
+            // Create the UKI file
+            std::fs::write(&uki_path, "mock uki content").unwrap();
+
+            // Get the expected addon directory
+            let addon_dir = uki_addon_dir(&uki_path);
+            assert!(addon_dir.to_string_lossy().ends_with(".extra.d"));
+
+            // Create the addon directory
+            std::fs::create_dir_all(&addon_dir).unwrap();
+
+            // Create some addon files in the directory
+            let addon_files = [
+                "driver1.addon.efi",
+                "driver2.addon.efi",
+                "firmware.addon.efi",
+            ];
+
+            for addon_file in &addon_files {
+                let addon_path = addon_dir.join(addon_file);
+                std::fs::write(&addon_path, "mock addon content").unwrap();
+
+                // Verify each file is correctly identified as addon file
+                assert!(
+                    is_uki_addon_file(&addon_path),
+                    "File {} should be identified as addon file",
+                    addon_file
+                );
+
+                // Verify name extraction works
+                let extracted_name = get_uki_name_from_addon_file(&addon_path).unwrap();
+                let expected_name = addon_file.strip_suffix(UKI_ADDON_FILE_SUFFIX).unwrap();
+                assert_eq!(
+                    extracted_name, expected_name,
+                    "Name extraction should work for {}",
+                    addon_file
+                );
+            }
+
+            // Create some non-addon files that should be ignored
+            let non_addon_files = ["readme.txt", "config.ini", "driver.efi"];
+            for non_addon_file in &non_addon_files {
+                let non_addon_path = addon_dir.join(non_addon_file);
+                std::fs::write(&non_addon_path, "not an addon").unwrap();
+
+                assert!(
+                    !is_uki_addon_file(&non_addon_path),
+                    "File {} should NOT be identified as addon file",
+                    non_addon_file
+                );
+            }
+        }
+
+        /// Test consistency between all functions with various inputs
+        #[test]
+        fn test_function_consistency() {
+            let temp_dir = TempDir::new().unwrap();
+
+            let test_kernels = [
+                "vmlinuz-5.15.0.efi",
+                "kernel.efi",
+                "boot.efi",
+                "complex-name_123.efi",
+            ];
+
+            for kernel_name in &test_kernels {
+                let uki_path = temp_dir.path().join(kernel_name);
+                std::fs::write(&uki_path, "uki content").unwrap();
+
+                // Test addon directory generation
+                let addon_dir = uki_addon_dir(&uki_path);
+                let expected_addon_name = format!("{}.extra.d", kernel_name);
+                assert!(
+                    addon_dir.to_string_lossy().ends_with(&expected_addon_name),
+                    "Addon directory should have correct suffix for {}",
+                    kernel_name
+                );
+
+                // Create addon directory and test addon files
+                std::fs::create_dir_all(&addon_dir).unwrap();
+
+                let addon_name = kernel_name.strip_suffix(".efi").unwrap_or(kernel_name);
+                let addon_filename = format!("{}-driver.addon.efi", addon_name);
+                let addon_path = addon_dir.join(&addon_filename);
+                std::fs::write(&addon_path, "addon content").unwrap();
+
+                // All functions should work consistently
+                assert!(
+                    is_uki_addon_file(&addon_path),
+                    "Addon file should be correctly identified for {}",
+                    kernel_name
+                );
+
+                let extracted_name = get_uki_name_from_addon_file(&addon_path).unwrap();
+                let expected_name = format!("{}-driver", addon_name);
+                assert_eq!(
+                    extracted_name, expected_name,
+                    "Name extraction should be consistent for {}",
+                    kernel_name
+                );
+            }
+        }
     }
 }

--- a/crates/osutils/src/uki.rs
+++ b/crates/osutils/src/uki.rs
@@ -28,6 +28,10 @@ pub fn is_uki_addon_file(path: &Path) -> bool {
             .is_some_and(|name| name.to_string_lossy().ends_with(UKI_ADDON_FILE_SUFFIX))
 }
 
+/// Extracts the UKI name from a given addon file path by removing the `.addon.efi` suffix.
+/// If the file name does not end with the expected suffix, an error is returned. For example,
+/// given the addon file path `vmlinuz-1-azla1.efi.addon.efi`, this function would return
+/// `vmlinuz-1-azla1.efi`.
 pub fn get_uki_name_from_addon_file(addon_file: &Path) -> Result<&str, Error> {
     addon_file
         .file_name()
@@ -50,6 +54,7 @@ pub fn get_uki_name_from_addon_file(addon_file: &Path) -> Result<&str, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     /// Validates that `uki_addon_dir` appends the `.extra.d` suffix to the
     /// UKI file path to form the addon directory path.
@@ -100,6 +105,33 @@ mod tests {
                 "Result should always end with UKI_ADDON_DIR_SUFFIX for path: '{}'",
                 input_path
             );
+        }
+    }
+
+    /// Test path handling edge cases
+    #[test]
+    fn test_uki_addon_dir_edge_cases() {
+        // Test with various path formats
+        let test_cases = vec![
+            // Absolute paths
+            ("/usr/lib/kernel.efi", "/usr/lib/kernel.efi.extra.d"),
+            ("/", "/.extra.d"),
+            // Relative paths
+            ("./relative.efi", "./relative.efi.extra.d"),
+            ("../parent.efi", "../parent.efi.extra.d"),
+            // Paths with multiple extensions
+            ("file.tar.gz.efi", "file.tar.gz.efi.extra.d"),
+            ("file.backup.old.efi", "file.backup.old.efi.extra.d"),
+            // Paths ending with directories
+            ("/path/to/dir/", "/path/to/dir/.extra.d"),
+        ];
+
+        for (input, expected) in test_cases {
+            let uki_path = PathBuf::from(input);
+            let result = uki_addon_dir(&uki_path);
+            let expected_path = PathBuf::from(expected);
+
+            assert_eq!(result, expected_path, "Failed for input: '{}'", input);
         }
     }
 
@@ -200,565 +232,147 @@ mod tests {
         }
     }
 
-    /// Tests for get_uki_name_from_addon_file function
-    mod get_uki_name_from_addon_file_tests {
-        use super::*;
-        use tempfile::TempDir;
+    /// Test successful get_uki_name_from_addon_file name extraction
+    /// from valid addon files
+    #[test]
+    fn test_get_uki_name_from_addon_file_valid() {
+        let temp_dir = TempDir::new().unwrap();
 
-        /// Test successful name extraction from valid addon files
-        #[test]
-        fn test_get_uki_name_from_addon_file_valid() {
-            let temp_dir = TempDir::new().unwrap();
+        let test_cases = vec![
+            ("simple.addon.efi", "simple"),
+            ("complex-name_123.addon.efi", "complex-name_123"),
+            ("driver.addon.efi", "driver"),
+            ("with.dots.in.name.addon.efi", "with.dots.in.name"),
+            (
+                "with-dashes-and_underscores.addon.efi",
+                "with-dashes-and_underscores",
+            ),
+            ("a.addon.efi", "a"),
+            (
+                "very-long-name-with-many-components-123_456.addon.efi",
+                "very-long-name-with-many-components-123_456",
+            ),
+        ];
 
-            let test_cases = vec![
-                ("simple.addon.efi", "simple"),
-                ("complex-name_123.addon.efi", "complex-name_123"),
-                ("driver.addon.efi", "driver"),
-                ("with.dots.in.name.addon.efi", "with.dots.in.name"),
-                (
-                    "with-dashes-and_underscores.addon.efi",
-                    "with-dashes-and_underscores",
-                ),
-                ("a.addon.efi", "a"),
-                (
-                    "very-long-name-with-many-components-123_456.addon.efi",
-                    "very-long-name-with-many-components-123_456",
-                ),
-            ];
+        for (file_name, expected_name) in test_cases {
+            let file_path = temp_dir.path().join(file_name);
+            std::fs::write(&file_path, "mock addon content").unwrap();
 
-            for (file_name, expected_name) in test_cases {
-                let file_path = temp_dir.path().join(file_name);
-                std::fs::write(&file_path, "mock addon content").unwrap();
-
-                let result = get_uki_name_from_addon_file(&file_path);
-                assert!(
-                    result.is_ok(),
-                    "Should successfully extract name from {}",
-                    file_name
-                );
-
-                let extracted_name = result.unwrap();
-                assert_eq!(
-                    extracted_name, expected_name,
-                    "Extracted name should match expected for {}",
-                    file_name
-                );
-            }
-        }
-
-        /// Test error cases for get_uki_name_from_addon_file
-        #[test]
-        fn test_get_uki_name_from_addon_file_errors() {
-            let temp_dir = TempDir::new().unwrap();
-
-            // Test with file that doesn't have correct suffix
-            let wrong_suffix_file = temp_dir.path().join("wrong.suffix.efi");
-            std::fs::write(&wrong_suffix_file, "content").unwrap();
-
-            let result = get_uki_name_from_addon_file(&wrong_suffix_file);
-            assert!(
-                result.is_err(),
-                "Should fail for file without correct suffix"
-            );
-            let error_msg = result.unwrap_err().to_string();
-            assert!(
-                error_msg.contains("does not end with expected suffix"),
-                "Error should mention suffix mismatch"
-            );
-            assert!(
-                error_msg.contains(".addon.efi"),
-                "Error should mention expected suffix"
-            );
-
-            // Test with file that has no extension at all
-            let no_extension_file = temp_dir.path().join("no_extension");
-            std::fs::write(&no_extension_file, "content").unwrap();
-
-            let result = get_uki_name_from_addon_file(&no_extension_file);
-            assert!(result.is_err(), "Should fail for file without extension");
-
-            // Test with file that ends with .efi but not .addon.efi
-            let wrong_efi_file = temp_dir.path().join("wrong.efi");
-            std::fs::write(&wrong_efi_file, "content").unwrap();
-
-            let result = get_uki_name_from_addon_file(&wrong_efi_file);
-            assert!(
-                result.is_err(),
-                "Should fail for .efi file without .addon prefix"
-            );
-        }
-
-        /// Test with directory paths (should fail)
-        #[test]
-        fn test_get_uki_name_from_addon_file_directory() {
-            let temp_dir = TempDir::new().unwrap();
-            let subdir = temp_dir.path().join("some_directory");
-            std::fs::create_dir_all(&subdir).unwrap();
-
-            let result = get_uki_name_from_addon_file(&subdir);
-            assert!(result.is_err(), "Should fail when path is a directory");
-
-            let error_msg = result.unwrap_err().to_string();
-            // Directory will fail because it doesn't end with .addon.efi suffix
-            assert!(
-                error_msg.contains("does not end with expected suffix")
-                    || error_msg.contains(".addon.efi"),
-                "Error should mention suffix issue, got: {}",
-                error_msg
-            );
-        }
-
-        /// Test edge cases with special characters and empty names
-        #[test]
-        fn test_get_uki_name_from_addon_file_edge_cases() {
-            let temp_dir = TempDir::new().unwrap();
-
-            // Test with Unicode characters (should work)
-            let unicode_file = temp_dir.path().join("test-ä-ü-ñ.addon.efi");
-            std::fs::write(&unicode_file, "content").unwrap();
-
-            let result = get_uki_name_from_addon_file(&unicode_file);
+            let result = get_uki_name_from_addon_file(&file_path);
             assert!(
                 result.is_ok(),
-                "Should handle Unicode characters in filename"
+                "Should successfully extract name from {}",
+                file_name
             );
-            assert_eq!(result.unwrap(), "test-ä-ü-ñ");
 
-            // Test with numbers only
-            let numbers_file = temp_dir.path().join("123456.addon.efi");
-            std::fs::write(&numbers_file, "content").unwrap();
-
-            let result = get_uki_name_from_addon_file(&numbers_file);
-            assert!(result.is_ok(), "Should handle numeric-only names");
-            assert_eq!(result.unwrap(), "123456");
-
-            // Test minimum valid case - just the suffix
-            let minimal_file = temp_dir.path().join(".addon.efi");
-            std::fs::write(&minimal_file, "content").unwrap();
-
-            let result = get_uki_name_from_addon_file(&minimal_file);
-            assert!(result.is_ok(), "Should handle minimal case with empty name");
-            assert_eq!(result.unwrap(), "");
-        }
-
-        /// Test with files containing the suffix multiple times
-        #[test]
-        fn test_get_uki_name_from_addon_file_multiple_suffixes() {
-            let temp_dir = TempDir::new().unwrap();
-
-            // Test with name that contains the suffix pattern
-            let multiple_suffix_file = temp_dir.path().join("driver.addon.efi.backup.addon.efi");
-            std::fs::write(&multiple_suffix_file, "content").unwrap();
-
-            let result = get_uki_name_from_addon_file(&multiple_suffix_file);
-            assert!(
-                result.is_ok(),
-                "Should handle file with multiple suffix patterns"
-            );
+            let extracted_name = result.unwrap();
             assert_eq!(
-                result.unwrap(),
-                "driver.addon.efi.backup",
-                "Should strip only the final suffix"
-            );
-        }
-
-        /// Test non-existent files (should still work for name extraction if path has correct suffix)
-        #[test]
-        fn test_get_uki_name_from_addon_file_nonexistent() {
-            let temp_dir = TempDir::new().unwrap();
-            let nonexistent_file = temp_dir.path().join("nonexistent.addon.efi");
-            // Don't create the file
-
-            let result = get_uki_name_from_addon_file(&nonexistent_file);
-            // This should work because the function only checks the path string, not file existence
-            assert!(
-                result.is_ok(),
-                "Should extract name from path even if file doesn't exist"
-            );
-            assert_eq!(result.unwrap(), "nonexistent");
-        }
-
-        /// Test integration with is_uki_addon_file function
-        #[test]
-        fn test_integration_with_is_uki_addon_file() {
-            let temp_dir = TempDir::new().unwrap();
-
-            let test_files = [
-                ("valid.addon.efi", true, Some("valid")),
-                ("invalid.txt", false, None),
-                ("wrong.efi", false, None),
-            ];
-
-            for (file_name, should_be_addon, expected_name) in test_files {
-                let file_path = temp_dir.path().join(file_name);
-                std::fs::write(&file_path, "content").unwrap();
-
-                let is_addon = is_uki_addon_file(&file_path);
-                assert_eq!(
-                    is_addon, should_be_addon,
-                    "is_uki_addon_file result for {}",
-                    file_name
-                );
-
-                if should_be_addon {
-                    let name_result = get_uki_name_from_addon_file(&file_path);
-                    assert!(
-                        name_result.is_ok(),
-                        "get_uki_name_from_addon_file should succeed for valid addon file"
-                    );
-                    assert_eq!(name_result.unwrap(), expected_name.unwrap());
-                } else {
-                    let name_result = get_uki_name_from_addon_file(&file_path);
-                    assert!(
-                        name_result.is_err(),
-                        "get_uki_name_from_addon_file should fail for non-addon file"
-                    );
-                }
-            }
-        }
-    }
-
-    /// Additional comprehensive tests for uki_addon_dir function
-    mod uki_addon_dir_tests {
-        use super::*;
-
-        /// Test path handling edge cases
-        #[test]
-        fn test_uki_addon_dir_edge_cases() {
-            // Test with various path formats
-            let test_cases = vec![
-                // Absolute paths
-                ("/usr/lib/kernel.efi", "/usr/lib/kernel.efi.extra.d"),
-                ("/", "/.extra.d"),
-                // Relative paths
-                ("./relative.efi", "./relative.efi.extra.d"),
-                ("../parent.efi", "../parent.efi.extra.d"),
-                // Paths with multiple extensions
-                ("file.tar.gz.efi", "file.tar.gz.efi.extra.d"),
-                ("file.backup.old.efi", "file.backup.old.efi.extra.d"),
-                // Paths ending with directories
-                ("/path/to/dir/", "/path/to/dir/.extra.d"),
-            ];
-
-            for (input, expected) in test_cases {
-                let uki_path = PathBuf::from(input);
-                let result = uki_addon_dir(&uki_path);
-                let expected_path = PathBuf::from(expected);
-
-                assert_eq!(result, expected_path, "Failed for input: '{}'", input);
-            }
-        }
-
-        /// Test that the function works correctly with different file extensions
-        #[test]
-        fn test_uki_addon_dir_various_extensions() {
-            let extensions = vec![".efi", ".EFI", "", ".bin", ".img", ".kernel"];
-
-            for ext in extensions {
-                let filename = format!("kernel{}", ext);
-                let expected = format!("{}{}", filename, UKI_ADDON_DIR_SUFFIX);
-
-                let uki_path = PathBuf::from(&filename);
-                let result = uki_addon_dir(&uki_path);
-
-                assert_eq!(
-                    result.to_string_lossy(),
-                    expected,
-                    "Failed for extension: '{}'",
-                    ext
-                );
-            }
-        }
-
-        /// Test that the function preserves the original path structure
-        #[test]
-        fn test_uki_addon_dir_path_preservation() {
-            let base_path = PathBuf::from("/complex/path/with/multiple/components");
-            let uki_filename = "kernel-5.15.0-azl.efi";
-            let uki_path = base_path.join(uki_filename);
-
-            let result = uki_addon_dir(&uki_path);
-
-            // Should preserve the directory structure
-            assert_eq!(result.parent().unwrap(), base_path);
-
-            // Should have correct filename with suffix
-            let result_filename = result.file_name().unwrap().to_string_lossy();
-            let expected_filename = format!("{}{}", uki_filename, UKI_ADDON_DIR_SUFFIX);
-            assert_eq!(result_filename, expected_filename);
-        }
-
-        /// Test with Unicode and special characters in paths
-        #[test]
-        fn test_uki_addon_dir_unicode_and_special_chars() {
-            let test_paths = vec![
-                "kernel-ñ-ü-ä.efi",
-                "kernel with spaces.efi",
-                "kernel-123_456.efi",
-                "kernel@host.efi",
-                "kernel#hash.efi",
-                "kernel$dollar.efi",
-                "kernel&ampersand.efi",
-            ];
-
-            for path_str in test_paths {
-                let uki_path = PathBuf::from(path_str);
-                let result = uki_addon_dir(&uki_path);
-
-                // Should always end with the correct suffix
-                assert!(
-                    result.to_string_lossy().ends_with(UKI_ADDON_DIR_SUFFIX),
-                    "Result should end with suffix for path: '{}'",
-                    path_str
-                );
-
-                // Should contain the original filename
-                assert!(
-                    result.to_string_lossy().contains(path_str),
-                    "Result should contain original path: '{}'",
-                    path_str
-                );
-            }
-        }
-    }
-
-    /// Additional comprehensive tests for is_uki_addon_file function
-    mod is_uki_addon_file_tests {
-        use super::*;
-        use tempfile::TempDir;
-
-        /// Test file permission scenarios
-        #[test]
-        #[cfg(unix)]
-        fn test_is_uki_addon_file_permissions() {
-            use std::os::unix::fs::PermissionsExt;
-
-            let temp_dir = TempDir::new().unwrap();
-
-            // Test with different file permissions
-            let test_cases = vec![
-                (0o644, true, "read-write for owner, read for others"),
-                (0o755, true, "executable file"),
-                (0o400, true, "read-only for owner"),
-                (0o000, true, "no permissions (file still exists)"),
-            ];
-
-            for (mode, should_succeed, description) in test_cases {
-                let file_path = temp_dir.path().join(format!("test_{:o}.addon.efi", mode));
-                std::fs::write(&file_path, "content").unwrap();
-
-                let mut perms = std::fs::metadata(&file_path).unwrap().permissions();
-                perms.set_mode(mode);
-                std::fs::set_permissions(&file_path, perms).unwrap();
-
-                let result = is_uki_addon_file(&file_path);
-                assert_eq!(
-                    result, should_succeed,
-                    "Failed for {}: mode {:o}",
-                    description, mode
-                );
-            }
-        }
-
-        /// Test with very long filenames
-        #[test]
-        fn test_is_uki_addon_file_long_names() {
-            let temp_dir = TempDir::new().unwrap();
-
-            // Create a very long but valid addon filename
-            let long_name = format!("{}.addon.efi", "a".repeat(200));
-            let file_path = temp_dir.path().join(&long_name);
-
-            // Only test if the filesystem supports this length
-            if std::fs::write(&file_path, "content").is_ok() {
-                assert!(
-                    is_uki_addon_file(&file_path),
-                    "Should handle long addon filenames"
-                );
-            }
-        }
-
-        /// Test case sensitivity
-        #[test]
-        fn test_is_uki_addon_file_case_sensitivity() {
-            let temp_dir = TempDir::new().unwrap();
-
-            let test_cases = vec![
-                ("file.addon.efi", true, "lowercase (correct)"),
-                ("file.ADDON.EFI", false, "uppercase addon and efi"),
-                ("file.Addon.Efi", false, "mixed case"),
-                ("file.addon.EFI", false, "uppercase efi only"),
-                ("file.ADDON.efi", false, "uppercase addon only"),
-            ];
-
-            for (filename, should_be_addon, description) in test_cases {
-                let file_path = temp_dir.path().join(filename);
-                std::fs::write(&file_path, "content").unwrap();
-
-                let result = is_uki_addon_file(&file_path);
-                assert_eq!(
-                    result, should_be_addon,
-                    "Failed for {}: '{}'",
-                    description, filename
-                );
-            }
-        }
-
-        /// Test behavior with broken symlinks
-        #[test]
-        #[cfg(unix)]
-        fn test_is_uki_addon_file_broken_symlinks() {
-            let temp_dir = TempDir::new().unwrap();
-
-            // Create a symlink to a non-existent file
-            let target_path = temp_dir.path().join("nonexistent.addon.efi");
-            let symlink_path = temp_dir.path().join("broken_symlink.addon.efi");
-
-            if std::os::unix::fs::symlink(&target_path, &symlink_path).is_ok() {
-                // Broken symlink should not be considered a valid addon file
-                assert!(
-                    !is_uki_addon_file(&symlink_path),
-                    "Broken symlink should not be identified as addon file"
-                );
-            }
-        }
-
-        /// Test with empty files and zero-byte files
-        #[test]
-        fn test_is_uki_addon_file_empty_files() {
-            let temp_dir = TempDir::new().unwrap();
-
-            // Empty file should still be valid addon file if named correctly
-            let empty_file = temp_dir.path().join("empty.addon.efi");
-            std::fs::write(&empty_file, "").unwrap();
-
-            assert!(
-                is_uki_addon_file(&empty_file),
-                "Empty file with correct name should be valid addon file"
-            );
-
-            // File with just whitespace
-            let whitespace_file = temp_dir.path().join("whitespace.addon.efi");
-            std::fs::write(&whitespace_file, "   \n  \t  ").unwrap();
-
-            assert!(
-                is_uki_addon_file(&whitespace_file),
-                "File with whitespace should be valid addon file"
+                extracted_name, expected_name,
+                "Extracted name should match expected for {}",
+                file_name
             );
         }
     }
 
-    /// Integration and cross-function tests
-    mod integration_tests {
-        use super::*;
-        use tempfile::TempDir;
+    /// Test error cases for get_uki_name_from_addon_file
+    #[test]
+    fn test_get_uki_name_from_addon_file_errors() {
+        let temp_dir = TempDir::new().unwrap();
 
-        /// Test the workflow of creating addon directory and checking addon files
-        #[test]
-        fn test_uki_workflow_integration() {
-            let temp_dir = TempDir::new().unwrap();
-            let uki_path = temp_dir.path().join("kernel.efi");
+        // Test with file that doesn't have correct suffix
+        let wrong_suffix_file = temp_dir.path().join("wrong.suffix.efi");
+        std::fs::write(&wrong_suffix_file, "content").unwrap();
 
-            // Create the UKI file
-            std::fs::write(&uki_path, "mock uki content").unwrap();
+        let result = get_uki_name_from_addon_file(&wrong_suffix_file);
+        assert!(
+            result.is_err(),
+            "Should fail for file without correct suffix"
+        );
+        let error_msg = result.unwrap_err().to_string();
+        assert!(
+            error_msg.contains("does not end with expected suffix"),
+            "Error should mention suffix mismatch"
+        );
+        assert!(
+            error_msg.contains(".addon.efi"),
+            "Error should mention expected suffix"
+        );
 
-            // Get the expected addon directory
-            let addon_dir = uki_addon_dir(&uki_path);
-            assert!(addon_dir.to_string_lossy().ends_with(".extra.d"));
+        // Test with file that has no extension at all
+        let no_extension_file = temp_dir.path().join("no_extension");
+        std::fs::write(&no_extension_file, "content").unwrap();
 
-            // Create the addon directory
-            std::fs::create_dir_all(&addon_dir).unwrap();
+        let result = get_uki_name_from_addon_file(&no_extension_file);
+        assert!(result.is_err(), "Should fail for file without extension");
 
-            // Create some addon files in the directory
-            let addon_files = [
-                "driver1.addon.efi",
-                "driver2.addon.efi",
-                "firmware.addon.efi",
-            ];
+        // Test with file that ends with .efi but not .addon.efi
+        let wrong_efi_file = temp_dir.path().join("wrong.efi");
+        std::fs::write(&wrong_efi_file, "content").unwrap();
 
-            for addon_file in &addon_files {
-                let addon_path = addon_dir.join(addon_file);
-                std::fs::write(&addon_path, "mock addon content").unwrap();
+        let result = get_uki_name_from_addon_file(&wrong_efi_file);
+        assert!(
+            result.is_err(),
+            "Should fail for .efi file without .addon prefix"
+        );
+    }
 
-                // Verify each file is correctly identified as addon file
-                assert!(
-                    is_uki_addon_file(&addon_path),
-                    "File {} should be identified as addon file",
-                    addon_file
-                );
+    /// Test with directory paths (should fail)
+    #[test]
+    fn test_get_uki_name_from_addon_file_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let subdir = temp_dir.path().join("some_directory");
+        std::fs::create_dir_all(&subdir).unwrap();
 
-                // Verify name extraction works
-                let extracted_name = get_uki_name_from_addon_file(&addon_path).unwrap();
-                let expected_name = addon_file.strip_suffix(UKI_ADDON_FILE_SUFFIX).unwrap();
-                assert_eq!(
-                    extracted_name, expected_name,
-                    "Name extraction should work for {}",
-                    addon_file
-                );
-            }
+        let result = get_uki_name_from_addon_file(&subdir);
+        assert!(result.is_err(), "Should fail when path is a directory");
+    }
 
-            // Create some non-addon files that should be ignored
-            let non_addon_files = ["readme.txt", "config.ini", "driver.efi"];
-            for non_addon_file in &non_addon_files {
-                let non_addon_path = addon_dir.join(non_addon_file);
-                std::fs::write(&non_addon_path, "not an addon").unwrap();
+    /// Test edge cases with special characters and empty names
+    #[test]
+    fn test_get_uki_name_from_addon_file_edge_cases() {
+        let temp_dir = TempDir::new().unwrap();
 
-                assert!(
-                    !is_uki_addon_file(&non_addon_path),
-                    "File {} should NOT be identified as addon file",
-                    non_addon_file
-                );
-            }
-        }
+        // Test with Unicode characters (should work)
+        let unicode_file = temp_dir.path().join("test-ä-ü-ñ.addon.efi");
+        std::fs::write(&unicode_file, "content").unwrap();
 
-        /// Test consistency between all functions with various inputs
-        #[test]
-        fn test_function_consistency() {
-            let temp_dir = TempDir::new().unwrap();
+        let result = get_uki_name_from_addon_file(&unicode_file);
+        assert!(
+            result.is_ok(),
+            "Should handle Unicode characters in filename"
+        );
+        assert_eq!(result.unwrap(), "test-ä-ü-ñ");
 
-            let test_kernels = [
-                "vmlinuz-5.15.0.efi",
-                "kernel.efi",
-                "boot.efi",
-                "complex-name_123.efi",
-            ];
+        // Test with numbers only
+        let numbers_file = temp_dir.path().join("123456.addon.efi");
+        std::fs::write(&numbers_file, "content").unwrap();
 
-            for kernel_name in &test_kernels {
-                let uki_path = temp_dir.path().join(kernel_name);
-                std::fs::write(&uki_path, "uki content").unwrap();
+        let result = get_uki_name_from_addon_file(&numbers_file);
+        assert!(result.is_ok(), "Should handle numeric-only names");
+        assert_eq!(result.unwrap(), "123456");
 
-                // Test addon directory generation
-                let addon_dir = uki_addon_dir(&uki_path);
-                let expected_addon_name = format!("{}.extra.d", kernel_name);
-                assert!(
-                    addon_dir.to_string_lossy().ends_with(&expected_addon_name),
-                    "Addon directory should have correct suffix for {}",
-                    kernel_name
-                );
+        // Test minimum valid case - just the suffix
+        let minimal_file = temp_dir.path().join(".addon.efi");
+        std::fs::write(&minimal_file, "content").unwrap();
 
-                // Create addon directory and test addon files
-                std::fs::create_dir_all(&addon_dir).unwrap();
+        let result = get_uki_name_from_addon_file(&minimal_file);
+        assert!(result.is_ok(), "Should handle minimal case with empty name");
+        assert_eq!(result.unwrap(), "");
+    }
 
-                let addon_name = kernel_name.strip_suffix(".efi").unwrap_or(kernel_name);
-                let addon_filename = format!("{}-driver.addon.efi", addon_name);
-                let addon_path = addon_dir.join(&addon_filename);
-                std::fs::write(&addon_path, "addon content").unwrap();
+    /// Test with files containing the suffix multiple times
+    #[test]
+    fn test_get_uki_name_from_addon_file_multiple_suffixes() {
+        let temp_dir = TempDir::new().unwrap();
 
-                // All functions should work consistently
-                assert!(
-                    is_uki_addon_file(&addon_path),
-                    "Addon file should be correctly identified for {}",
-                    kernel_name
-                );
+        // Test with name that contains the suffix pattern
+        let multiple_suffix_file = temp_dir.path().join("driver.addon.efi.backup.addon.efi");
+        std::fs::write(&multiple_suffix_file, "content").unwrap();
 
-                let extracted_name = get_uki_name_from_addon_file(&addon_path).unwrap();
-                let expected_name = format!("{}-driver", addon_name);
-                assert_eq!(
-                    extracted_name, expected_name,
-                    "Name extraction should be consistent for {}",
-                    kernel_name
-                );
-            }
-        }
+        let result = get_uki_name_from_addon_file(&multiple_suffix_file).unwrap();
+        assert_eq!(
+            result, "driver.addon.efi.backup",
+            "Should strip only the final suffix"
+        );
     }
 }

--- a/crates/osutils/src/uki.rs
+++ b/crates/osutils/src/uki.rs
@@ -1,7 +1,8 @@
 use std::path::{Path, PathBuf};
 
-/// Temporary name for the UKI file before renaming.
+/// UKI Addon directory suffix.
 pub const UKI_ADDON_DIR_SUFFIX: &str = ".extra.d";
+/// UKI Addon file suffix.
 pub const UKI_ADDON_FILE_SUFFIX: &str = ".addon.efi";
 
 /// Returns the path to the addon directory associated with the given UKI file,

--- a/crates/osutils/src/uki.rs
+++ b/crates/osutils/src/uki.rs
@@ -1,0 +1,29 @@
+use std::path::{Path, PathBuf};
+
+/// Temporary name for the UKI file before renaming.
+pub const UKI_ADDON_DIR_SUFFIX: &str = ".extra.d";
+pub const UKI_ADDON_FILE_SUFFIX: &str = ".addon.efi";
+
+/// Returns the path to the addon directory associated with the given UKI file,
+/// which is expected to be named `<UKI_filename>.extra.d/`. For example, if the
+/// UKI file is `vmlinuz-1-azla1.efi`, the associated addon directory would be
+/// `vmlinuz-1-azla1.efi.extra.d/` in the same directory as the UKI file.
+pub fn uki_addon_dir(uki_path: &Path) -> PathBuf {
+    let mut addon_dir = uki_path.to_path_buf().into_os_string();
+    addon_dir.push(UKI_ADDON_DIR_SUFFIX);
+    PathBuf::from(addon_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Validates that `uki_addon_dir` appends the `.extra.d` suffix to the
+    /// UKI file path to form the addon directory path.
+    #[test]
+    fn test_uki_addon_dir() {
+        let uki_path = PathBuf::from("/some/path/vmlinuz-1-azla1.efi");
+        let expected_addon_dir = PathBuf::from("/some/path/vmlinuz-1-azla1.efi.extra.d");
+        assert_eq!(uki_addon_dir(&uki_path), expected_addon_dir);
+    }
+}

--- a/crates/trident/src/engine/boot/uki.rs
+++ b/crates/trident/src/engine/boot/uki.rs
@@ -438,15 +438,6 @@ mod tests {
         assert_eq!(uki_suffix(&ctx), "azla3.efi");
     }
 
-    /// Validates that `uki_addon_dir` appends the `.extra.d` suffix to the
-    /// UKI file path to form the addon directory path.
-    #[test]
-    fn test_uki_addon_dir() {
-        let uki_path = PathBuf::from("/some/path/vmlinuz-1-azla1.efi");
-        let expected_addon_dir = PathBuf::from("/some/path/vmlinuz-1-azla1.efi.extra.d");
-        assert_eq!(uki::uki_addon_dir(&uki_path), expected_addon_dir);
-    }
-
     /// Validates that `is_staged` returns false when no staged UKI exists
     /// and true after a staged UKI file is written.
     #[test]


### PR DESCRIPTION
# 🔍 Description
 
UKI addons are measured into Pcr4.  Trident should use systemd-pcrlock lock-pe for each UKI addon found (`<uki>.extra.d/*.addon.efi`)

Validation with addons: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1056259&view=results
Validation w/out addons: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1056258&view=results