### PR TITLE
engineering: improve direct streaming test stability

### DIFF
--- a/.pipelines/templates/stages/direct-streaming/netlaunch-testing.yml
+++ b/.pipelines/templates/stages/direct-streaming/netlaunch-testing.yml
@@ -75,8 +75,6 @@ stages:
               ${{ if eq(parameters.architecture, 'amd64') }}:
                 goToolsArtifactName: go-tools
 
-          - template: ../testing_vm/netlaunch-prep.yml
-
           - bash: |
               set -ex
               sudo apt update -y
@@ -84,6 +82,8 @@ stages:
 
             displayName: "Install pip and seabios"
             retryCountOnTaskFailure: 3
+
+          - template: ../testing_vm/netlaunch-prep.yml
 
           - bash: |
               set -eux

--- a/.pipelines/templates/stages/direct-streaming/netlaunch-testing.yml
+++ b/.pipelines/templates/stages/direct-streaming/netlaunch-testing.yml
@@ -75,17 +75,15 @@ stages:
               ${{ if eq(parameters.architecture, 'amd64') }}:
                 goToolsArtifactName: go-tools
 
+          - template: ../testing_vm/netlaunch-prep.yml
+
           - bash: |
               set -ex
               sudo apt update -y
               sudo apt install -y python3 python3-pip seabios
 
-              sudo snap install yq
-
-            displayName: "Install pip and yq"
+            displayName: "Install pip and seabios"
             retryCountOnTaskFailure: 3
-
-          - template: ../testing_vm/netlaunch-prep.yml
 
           - bash: |
               set -eux


### PR DESCRIPTION
# 🔍 Description
 
direct-streaming tests are failing more commonly than other tests that use netlaunch-prep.yml.

Validated: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1057029&view=results