### PR TITLE
engineering: expand direct streming image build timeout

### DIFF
--- a/.pipelines/templates/direct-streaming-test.yml
+++ b/.pipelines/templates/direct-streaming-test.yml
@@ -38,6 +38,7 @@ stages:
               baseimgType: baremetal
             # Need rcp-agent from go tools
             downloadGoTools: true
+            timeoutInMinutes: 30
 
   - ${{ if parameters.testAzureLinuxStreamingImage }}:
     - stage: BuildImagesForDirectStreaming_azurelinux_${{ parameters.architecture }}
@@ -65,6 +66,7 @@ stages:
               baseimgType: core_arm64
             ${{ if eq(parameters.architecture, 'amd64') }}:
               baseimgType: baremetal
+            timeoutInMinutes: 30
 
     # Run netlaunch test to validate direct streaming installer
     - template: stages/direct-streaming/netlaunch-testing.yml
@@ -95,7 +97,7 @@ stages:
             label: "ubuntu-direct-streaming-testimage-${{ parameters.architecture }}"
             makeTarget: "artifacts/ubuntu-direct-streaming-testimage-${{ parameters.architecture }}.cosi"
             baseimgType: ubuntu_${{ parameters.architecture }}
-
+            timeoutInMinutes: 30
     # Run netlaunch test to validate direct streaming installer
     - template: stages/direct-streaming/netlaunch-testing.yml
       parameters:

--- a/.pipelines/templates/stages/trident_images/build-image.yml
+++ b/.pipelines/templates/stages/trident_images/build-image.yml
@@ -55,11 +55,16 @@ parameters:
     type: boolean
     default: false
 
+  - name: timeoutInMinutes
+    displayName: "Timeout for the job in minutes"
+    type: number
+    default: 20
+
 
 jobs:
   - job: PrepareImage_${{ replace(parameters.label, '-', '_') }}
     displayName: Prepare Image ${{ parameters.label }}
-    timeoutInMinutes: 20
+    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     pool:
       ${{ if eq(parameters.architecture, 'arm64') }}:
         type: linux


### PR DESCRIPTION
# 🔍 Description
 
Successful direct-streaming image tasks seem to take around 19 minutes.  There have been a lot of timeouts where there are no failures recently, so upping the timeout for these from 20 to 30.