### PR TITLE
engineering: make logexplorer more accessible

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -170,6 +170,10 @@ const config = {
             title: "More",
             items: [
               {
+                href: 'pathname:///logexplorer/',
+                label: "Log Explorer",
+              },
+              {
                 label: "GitHub",
                 href: "https://github.com/microsoft/trident",
               },


### PR DESCRIPTION
# 🔍 Description
 
Make logexplorer more accessible by including a link to it in the footer:

<img width="394" height="274" alt="image" src="https://github.com/user-attachments/assets/2ebe8aa2-8a98-4586-bca1-83eb05628f7c" />
