### PR TITLE
engineering: update trident for imagecustomizer 1.2

### DIFF
--- a/.pipelines/templates/direct-streaming-test.yml
+++ b/.pipelines/templates/direct-streaming-test.yml
@@ -5,12 +5,28 @@ parameters:
       - arm64
       - amd64
     default: arm64
+
   - name: testAzureLinuxStreamingImage
     type: boolean
     default: true
+
   - name: testUbuntuStreamingImage
     type: boolean
     default: true
+
+  - name: micBuildType
+    displayName: MIC Build Type
+    type: string
+    values:
+      - dev
+      - preview
+      - release
+    default: release
+
+  - name: micVersion
+    displayName: MIC Version
+    type: string
+    default: "*.*.*"
 
 stages:
   - ${{ if or(parameters.testAzureLinuxStreamingImage, parameters.testUbuntuStreamingImage) }}:
@@ -57,9 +73,8 @@ stages:
           parameters:
             labelPrefix: "" # No prefix for this image
             architecture: ${{ parameters.architecture }}
-            # TODO: when IC next releases, no longer needs dev image
-            micBuildType: dev
-            micVersion: "main"
+            micBuildType: ${{ parameters.micBuildType }}
+            micVersion: ${{ parameters.micVersion }}
             label: "azurelinux-direct-streaming-testimage-${{ parameters.architecture }}"
             makeTarget: "artifacts/azurelinux-direct-streaming-testimage-${{ parameters.architecture }}.cosi"
             ${{ if eq(parameters.architecture, 'arm64') }}:
@@ -91,9 +106,8 @@ stages:
           parameters:
             labelPrefix: "" # No prefix for this image
             architecture: ${{ parameters.architecture }}
-            # TODO: when IC next releases, no longer needs dev image
-            micBuildType: dev
-            micVersion: "main"
+            micBuildType: ${{ parameters.micBuildType }}
+            micVersion: ${{ parameters.micVersion }}
             label: "ubuntu-direct-streaming-testimage-${{ parameters.architecture }}"
             makeTarget: "artifacts/ubuntu-direct-streaming-testimage-${{ parameters.architecture }}.cosi"
             baseimgType: ubuntu_${{ parameters.architecture }}
@@ -103,4 +117,3 @@ stages:
       parameters:
         architecture: ${{ parameters.architecture }}
         streamingImageDistro: ubuntu
-

--- a/.pipelines/templates/e2e-arm64-template.yml
+++ b/.pipelines/templates/e2e-arm64-template.yml
@@ -37,6 +37,20 @@ parameters:
     type: string
     default: ''
 
+  - name: micBuildType
+    displayName: MIC Build Type
+    type: string
+    values:
+      - dev
+      - preview
+      - release
+    default: release
+
+  - name: micVersion
+    displayName: MIC Version
+    type: string
+    default: "*.*.*"
+
 stages:
   # Trident Build/Download
   - template: stages/trident_rpms/trident-stage.yml
@@ -60,3 +74,5 @@ stages:
     - template: direct-streaming-test.yml
       parameters:
         architecture: arm64
+        micBuildType: ${{ parameters.micBuildType }}
+        micVersion: ${{ parameters.micVersion }}

--- a/.pipelines/templates/e2e-template.yml
+++ b/.pipelines/templates/e2e-template.yml
@@ -272,6 +272,8 @@ stages:
       - template: direct-streaming-test.yml
         parameters:
           architecture: amd64
+          micBuildType: ${{ parameters.micBuildType }}
+          micVersion: ${{ parameters.micVersion }}
 
   # TESTING stages for full validation matrix host/container and bm/bm
   - ${{ if eq(parameters.stageType, 'full-validation') }}:
@@ -297,6 +299,8 @@ stages:
       - template: direct-streaming-test.yml
         parameters:
           architecture: amd64
+          micBuildType: ${{ parameters.micBuildType }}
+          micVersion: ${{ parameters.micVersion }}
 
       - ${{ if parameters.baremetalTestsEnabled }}:
           # BM Testing (host, weekly)
@@ -336,6 +340,8 @@ stages:
       - template: direct-streaming-test.yml
         parameters:
           architecture: amd64
+          micBuildType: ${{ parameters.micBuildType }}
+          micVersion: ${{ parameters.micVersion }}
 
   # TESTING stages for PR-E2E
   - ${{ if eq(parameters.stageType, 'pr-e2e') }}:
@@ -363,6 +369,8 @@ stages:
       - template: direct-streaming-test.yml
         parameters:
           architecture: amd64
+          micBuildType: ${{ parameters.micBuildType }}
+          micVersion: ${{ parameters.micVersion }}
 
   # PUBLISHING
   #

--- a/.pipelines/templates/trident-platform-cicd-for-prism-template.yml
+++ b/.pipelines/templates/trident-platform-cicd-for-prism-template.yml
@@ -40,3 +40,5 @@ stages:
         forceTridentRebuild: true
         osModifierBranch: ${{ parameters.osModifierBranch }}
         baseImageArtifactStage: CreateBaseImageConfig
+        micBuildType: ${{ parameters.micBuildType }}
+        micVersion: ${{ parameters.micVersion }}

--- a/docs/Explanation/Bootloader-Configuration.md
+++ b/docs/Explanation/Bootloader-Configuration.md
@@ -36,7 +36,7 @@ os:
   bootLoader:
     resetType: hard-reset
   uki:
-    kernels: auto
+    mode: create
 previewFeatures:
 - uki
 ```

--- a/docs/Explanation/Usr-Verity.md
+++ b/docs/Explanation/Usr-Verity.md
@@ -81,7 +81,7 @@ At a high level, there are only a couple things that need to be configured:
         - rd.hostonly=0
 
     uki:
-      kernels: auto
+      mode: create
 
     previewFeatures:
     - uki

--- a/docs/How-To-Guides/Set-Up-Usr-Verity.md
+++ b/docs/How-To-Guides/Set-Up-Usr-Verity.md
@@ -169,7 +169,7 @@ os:
     enable:
       - trident
   uki:
-    kernels: auto
+    mode: create
 
 previewFeatures:
   - uki

--- a/tests/images/testimages.py
+++ b/tests/images/testimages.py
@@ -20,7 +20,7 @@ from builder import (
 # to use by default when building   #
 # images.                           #
 # # # # # # # # # # # # # # # # # # #
-DEFAULT_IMAGE_CUSTOMIZER_VERSION = "0.19"
+DEFAULT_IMAGE_CUSTOMIZER_VERSION = "latest"
 
 
 DEFINED_IMAGES: List[ImageConfig] = [

--- a/tests/images/trident-vm-testimage/base/baseimg-root-verity.yaml
+++ b/tests/images/trident-vm-testimage/base/baseimg-root-verity.yaml
@@ -107,7 +107,7 @@ os:
     mode: disabled
 
   uki:
-    kernels: auto
+    mode: create
   kernelCommandLine:
     # Replicates BM base image settings, that would otherwise be lost
     extraCommandLine:

--- a/tests/images/trident-vm-testimage/base/baseimg-usr-verity.yaml
+++ b/tests/images/trident-vm-testimage/base/baseimg-usr-verity.yaml
@@ -106,7 +106,7 @@ os:
     mode: disabled
 
   uki:
-    kernels: auto
+    mode: create
   kernelCommandLine:
     # Replicates BM base image settings, that would otherwise be lost
     extraCommandLine:

--- a/tools/storm/rollback/tests/prepare_qcow2.go
+++ b/tools/storm/rollback/tests/prepare_qcow2.go
@@ -64,6 +64,9 @@ func PrepareQcow2(testConfig stormrollbackconfig.TestConfig, vmConfig stormvmcon
 		},
 	}
 	if testConfig.Uki {
+		customizerConfig["os"].(map[string]interface{})["uki"] = map[string]interface{}{
+			"mode": "passthrough",
+		}
 		customizerConfig["previewFeatures"] = append(customizerConfig["previewFeatures"].([]string), "uki")
 	}
 	customizerConfigContent, err := yaml.Marshal(customizerConfig)


### PR DESCRIPTION
# 🔍 Description
 
Once the new IC release is pushed to mcr:
* Use micVersion for direct streaming tests 
* Adjust IC e2e config files to use new UKI API
* Adjust IC config in rollback tests for new UKI API
* configure testimages.py to use imagecustomizer:latest
* modify ubuntu image builds to not pass rpm-source(s)