### PR TITLE
engineering: start using patch in trident version for pipelines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,15 @@ check-sh:
 
 .PHONY: version-vars
 version-vars:
-	$(eval TRIDENT_CARGO_VERSION := $(shell python3 ./scripts/get-version.py "$(shell date +%Y%m%d).99"))
-	$(eval GIT_COMMIT := $(shell git rev-parse --short HEAD)$(shell git diff --quiet || echo '.dirty'))
-	$(eval LOCAL_BUILD_TRIDENT_VERSION=$(TRIDENT_CARGO_VERSION)-dev.$(GIT_COMMIT))
+	$(eval SIMULATED_BUILD_ID := 99)
+	$(eval TRIDENT_BUILD_DATE := $(shell date +%Y%m%d))
+	$(eval TRIDENT_CARGO_VERSION := $(shell python3 ./scripts/get-version.py "$(TRIDENT_BUILD_DATE).$(SIMULATED_BUILD_ID)"))
+	$(eval GIT_COMMIT := v$(shell git rev-parse --short HEAD)$(shell git diff --quiet || echo '.dirty'))
+	$(eval TRIDENT_PREVIEW_VERSION := "dev.$(TRIDENT_BUILD_DATE)$(SIMULATED_BUILD_ID).$(GIT_COMMIT)")
+	$(eval LOCAL_BUILD_TRIDENT_VERSION := "$(TRIDENT_CARGO_VERSION)-$(TRIDENT_PREVIEW_VERSION)")
 	@echo "TRIDENT_CARGO_VERSION=$(TRIDENT_CARGO_VERSION)"
+	@echo "TRIDENT_PREVIEW_VERSION=$(TRIDENT_PREVIEW_VERSION)"
+	@echo "LOCAL_BUILD_TRIDENT_VERSION=$(LOCAL_BUILD_TRIDENT_VERSION)"
 	@echo "GIT_COMMIT=$(GIT_COMMIT)"
 
 .PHONY: build
@@ -82,7 +87,7 @@ build: .cargo/config version-vars
 	@OPENSSL_STATIC=1 \
 		OPENSSL_LIB_DIR=$(shell dirname `whereis libssl.a | cut -d" " -f2`) \
 		OPENSSL_INCLUDE_DIR=/usr/include/openssl \
-		TRIDENT_VERSION="$(TRIDENT_CARGO_VERSION)-dev.$(GIT_COMMIT)" \
+		TRIDENT_VERSION="$(LOCAL_BUILD_TRIDENT_VERSION)" \
 		cargo build --release --features dangerous-options,grpc-preview
 	@mkdir -p bin
 
@@ -177,7 +182,7 @@ build-azl3: azl3-builder-image version-vars
 	@mkdir -p target/azl3/
 	@echo "Building Trident for Azure Linux 3 using Docker image $(AZL3_BUILDER_IMAGE)..."
 	@docker run --rm \
-		-e TRIDENT_VERSION="$(TRIDENT_CARGO_VERSION)-dev.$(GIT_COMMIT)" \
+		-e TRIDENT_VERSION="$(LOCAL_BUILD_TRIDENT_VERSION)" \
 		-v $(PWD):/work -w /work $(AZL3_BUILDER_IMAGE) \
 		cargo build --color always --target-dir target/azl3 --release --features dangerous-options,grpc-preview
 
@@ -196,7 +201,7 @@ bin/trident-rpms-azl3.tar.gz: packaging/docker/Dockerfile.full packaging/systemd
 			--build-arg CARGO_REGISTRIES_FROM_ENV="true" \
 			--build-arg TRIDENT_VERSION="$(LOCAL_BUILD_TRIDENT_VERSION)" \
 			--build-arg RPM_VER="$(TRIDENT_CARGO_VERSION)" \
-			--build-arg RPM_REL="dev.$(GIT_COMMIT)" \
+			--build-arg RPM_REL="$(TRIDENT_PREVIEW_VERSION)" \
 			--target artifact \
 			--output type=local,dest=$$tmpdir \
 			-f packaging/docker/Dockerfile.full \
@@ -211,7 +216,7 @@ bin/trident-rpms.tar.gz: packaging/docker/Dockerfile.azl3 packaging/systemd/*.se
 	@docker build -t trident/trident-build:latest \
 		--build-arg TRIDENT_VERSION="$(LOCAL_BUILD_TRIDENT_VERSION)" \
 		--build-arg RPM_VER="$(TRIDENT_CARGO_VERSION)" \
-		--build-arg RPM_REL="dev.$(GIT_COMMIT)" \
+		--build-arg RPM_REL="$(TRIDENT_PREVIEW_VERSION)" \
 		-f packaging/docker/Dockerfile.azl3 \
 		.
 	@mkdir -p bin/

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ check-sh:
 version-vars:
 	$(eval SIMULATED_BUILD_ID := 99)
 	$(eval TRIDENT_BUILD_DATE := $(shell date +%Y%m%d))
-	$(eval TRIDENT_CARGO_VERSION := $(shell python3 ./scripts/get-version.py "$(TRIDENT_BUILD_DATE).$(SIMULATED_BUILD_ID)"))
+	$(eval TRIDENT_CARGO_VERSION := $(shell python3 ./scripts/get-version.py))
 	$(eval GIT_COMMIT := v$(shell git rev-parse --short HEAD)$(shell git diff --quiet || echo '.dirty'))
 	$(eval TRIDENT_PREVIEW_VERSION := "dev.$(TRIDENT_BUILD_DATE)$(SIMULATED_BUILD_ID).$(GIT_COMMIT)")
 	$(eval LOCAL_BUILD_TRIDENT_VERSION := "$(TRIDENT_CARGO_VERSION)-$(TRIDENT_PREVIEW_VERSION)")

--- a/scripts/get-version.py
+++ b/scripts/get-version.py
@@ -37,7 +37,7 @@ When no BuildNumber is provided, the version from the cargo file will be
 produced as-is, in the format MAJOR.MINOR.PATCH. 
 
 If a BuildNumber is provided, the format will be MAJOR.MINOR.PATCH-YYYYMMDDID, where:
-- MAJOR and MINOR are taken from the cargo file.
+- MAJOR, MINOR, and PATCH are taken from the cargo file.
 - YYYYMMDD is the date part of the BuildNumber.
 - ID is the counter part of the BuildNumber, formatted as a two-digit number.
 
@@ -70,13 +70,16 @@ with open("crates/trident/Cargo.toml", "r") as file:
 version = get_version(content)
 
 if args.BuildNumber is not None:
-    version = get_version(content)
-
-    # Check if BuildNumber is already the Trident version
     version_pattern = rf"({version})-(\d{{10}})(\.?.*)"
     if re.match(version_pattern, args.BuildNumber):
+        # If BuildNumber contains the Trident version found in Cargo.toml
+        # followed by the date and build id, just return it
+        # Format: MAJOR.MINOR.PATCH-YYYYMMDDID.*
         print(args.BuildNumber)
     else:
+        # Otherwise, BuildNumber is expected to be date.buildid. In this case
+        # use the date and build id to construct the returned version. If --commit
+        # is specified, also include the git short hash.
         match = re.match(r"^(\d{8})\.(\d+)$", args.BuildNumber)
         if match is None:
             print(
@@ -92,6 +95,8 @@ if args.BuildNumber is not None:
             # Format: MAJOR.MINOR.PATCH-YYYYMMDDID.vCOMMIT
             print(f"{version}-{date}{id:02d}.v{short_commit.strip()}")
         else:
+            # Format: MAJOR.MINOR.PATCH-YYYYMMDDID
             print(f"{version}-{date}{id:02d}")
 else:
+    # If BuildNumber is not provided, return Cargo version (MAJOR.MINOR.PATCH)
     print(f"{version}")

--- a/scripts/get-version.py
+++ b/scripts/get-version.py
@@ -20,16 +20,12 @@ def get_git_revision_short_hash() -> str:
     )
 
 
-def get_version(file, full=False):
-    pattern = r'version\s*=\s*"(\d+\.\d+)(\.\d+)"'
-
+def get_version(file):
+    pattern = r'version\s*=\s*"(\d+\.\d+\.\d+)"'
     match = re.search(pattern, file)
-
     if match:
-        if full:
-            return match.group(1) + match.group(2)
-        else:
-            return match.group(1)
+        # Return the major.minor.patch version
+        return match.group(1)
     else:
         print("Version definition not found.")
         sys.exit(1)
@@ -40,14 +36,13 @@ desc = """Return the Trident version.
 When no BuildNumber is provided, the version from the cargo file will be
 produced as-is, in the format MAJOR.MINOR.PATCH. 
 
-If a BuildNumber is provided, the patch number from cargo will be ignored
-and the version will be in the format MAJOR.MINOR.YYYYMMDDID, where:
+If a BuildNumber is provided, the format will be MAJOR.MINOR.PATCH-YYYYMMDDID, where:
 - MAJOR and MINOR are taken from the cargo file.
 - YYYYMMDD is the date part of the BuildNumber.
 - ID is the counter part of the BuildNumber, formatted as a two-digit number.
 
 When the optional flag --commit is used, the short commit hash will be appended
-to the version in the format MAJOR.MINOR.YYYYMMDDID-vCOMMIT, where COMMIT is the
+to the version in the format MAJOR.MINOR.PATCH-YYYYMMDDID.vCOMMIT, where COMMIT is the
 short commit hash.
 """
 
@@ -56,7 +51,7 @@ parser.add_argument(
     "-c",
     "--commit",
     action="store_true",
-    help="Optional flag to use the short commit hash as part of the ID. Format: MAJOR.MINOR.YYYYMMDDID-COMMIT",
+    help="Optional flag to include prerelease version in output, where prerelease is YYYYMMDDID-vCOMMIT. See `BuildNumber` help for more details.",
 )
 parser.add_argument(
     "BuildNumber",
@@ -71,27 +66,32 @@ args = parser.parse_args()
 with open("crates/trident/Cargo.toml", "r") as file:
     content = file.read()
 
+# Format: MAJOR.MINOR.PATCH
+version = get_version(content)
+
 if args.BuildNumber is not None:
     version = get_version(content)
-    match = re.match(r"(\d+)\.(\d+)", args.BuildNumber)
-    if match is None:
-        print(
-            "Invalid input. BuildNumber should be a date and ID, for example a counter, separated by a point."
-        )
-        sys.exit(1)
 
     # Check if BuildNumber is already the Trident version
-    version_pattern = rf"(^{version}\.)(\d{{10}})(-?.*$)"
+    version_pattern = rf"({version})-(\d{{10}})(\.?.*)"
     if re.match(version_pattern, args.BuildNumber):
         print(args.BuildNumber)
     else:
+        match = re.match(r"^(\d{8})\.(\d+)$", args.BuildNumber)
+        if match is None:
+            print(
+                "Invalid input. BuildNumber should be a date and ID, for example a counter, separated by a point."
+            )
+            sys.exit(1)
+
         date, id = match.groups()
         id = int(id)
 
         if args.commit:
             short_commit = get_git_revision_short_hash()
-            print(f"{version}.{date}{id:02d}-v{short_commit.strip()}")
+            # Format: MAJOR.MINOR.PATCH-YYYYMMDDID.vCOMMIT
+            print(f"{version}-{date}{id:02d}.v{short_commit.strip()}")
         else:
-            print(f"{version}.{date}{id:02d}")
+            print(f"{version}-{date}{id:02d}")
 else:
-    print(get_version(content, full=True))
+    print(f"{version}")


### PR DESCRIPTION
# 🔍 Description
 
Change versioning to include patch: `0.22.0-<date>.v<commit>` (prior to this change, version uses date as patch: `0.22.<date>-v<commit>`)
