### PR TITLE
test: onebranch is choking on outputdir populated from sudo process

### DIFF
--- a/.pipelines/templates/stages/direct-streaming/netlaunch-testing.yml
+++ b/.pipelines/templates/stages/direct-streaming/netlaunch-testing.yml
@@ -100,6 +100,7 @@ stages:
 
           - bash: |
               set -euxo pipefail
+              mkdir -p $(ob_outputDirectory)
               ISO_FILE=./artifacts/iso/$(installerISOName).iso
               COSI_FILE=./artifacts/test-image/regular.cosi
               HASH=$(./scripts/cosi-sha384.py $COSI_FILE)
@@ -124,3 +125,12 @@ stages:
                   --artifacts-folder "$(ob_outputDirectory)"
             displayName: "📷 Capture screenshot: direct streaming"
             condition: succeededOrFailed()
+
+          - bash: |
+              set -eux
+              mkdir -p $(ob_outputDirectory)
+              sudo chmod -R 777 $(ob_outputDirectory)/
+              sudo chown -R $USER:$USER $(ob_outputDirectory)/
+              ls -lR $(ob_outputDirectory)/
+            condition: always()
+            displayName: "Ensure output directory permissions"


### PR DESCRIPTION
# 🔍 Description
 
OneBranch is trying to analyze artifacts created by sudo and failing to get access.  This causes trident-ci to be orange (not green), which causes functional tests to fail to get the last good CI functest image.

Validation: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1072631&view=results