### PR TITLE
bug: pcrlock predict uses sort order to predict, so addons need to load between uki (650-*) and uki .linux (660-*)

### DIFF
--- a/crates/osutils/src/pcrlock.rs
+++ b/crates/osutils/src/pcrlock.rs
@@ -50,14 +50,15 @@ const BOOT_LOADER_CODE_SDBOOT_PCRLOCK_DIR: &str = "640-boot-loader-code-sdboot.p
 /// into PCR 4,
 const UKI_PCRLOCK_DIR: &str = "650-uki.pcrlock.d";
 
+/// `/var/lib/pcrlock.d/655-uki-addons-<name>.pcrlock.d`, where `lock-pe` measures the UKI addons binaries, as recorded
+/// into PCR 4. This needs to occur between 650-* and 660-* as the addons are loaded between the uki and the uki .linux
+/// section.
+const UKI_ADDONS_PCRLOCK_DIR_PREFIX: &str = "655-uki-addons-";
+const UKI_ADDONS_PCRLOCK_DIR_SUFFIX: &str = ".pcrlock.d";
+
 /// `/var/lib/pcrlock.d/660-boot-loader-code-uki.pcrlock.d`, where `lock-pe` measures the .linux
 /// section of the UKI binary, as recorded into PCR 4 following Microsoft's Authenticode hash spec,
 const BOOT_LOADER_CODE_UKI_PCRLOCK_DIR: &str = "660-boot-loader-code-uki.pcrlock.d";
-
-/// `/var/lib/pcrlock.d/670-uki-addons-<name>.pcrlock.d`, where `lock-pe` measures the UKI addons binaries, as recorded
-/// into PCR 4.
-const UKI_ADDONS_PCRLOCK_DIR_PREFIX: &str = "670-uki-addons-";
-const UKI_ADDONS_PCRLOCK_DIR_SUFFIX: &str = ".pcrlock.d";
 
 #[derive(Debug, Deserialize)]
 struct PcrValue {


### PR DESCRIPTION
# 🔍 Description
 
`systemd-pcrlock predict` depends on the pcrlock.d folder sort order to match the measurement order.

Using `670-uki-addons-*` as a pcrlock.d folder name misordered the component.  This only repro's on baremetal because we have SecureBoot enabled in VM tests (in which case, the uki .linux section is not measured).

`systemd-pcrlock log` dumps the events in order, where the uki add-on (`670-*`) is loaded **after** the uki (`650-*`) and **before** the uki .linux section (`660-*`):
``` shell
root@trident-usrverity-testimg [ ~ ]# /usr/lib/systemd/systemd-pcrlock log
( . . . )
PCR   PCRNAME            EVENT                         MATCH SHA256                                                           F/U COMPONENT                               DESCRIPTION                                                                                                                                                                                                                                             
( . . . )
  4 █ boot-loader-code   efi-boot-services-application     - SHA F   650-uki                                 File: \EFI\Linux\vmlinuz-100-azla0.efi
  4 █ boot-loader-code   efi-boot-services-application     - SHA F   670-uki-addons-vmlinuz-6.6.126.1-1.azl3 File: \EFI\Linux\vmlinuz-100-azla0.efi.extra.d\vmlinuz-6.6.126.1-1.azl3.addon.efi
( . . . )
  4 █ boot-loader-code   efi-boot-services-application     - SHA F   660-boot-loader-code-uki                Raw: . . .
( . . . )
```

`systemd-pcrlock list-components` shows the sort order that predict uses, where the uki addon is used **after** both the uki and uki .linux section:

``` shell
root@trident-usrverity-testimg [ ~ ]# /usr/lib/systemd/systemd-pcrlock list-components --pcr 4
ID                                      VARIANTS
( . . . )
650-uki                                 /var/lib/pcrlock.d/650-uki.pcrlock.d/generated-0.pcrlock
660-boot-loader-code-uki                /var/lib/pcrlock.d/660-boot-loader-code-uki.pcrlock.d/generated-0.pcrlock
670-uki-addons-vmlinuz-6.6.126.1-1.azl3 /var/lib/pcrlock.d/670-uki-addons-vmlinuz-6.6.126.1-1.azl3.pcrlock.d/generated-0.pcrlock
( . . . )
```

The fix is to change the pcrlock folder name to sit between uki (650) and uki .linux (660).

Verified on baremetal manually, vm tests still succeed: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1074120&view=results