### PR TITLE
test: pipelines using Pip should authenticate to feed

### DIFF
--- a/.pipelines/templates/stages/common_tasks/avoid-pypi-usage.yml
+++ b/.pipelines/templates/stages/common_tasks/avoid-pypi-usage.yml
@@ -2,7 +2,7 @@ steps:
   - bash: |
       set -eux
       printenv
-    displayName: List vars before PipAuthenticate
+    displayName: List vars before
 
   - task: PipAuthenticate@1
     displayName: Provision - Authenticate Pip
@@ -12,9 +12,9 @@ steps:
   - bash: |
       set -eux
       printenv
-    displayName: List vars after PipAuthenticate
+    displayName: Apply user pip.conf to global pip.conf
 
-    - bash: |
+  - bash: |
       set -eux
       sudo cp $(find $HOME -name pip.conf) /etc/pip.conf
     displayName: Apply user pip.conf to global pip.conf

--- a/.pipelines/templates/stages/common_tasks/avoid-pypi-usage.yml
+++ b/.pipelines/templates/stages/common_tasks/avoid-pypi-usage.yml
@@ -1,22 +1,7 @@
 steps:
-  - bash: |
-      set -eux
-      printenv
-    displayName: List vars before
-
   - task: PipAuthenticate@1
     displayName: Provision - Authenticate Pip
     inputs:
       artifactFeeds: "mariner/Mariner-Pypi-Feed"
-
-  - bash: |
-      set -eux
-      printenv
-    displayName: Apply user pip.conf to global pip.conf
-
-  - bash: |
-      set -eux
-      sudo cp $(find $HOME -name pip.conf) /etc/pip.conf
-    displayName: Apply user pip.conf to global pip.conf
 
   - template: common/sfi-enforce-isolation-with-etc-hosts.yaml@platform-pipelines

--- a/.pipelines/templates/stages/common_tasks/avoid-pypi-usage.yml
+++ b/.pipelines/templates/stages/common_tasks/avoid-pypi-usage.yml
@@ -1,10 +1,20 @@
 steps:
+  - bash: |
+      set -eux
+      printenv
+    displayName: List vars before PipAuthenticate
+
   - task: PipAuthenticate@1
     displayName: Provision - Authenticate Pip
     inputs:
       artifactFeeds: "mariner/Mariner-Pypi-Feed"
 
   - bash: |
+      set -eux
+      printenv
+    displayName: List vars after PipAuthenticate
+
+    - bash: |
       set -eux
       sudo cp $(find $HOME -name pip.conf) /etc/pip.conf
     displayName: Apply user pip.conf to global pip.conf

--- a/.pipelines/templates/stages/common_tasks/avoid-pypi-usage.yml
+++ b/.pipelines/templates/stages/common_tasks/avoid-pypi-usage.yml
@@ -4,4 +4,9 @@ steps:
     inputs:
       artifactFeeds: "mariner/Mariner-Pypi-Feed"
 
+  - bash: |
+      set -eux
+      sudo cp $(find $HOME -name pip.conf) /etc/pip.conf
+    displayName: Apply user pip.conf to global pip.conf
+
   - template: common/sfi-enforce-isolation-with-etc-hosts.yaml@platform-pipelines

--- a/.pipelines/templates/stages/testing_common/e2e-test-run.yml
+++ b/.pipelines/templates/stages/testing_common/e2e-test-run.yml
@@ -66,8 +66,10 @@ parameters:
 steps:
   - bash: |
       set -eux
-      sudo pip3 install pytest -vvv
-      sudo pip3 install fabric -vvv
+      # Use `-E` to preserve PipAuthenticate connection to
+      # internal feed replacing PyPI
+      sudo -E pip3 install pytest -vvv
+      sudo -E pip3 install fabric -vvv
     displayName: "Installing dependencies for E2E tests"
 
   - bash: |

--- a/.pipelines/templates/stages/testing_common/e2e-test-run.yml
+++ b/.pipelines/templates/stages/testing_common/e2e-test-run.yml
@@ -66,8 +66,8 @@ parameters:
 steps:
   - bash: |
       set -eux
-      pip3 install pytest -vvv
-      pip3 install fabric -vvv
+      sudo pip3 install pytest -vvv
+      sudo pip3 install fabric -vvv
     displayName: "Installing dependencies for E2E tests"
 
   - bash: |

--- a/.pipelines/templates/stages/testing_common/e2e-test-run.yml
+++ b/.pipelines/templates/stages/testing_common/e2e-test-run.yml
@@ -66,8 +66,8 @@ parameters:
 steps:
   - bash: |
       set -eux
-      sudo pip3 install pytest
-      sudo pip3 install fabric
+      pip3 install pytest -vvv
+      pip3 install fabric -vvv
     displayName: "Installing dependencies for E2E tests"
 
   - bash: |

--- a/.pipelines/templates/stages/testing_e2e/test_execution_template.yml
+++ b/.pipelines/templates/stages/testing_e2e/test_execution_template.yml
@@ -87,6 +87,7 @@ stages:
                 value: false
 
         steps:
+          - template: ../common_tasks/avoid-pypi-usage.yml
           - bash: |
               if [ ${{ variables['tridentConfigurationName'] }} == 'split' ]; then
                 splitInstallerIsoName="trident-split-installer"

--- a/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
+++ b/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
@@ -56,7 +56,7 @@ steps:
           zstd \
           imagemagick
 
-      sudo pip3 install virt-firmware
+      sudo pip3 install virt-firmware -vvv
     displayName: Install virt-deploy dependencies
     retryCountOnTaskFailure: 3
 

--- a/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
+++ b/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
@@ -56,8 +56,7 @@ steps:
           zstd \
           imagemagick
 
-      sudo python3 -m pip install virt-firmware -vvv
-      # sudo pip3 install virt-firmware -vvv
+      pip3 install virt-firmware -vvv
     displayName: Install virt-deploy dependencies
     retryCountOnTaskFailure: 3
 

--- a/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
+++ b/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
@@ -31,6 +31,8 @@ steps:
     displayName: "Install SWTPM PPA"
     retryCountOnTaskFailure: 3
 
+  # Connect Pip to internal feed rather than PyPI
+  - template: ../common_tasks/avoid-pypi-usage.yml
   - bash: |
       set -eux
 

--- a/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
+++ b/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
@@ -56,7 +56,9 @@ steps:
           zstd \
           imagemagick
 
-      sudo pip3 install virt-firmware -vvv
+      # Use `-E` to preserve PipAuthenticate connection to
+      # internal feed replacing PyPI
+      sudo -E pip3 install virt-firmware -vvv
     displayName: Install virt-deploy dependencies
     retryCountOnTaskFailure: 3
 

--- a/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
+++ b/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
@@ -56,7 +56,8 @@ steps:
           zstd \
           imagemagick
 
-      sudo pip3 install virt-firmware -vvv
+      sudo python3 -m pip install virt-firmware -vvv
+      # sudo pip3 install virt-firmware -vvv
     displayName: Install virt-deploy dependencies
     retryCountOnTaskFailure: 3
 

--- a/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
+++ b/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
@@ -56,7 +56,7 @@ steps:
           zstd \
           imagemagick
 
-      pip3 install virt-firmware -vvv
+      sudo pip3 install virt-firmware -vvv
     displayName: Install virt-deploy dependencies
     retryCountOnTaskFailure: 3
 

--- a/.pipelines/templates/stages/trident_images/trident-testimg-template.yml
+++ b/.pipelines/templates/stages/trident_images/trident-testimg-template.yml
@@ -102,12 +102,7 @@ parameters:
     default: false
 
 steps:
-  - task: PipAuthenticate@1
-    displayName: Provision - Authenticate Pip
-    inputs:
-      artifactFeeds: "mariner/Mariner-Pypi-Feed"
-
-  - template: common/sfi-enforce-isolation-with-etc-hosts.yaml@platform-pipelines
+  - template: ../common_tasks/avoid-pypi-usage.yml
 
   - ${{ if eq(parameters.downloadTrident, true) }}:
       - task: DownloadPipelineArtifact@2

--- a/tools/storm/e2e/scenario/dependencies.go
+++ b/tools/storm/e2e/scenario/dependencies.go
@@ -88,7 +88,9 @@ func installUbuntuDependencies(osRelease *env.OsReleaseInfo) error {
 	case "focal":
 		fallthrough
 	case "jammy":
-		err = cmd.Run("sudo", "pip3", "install", "virt-firmware", "-vvv")
+		// Use `-E` to preserve PipAuthenticate connection to
+		// internal feed replacing PyPI
+		err = cmd.Run("sudo", "-E", "pip3", "install", "virt-firmware", "-vvv")
 	case "noble":
 		err = cmd.Run("sudo", "apt-get", "-y", "install", "python3-virt-firmware")
 	default:

--- a/tools/storm/e2e/scenario/dependencies.go
+++ b/tools/storm/e2e/scenario/dependencies.go
@@ -88,7 +88,7 @@ func installUbuntuDependencies(osRelease *env.OsReleaseInfo) error {
 	case "focal":
 		fallthrough
 	case "jammy":
-		err = cmd.Run("sudo", "pip3", "install", "virt-firmware")
+		err = cmd.Run("sudo", "pip3", "install", "virt-firmware", "-vvv")
 	case "noble":
 		err = cmd.Run("sudo", "apt-get", "-y", "install", "python3-virt-firmware")
 	default:


### PR DESCRIPTION
# 🔍 Description
 
`pip install virt-firmware` is failing in the pipelines because PipAuthenticate creates env vars that sudo does not grab when we invoke `sudo pip install`.  Solution is to use `sudo -E pip install` so that sudo grabs the user env vars.

Validation: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1076612&view=results