### PR TITLE
test: disable azure servicing tests

### DIFF
--- a/.pipelines/templates/pipeline-selector.yml
+++ b/.pipelines/templates/pipeline-selector.yml
@@ -66,8 +66,6 @@ stages:
         parameters:
           stageType: ${{ parameters.targetStage }}
           blockPublishing: ${{ parameters.blockPublishing }}
-          # Only perform Azure testing from official pipelines, as only those have access to the Azure subscription.
-          includeAzure: ${{ or(eq(parameters.targetStage, 'pre'), eq(parameters.targetStage, 'ci'), eq(parameters.targetStage, 'pr-e2e-azure')) }}
           numberOfUpdateIterations: ${{ parameters.numberOfUpdateIterations }}
       - template: e2e-arm64-template.yml
         parameters:

--- a/.pipelines/templates/pipeline-selector.yml
+++ b/.pipelines/templates/pipeline-selector.yml
@@ -66,6 +66,9 @@ stages:
         parameters:
           stageType: ${{ parameters.targetStage }}
           blockPublishing: ${{ parameters.blockPublishing }}
+          # TODO: enable this when Azure resources are available
+          # # Only perform Azure testing from official pipelines, as only those have access to the Azure subscription.
+          # includeAzure: ${{ or(eq(parameters.targetStage, 'pre'), eq(parameters.targetStage, 'ci'), eq(parameters.targetStage, 'pr-e2e-azure')) }}
           numberOfUpdateIterations: ${{ parameters.numberOfUpdateIterations }}
       - template: e2e-arm64-template.yml
         parameters:


### PR DESCRIPTION
# 🔍 Description
 
SKU availability is causing azure servicing tests to fail.  Disable for now.

Validation : https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1076915&view=results