### PR TITLE
feature: implement grpc-client update

### DIFF
--- a/crates/trident/src/grpc_client/mod.rs
+++ b/crates/trident/src/grpc_client/mod.rs
@@ -2,6 +2,7 @@ use std::process::ExitCode;
 
 use anyhow::{bail, Context, Error};
 use log::error;
+use tokio::fs;
 use tokio::runtime::Builder;
 
 use crate::{
@@ -9,10 +10,6 @@ use crate::{
     ExitKind, TRIDENT_VERSION,
 };
 
-#[cfg(feature = "grpc-preview")]
-use tokio::fs;
-
-#[cfg(feature = "grpc-preview")]
 use crate::cli;
 
 mod error;

--- a/crates/trident/src/grpc_client/mod.rs
+++ b/crates/trident/src/grpc_client/mod.rs
@@ -66,6 +66,31 @@ async fn run_client(args: &ClientArgs) -> Result<ExitKind, Error> {
                 .context("Trident failed to stream image");
         }
 
+        ClientCommands::Update {
+            config,
+            allowed_operations,
+            ..
+        } => {
+            let config_yaml = fs::read_to_string(config).await.with_context(|| {
+                format!("Failed to read configuration file: {}", config.display())
+            })?;
+
+            let operations = cli::to_operations(allowed_operations);
+
+            if operations.has_finalize() && operations.has_stage() {
+                return client
+                    .update(config_yaml, RebootHandling::Trident)
+                    .await
+                    .context("Trident failed to perform update");
+            } else if operations.has_stage() {
+                bail!("Staging-only updates are not implemented via gRPC client yet");
+            } else if operations.has_finalize() {
+                bail!("Finalizing-only updates are not implemented via gRPC client yet");
+            } else {
+                bail!("At least one allowed operation must be specified");
+            }
+        }
+
         #[cfg(feature = "grpc-preview")]
         ClientCommands::Install {
             config,

--- a/crates/trident/src/grpc_client/mod.rs
+++ b/crates/trident/src/grpc_client/mod.rs
@@ -80,9 +80,15 @@ async fn run_client(args: &ClientArgs) -> Result<ExitKind, Error> {
                     .await
                     .context("Trident failed to perform update");
             } else if operations.has_stage() {
-                bail!("Staging-only updates are not implemented via gRPC client yet");
+                return client
+                    .update_stage(config_yaml)
+                    .await
+                    .context("Trident failed to perform update_stage");
             } else if operations.has_finalize() {
-                bail!("Finalizing-only updates are not implemented via gRPC client yet");
+                return client
+                    .update_finalize(RebootHandling::Trident)
+                    .await
+                    .context("Trident failed to perform update_finalize");
             } else {
                 bail!("At least one allowed operation must be specified");
             }

--- a/crates/trident/src/grpc_client/tridentclient.rs
+++ b/crates/trident/src/grpc_client/tridentclient.rs
@@ -10,13 +10,11 @@ use url::Url;
 use trident_proto::v1::{
     servicing_response::Response as ResponseBody, streaming_service_client::StreamingServiceClient,
     update_service_client::UpdateServiceClient, version_service_client::VersionServiceClient,
-    FinalizeUpdateRequest, RebootHandling as ProtoRebootHandling, RebootManagement, RebootStatus,
-    ServicingResponse, StageUpdateRequest, StatusCode, StreamDiskRequest, UpdateRequest,
-    VersionRequest,
+    FinalizeUpdateRequest, HostConfiguration, RebootHandling as ProtoRebootHandling,
+    RebootManagement, RebootStatus, ServicingResponse, StageUpdateRequest, StatusCode,
+    StreamDiskRequest, UpdateRequest, VersionRequest,
 };
 
-#[cfg(feature = "grpc-preview")]
-use trident_proto::v1::HostConfiguration;
 #[cfg(feature = "grpc-preview")]
 use trident_proto::v1preview::{
     commit_service_client::CommitServiceClient, install_service_client::InstallServiceClient,

--- a/crates/trident/src/grpc_client/tridentclient.rs
+++ b/crates/trident/src/grpc_client/tridentclient.rs
@@ -10,8 +10,9 @@ use url::Url;
 use trident_proto::v1::{
     servicing_response::Response as ResponseBody, streaming_service_client::StreamingServiceClient,
     update_service_client::UpdateServiceClient, version_service_client::VersionServiceClient,
-    RebootHandling as ProtoRebootHandling, RebootManagement, RebootStatus, ServicingResponse,
-    StatusCode, StreamDiskRequest, VersionRequest,
+    FinalizeUpdateRequest, RebootHandling as ProtoRebootHandling, RebootManagement, RebootStatus,
+    ServicingResponse, StageUpdateRequest, StatusCode, StreamDiskRequest, UpdateRequest,
+    VersionRequest,
 };
 
 #[cfg(feature = "grpc-preview")]
@@ -59,7 +60,6 @@ pub struct TridentClient {
     version_client: VersionServiceClient<Channel>,
     streaming_client: StreamingServiceClient<Channel>,
 
-    #[expect(dead_code)]
     update_client: UpdateServiceClient<Channel>,
 
     #[cfg(feature = "grpc-preview")]
@@ -155,6 +155,34 @@ impl TridentClient {
             .install(request)
             .await
             .map_err(|e| TridentClientError::RequestError("install".to_string(), e))?
+            .into_inner();
+
+        handle_servicing_response_stream(response).await
+    }
+
+    pub async fn update(
+        &mut self,
+        host_configuration: impl Into<String>,
+        reboot_handling: RebootHandling,
+    ) -> Result<ExitKind, TridentClientError> {
+        let request = Request::new(UpdateRequest {
+            stage: Some(StageUpdateRequest {
+                config: Some(HostConfiguration {
+                    config: host_configuration.into(),
+                }),
+            }),
+            finalize: Some(FinalizeUpdateRequest {
+                reboot: Some(RebootManagement {
+                    handling: reboot_handling.into(),
+                }),
+            }),
+        });
+
+        let response = self
+            .update_client
+            .update(request)
+            .await
+            .map_err(|e| TridentClientError::RequestError("update".to_string(), e))?
             .into_inner();
 
         handle_servicing_response_stream(response).await

--- a/crates/trident/src/grpc_client/tridentclient.rs
+++ b/crates/trident/src/grpc_client/tridentclient.rs
@@ -57,7 +57,6 @@ impl From<RebootHandling> for i32 {
 pub struct TridentClient {
     version_client: VersionServiceClient<Channel>,
     streaming_client: StreamingServiceClient<Channel>,
-
     update_client: UpdateServiceClient<Channel>,
 
     #[cfg(feature = "grpc-preview")]

--- a/crates/trident/src/grpc_client/tridentclient.rs
+++ b/crates/trident/src/grpc_client/tridentclient.rs
@@ -185,6 +185,46 @@ impl TridentClient {
         handle_servicing_response_stream(response).await
     }
 
+    pub async fn update_stage(
+        &mut self,
+        host_configuration: impl Into<String>,
+    ) -> Result<ExitKind, TridentClientError> {
+        let request = Request::new(StageUpdateRequest {
+            config: Some(HostConfiguration {
+                config: host_configuration.into(),
+            }),
+        });
+
+        let response = self
+            .update_client
+            .update_stage(request)
+            .await
+            .map_err(|e| TridentClientError::RequestError("update_stage".to_string(), e))?
+            .into_inner();
+
+        handle_servicing_response_stream(response).await
+    }
+
+    pub async fn update_finalize(
+        &mut self,
+        reboot_handling: RebootHandling,
+    ) -> Result<ExitKind, TridentClientError> {
+        let request = Request::new(FinalizeUpdateRequest {
+            reboot: Some(RebootManagement {
+                handling: reboot_handling.into(),
+            }),
+        });
+
+        let response = self
+            .update_client
+            .update_finalize(request)
+            .await
+            .map_err(|e| TridentClientError::RequestError("update_finalize".to_string(), e))?
+            .into_inner();
+
+        handle_servicing_response_stream(response).await
+    }
+
     /// Stream an image to the Trident server.
     pub async fn stream_disk(
         &mut self,

--- a/crates/trident/src/lib.rs
+++ b/crates/trident/src/lib.rs
@@ -567,6 +567,13 @@ impl Trident {
         let mut host_config = self
             .host_config
             .clone()
+            .or_else(|| {
+                if !allowed_operations.has_stage() && allowed_operations.has_finalize() {
+                    Some(datastore.host_status().spec.clone())
+                } else {
+                    None
+                }
+            })
             .structured(InternalError::Internal(
                 "update called without Host Configuration set",
             ))?;

--- a/tests/images/trident-vm-testimage/base/baseimg-grub-verity-azure.yaml
+++ b/tests/images/trident-vm-testimage/base/baseimg-grub-verity-azure.yaml
@@ -149,6 +149,7 @@ os:
     enable:
       - etc-mount
       - kdump
+      - tridentd.socket
 
   users:
     - name: testuser

--- a/tests/images/trident-vm-testimage/base/baseimg-grub-verity.yaml
+++ b/tests/images/trident-vm-testimage/base/baseimg-grub-verity.yaml
@@ -147,6 +147,7 @@ os:
     enable:
       - etc-mount
       - kdump
+      - tridentd.socket
 
   users:
     - name: testuser

--- a/tests/images/trident-vm-testimage/base/baseimg-grub.yaml
+++ b/tests/images/trident-vm-testimage/base/baseimg-grub.yaml
@@ -72,6 +72,9 @@ os:
       - trident-service
       - vim
       - netplan
+  services:
+    enable:
+      - tridentd.socket
 
   additionalFiles:
     - source: files/sshd-keygen.service

--- a/tests/images/trident-vm-testimage/base/baseimg-root-verity.yaml
+++ b/tests/images/trident-vm-testimage/base/baseimg-root-verity.yaml
@@ -158,6 +158,7 @@ os:
     enable:
       - kdump
       - trident
+      - tridentd.socket
 
   users:
     - name: testuser

--- a/tests/images/trident-vm-testimage/base/baseimg-usr-verity.yaml
+++ b/tests/images/trident-vm-testimage/base/baseimg-usr-verity.yaml
@@ -149,6 +149,7 @@ os:
     enable:
       - kdump
       - trident
+      - tridentd.socket
 
   users:
     - name: testuser

--- a/tests/images/trident-vm-testimage/base/updateimg-grub-verity-azure.yaml
+++ b/tests/images/trident-vm-testimage/base/updateimg-grub-verity-azure.yaml
@@ -137,6 +137,7 @@ os:
       - etc-mount
       - kdump
       - trident
+      - tridentd.socket
 
   users:
     - name: testuser

--- a/tests/images/trident-vm-testimage/base/updateimg-grub-verity.yaml
+++ b/tests/images/trident-vm-testimage/base/updateimg-grub-verity.yaml
@@ -130,6 +130,7 @@ os:
       - etc-mount
       - kdump
       - trident
+      - tridentd.socket
 
   users:
     - name: testuser

--- a/tests/images/trident-vm-testimage/base/updateimg-grub.yaml
+++ b/tests/images/trident-vm-testimage/base/updateimg-grub.yaml
@@ -56,6 +56,7 @@ os:
   services:
     enable:
       - trident
+      - tridentd.socket
   users:
     - name: testuser
       sshPublicKeyPaths:

--- a/tools/pkg/tridentgrpc/grpc.go
+++ b/tools/pkg/tridentgrpc/grpc.go
@@ -23,6 +23,7 @@ type TridentClient struct {
 	// Stable APIs
 	tridentpbv1.VersionServiceClient
 	tridentpbv1.StreamingServiceClient
+	tridentpbv1.UpdateServiceClient
 	grpcConn *grpc.ClientConn
 
 	// Preview APIs

--- a/tools/storm/e2e/scenario/ab_update.go
+++ b/tools/storm/e2e/scenario/ab_update.go
@@ -205,7 +205,7 @@ func (s *TridentE2EScenario) uploadNewConfig(tc storm.TestCase) error {
 
 func (s *TridentE2EScenario) abUpdateOs(tc storm.TestCase, split bool) error {
 	args := fmt.Sprintf(
-		"update -v trace %s",
+		"grpc-client update -v trace %s",
 		path.Join(s.runtime.HostPath(), hostConfigRemotePath),
 	)
 

--- a/tools/storm/e2e/scenario/ab_update.go
+++ b/tools/storm/e2e/scenario/ab_update.go
@@ -206,6 +206,7 @@ func (s *TridentE2EScenario) uploadNewConfig(tc storm.TestCase) error {
 func (s *TridentE2EScenario) abUpdateOs(tc storm.TestCase, split bool) error {
 	updateCmd := "update"
 	if s.runtime == trident.RuntimeTypeHost {
+		// For host, use grpc-client for update
 		updateCmd = "grpc-client update"
 	}
 

--- a/tools/storm/e2e/scenario/ab_update.go
+++ b/tools/storm/e2e/scenario/ab_update.go
@@ -204,8 +204,14 @@ func (s *TridentE2EScenario) uploadNewConfig(tc storm.TestCase) error {
 }
 
 func (s *TridentE2EScenario) abUpdateOs(tc storm.TestCase, split bool) error {
+	updateCmd := "update"
+	if s.runtime == trident.RuntimeTypeHost {
+		updateCmd = "grpc-client update"
+	}
+
 	args := fmt.Sprintf(
-		"grpc-client update -v trace %s",
+		"%s -v trace %s",
+		updateCmd,
 		path.Join(s.runtime.HostPath(), hostConfigRemotePath),
 	)
 

--- a/tools/storm/helpers/ab_update.go
+++ b/tools/storm/helpers/ab_update.go
@@ -310,8 +310,8 @@ func (h *AbUpdateHelper) triggerTridentUpdate(tc storm.TestCase) error {
 	if h.args.FinalizeAbUpdate {
 		logrus.Infof("Allowed operations: finalize")
 		allowedOperations = append(allowedOperations, "finalize")
-		if h.args.StageAbUpdate {
-			// If both stage and finalize, use `grpc-client update`
+		if h.args.StageAbUpdate && h.args.TridentRuntimeType == trident.RuntimeTypeHost {
+			// For runtime=host, if both stage and finalize, use `grpc-client update`
 			updateCmd = "grpc-client update"
 		}
 	}

--- a/tools/storm/helpers/ab_update.go
+++ b/tools/storm/helpers/ab_update.go
@@ -302,6 +302,10 @@ func (h *AbUpdateHelper) triggerTridentUpdate(tc storm.TestCase) error {
 	allowedOperations := make([]string, 0)
 
 	updateCmd := "update"
+	if h.args.TridentRuntimeType == trident.RuntimeTypeHost {
+		updateCmd = "grpc-client update"
+	}
+
 	if h.args.StageAbUpdate {
 		logrus.Infof("Allowed operations: stage")
 		allowedOperations = append(allowedOperations, "stage")
@@ -310,10 +314,6 @@ func (h *AbUpdateHelper) triggerTridentUpdate(tc storm.TestCase) error {
 	if h.args.FinalizeAbUpdate {
 		logrus.Infof("Allowed operations: finalize")
 		allowedOperations = append(allowedOperations, "finalize")
-		if h.args.StageAbUpdate && h.args.TridentRuntimeType == trident.RuntimeTypeHost {
-			// For runtime=host, if both stage and finalize, use `grpc-client update`
-			updateCmd = "grpc-client update"
-		}
 	}
 
 	args := fmt.Sprintf(

--- a/tools/storm/helpers/ab_update.go
+++ b/tools/storm/helpers/ab_update.go
@@ -301,6 +301,7 @@ func (h *AbUpdateHelper) handleAutoRollback(tc storm.TestCase) error {
 func (h *AbUpdateHelper) triggerTridentUpdate(tc storm.TestCase) error {
 	allowedOperations := make([]string, 0)
 
+	updateCmd := "update"
 	if h.args.StageAbUpdate {
 		logrus.Infof("Allowed operations: stage")
 		allowedOperations = append(allowedOperations, "stage")
@@ -309,10 +310,15 @@ func (h *AbUpdateHelper) triggerTridentUpdate(tc storm.TestCase) error {
 	if h.args.FinalizeAbUpdate {
 		logrus.Infof("Allowed operations: finalize")
 		allowedOperations = append(allowedOperations, "finalize")
+		if h.args.StageAbUpdate {
+			// If both stage and finalize, use `grpc-client update`
+			updateCmd = "grpc-client update"
+		}
 	}
 
 	args := fmt.Sprintf(
-		"update -v trace %s --allowed-operations %s",
+		"%s -v trace %s --allowed-operations %s",
+		updateCmd,
 		path.Join(h.args.TridentRuntimeType.HostPath(), h.args.TridentConfig),
 		strings.Join(allowedOperations, ","),
 	)

--- a/tools/storm/rollback/tests/helper.go
+++ b/tools/storm/rollback/tests/helper.go
@@ -160,7 +160,7 @@ func (u *UpdateTest) doUpdateTest() error {
 	logrus.Tracef("Host Configuration put on VM")
 	// Invoke trident update
 	logrus.Tracef("Invoking `trident update` on VM")
-	updateOutput, err := stormssh.SshCommandCombinedOutput(u.VMConfig.VMConfig, u.VMIP, fmt.Sprintf("sudo trident -v trace update %s", vmHostConfigPath))
+	updateOutput, err := stormssh.SshCommandCombinedOutput(u.VMConfig.VMConfig, u.VMIP, fmt.Sprintf("sudo trident -v trace grpc-client update %s", vmHostConfigPath))
 	logrus.Tracef("Update output (%v):\n%s", err, updateOutput)
 	if strings.Contains(updateOutput, "Trident failed due to a servicing error") {
 		return fmt.Errorf("failed to update: %w", err)

--- a/tools/storm/rollback/tests/helper.go
+++ b/tools/storm/rollback/tests/helper.go
@@ -159,8 +159,9 @@ func (u *UpdateTest) doUpdateTest() error {
 	}
 	logrus.Tracef("Host Configuration put on VM")
 	// Invoke trident update
-	logrus.Tracef("Invoking `trident update` on VM")
-	updateOutput, err := stormssh.SshCommandCombinedOutput(u.VMConfig.VMConfig, u.VMIP, fmt.Sprintf("sudo trident -v trace grpc-client update %s", vmHostConfigPath))
+	updateCmd := fmt.Sprintf("sudo trident -v trace grpc-client update %s", vmHostConfigPath)
+	logrus.Tracef("Invoking `trident update` on VM: '%s'", updateCmd)
+	updateOutput, err := stormssh.SshCommandCombinedOutput(u.VMConfig.VMConfig, u.VMIP, updateCmd)
 	logrus.Tracef("Update output (%v):\n%s", err, updateOutput)
 	if strings.Contains(updateOutput, "Trident failed due to a servicing error") {
 		return fmt.Errorf("failed to update: %w", err)

--- a/tools/storm/servicing/tests/update.go
+++ b/tools/storm/servicing/tests/update.go
@@ -194,7 +194,7 @@ func innerUpdateLoop(testConfig stormsvcconfig.TestConfig, vmConfig stormvmconfi
 		}
 
 		logrus.Tracef("Running Trident update staging command on VM")
-		combinedStagingOutput, stageErr := stormssh.SshCommandCombinedOutput(vmConfig.VMConfig, vmIP, fmt.Sprintf("sudo trident grpc-client update %s %s --allowed-operations stage", tridentLoggingArg, updateConfig))
+		combinedStagingOutput, stageErr := stormssh.SshCommandCombinedOutput(vmConfig.VMConfig, vmIP, fmt.Sprintf("sudo trident update %s %s --allowed-operations stage", tridentLoggingArg, updateConfig))
 		if testConfig.Verbose {
 			logrus.Tracef("Staging output for iteration %d:\n%s", i, combinedStagingOutput)
 		}

--- a/tools/storm/servicing/tests/update.go
+++ b/tools/storm/servicing/tests/update.go
@@ -194,7 +194,7 @@ func innerUpdateLoop(testConfig stormsvcconfig.TestConfig, vmConfig stormvmconfi
 		}
 
 		logrus.Tracef("Running Trident update staging command on VM")
-		combinedStagingOutput, stageErr := stormssh.SshCommandCombinedOutput(vmConfig.VMConfig, vmIP, fmt.Sprintf("sudo trident update %s %s --allowed-operations stage", tridentLoggingArg, updateConfig))
+		combinedStagingOutput, stageErr := stormssh.SshCommandCombinedOutput(vmConfig.VMConfig, vmIP, fmt.Sprintf("sudo trident grpc-client update %s %s --allowed-operations stage", tridentLoggingArg, updateConfig))
 		if testConfig.Verbose {
 			logrus.Tracef("Staging output for iteration %d:\n%s", i, combinedStagingOutput)
 		}
@@ -243,7 +243,7 @@ func innerUpdateLoop(testConfig stormsvcconfig.TestConfig, vmConfig stormvmconfi
 		}
 
 		logrus.Tracef("Running Trident update finalize command on VM")
-		combinedFinalizeOutput, finalizeErr := stormssh.SshCommandCombinedOutput(vmConfig.VMConfig, vmIP, fmt.Sprintf("sudo trident update %s %s --allowed-operations finalize", tridentLoggingArg, updateConfig))
+		combinedFinalizeOutput, finalizeErr := stormssh.SshCommandCombinedOutput(vmConfig.VMConfig, vmIP, fmt.Sprintf("sudo trident grpc-client update %s %s --allowed-operations finalize", tridentLoggingArg, updateConfig))
 		if testConfig.Verbose {
 			logrus.Tracef("Finalize output for iteration %d:\n%s\n%v", i, combinedFinalizeOutput, finalizeErr)
 		}

--- a/tools/storm/servicing/tests/update.go
+++ b/tools/storm/servicing/tests/update.go
@@ -243,7 +243,7 @@ func innerUpdateLoop(testConfig stormsvcconfig.TestConfig, vmConfig stormvmconfi
 		}
 
 		logrus.Tracef("Running Trident update finalize command on VM")
-		combinedFinalizeOutput, finalizeErr := stormssh.SshCommandCombinedOutput(vmConfig.VMConfig, vmIP, fmt.Sprintf("sudo trident grpc-client update %s %s --allowed-operations finalize", tridentLoggingArg, updateConfig))
+		combinedFinalizeOutput, finalizeErr := stormssh.SshCommandCombinedOutput(vmConfig.VMConfig, vmIP, fmt.Sprintf("sudo trident update %s %s --allowed-operations finalize", tridentLoggingArg, updateConfig))
 		if testConfig.Verbose {
 			logrus.Tracef("Finalize output for iteration %d:\n%s\n%v", i, combinedFinalizeOutput, finalizeErr)
 		}


### PR DESCRIPTION
# 🔍 Description
 
* Implement `grpc-client update`
* For rollback tests and host e2e tests, where update is run with unified stage & finalize, adjust test code to use `trident grpc-client update`.  For container tests and servicing tests and e2e tests where stage and finalize are separate update calls, `trident update` will remain.

# Validation
* https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1084784&view=results