### PR TITLE
tests: grpc-client udpate finalize is not communicating reboot to e2e tests

### DIFF
--- a/crates/trident/src/grpc_client/tridentclient.rs
+++ b/crates/trident/src/grpc_client/tridentclient.rs
@@ -1,6 +1,6 @@
 use std::ops::ControlFlow;
 
-use log::info;
+use log::{debug, info};
 use tonic::{
     transport::{Channel, Endpoint},
     Request, Streaming,
@@ -334,7 +334,14 @@ async fn handle_servicing_response(
             info!("Servicing completed successfully");
 
             match status.reboot_status() {
-                RebootStatus::RebootStarted => info!("A reboot has been started by Trident"),
+                RebootStatus::RebootStarted => {
+                    info!("A reboot has been started by Trident");
+                    // IMPORTANT: This message is used by E2E A/B update tests to validate that
+                    // a reboot was requested. Do not change or remove without updating the
+                    // test constant in:
+                    // tools/storm/utils/trident/trident.go:REBOOTING_LOG_MESSAGE
+                    debug!("Requesting reboot");
+                }
                 RebootStatus::RebootRequired => {
                     info!("A reboot is required to complete the operation");
                     return Ok(ControlFlow::Break(ExitKind::NeedsReboot));

--- a/tools/storm/e2e/scenario/ab_update.go
+++ b/tools/storm/e2e/scenario/ab_update.go
@@ -329,6 +329,11 @@ func runTridentUpdate(tc storm.TestCase, runtime trident.RuntimeType, client *ss
 			}
 		}
 
+		if out.Status == 0 && strings.Contains(out.Stderr, trident.REBOOTING_LOG_MESSAGE) {
+			logrus.Infof("Host rebooted successfully")
+			break
+		}
+
 		if out.Status == 0 && strings.Contains(out.Stderr, "Staging of A/B update succeeded") {
 			logrus.Infof("Staging of A/B update succeeded")
 			break

--- a/tools/storm/e2e/scenario/ab_update.go
+++ b/tools/storm/e2e/scenario/ab_update.go
@@ -257,20 +257,20 @@ func (s *TridentE2EScenario) abUpdateOs(tc storm.TestCase, split bool) error {
 	if !split {
 		// regular case
 		logrus.Infof("Running Trident A/B update...")
-		err = runTridentUpdate(tc, s.runtime, s.sshClient, args)
+		err = runTridentUpdate(tc, s.runtime, s.sshClient, args, false)
 		if err != nil {
 			return fmt.Errorf("failed to run Trident A/B update: %w", err)
 		}
 	} else {
 		// split stage and finalize
 		logrus.Infof("Running split Trident A/B update (stage)...")
-		err = runTridentUpdate(tc, s.runtime, s.sshClient, args+" --allowed-operations stage")
+		err = runTridentUpdate(tc, s.runtime, s.sshClient, args+" --allowed-operations stage", true)
 		if err != nil {
 			return fmt.Errorf("failed to run Trident A/B update: %w", err)
 		}
 
 		logrus.Infof("Running split Trident A/B update (finalize)...")
-		err = runTridentUpdate(tc, s.runtime, s.sshClient, args+" --allowed-operations finalize")
+		err = runTridentUpdate(tc, s.runtime, s.sshClient, args+" --allowed-operations finalize", false)
 		if err != nil {
 			return fmt.Errorf("failed to run Trident A/B update: %w", err)
 		}
@@ -311,41 +311,33 @@ func (s *TridentE2EScenario) abUpdateOs(tc storm.TestCase, split bool) error {
 	return nil
 }
 
-func runTridentUpdate(tc storm.TestCase, runtime trident.RuntimeType, client *ssh.Client, args string) error {
+func runTridentUpdate(tc storm.TestCase, runtime trident.RuntimeType, client *ssh.Client, args string, stagingOnly bool) error {
 	for i := 1; ; i++ {
 		logrus.Infof("Invoking Trident attempt #%d with args: %s", i, args)
 
 		out, err := trident.InvokeTrident(runtime, client, nil, args)
-		if err != nil {
-			if err, ok := err.(*ssh.ExitMissingError); ok && strings.Contains(out.Stderr, trident.REBOOTING_LOG_MESSAGE) {
-				// The connection closed without an exit code, and the output contains REBOOTING_LOG_MESSAGE.
-				// This indicates that the host has rebooted.
-				logrus.Infof("Host rebooted successfully")
-				break
-			} else {
-				// Some unknown error occurred.
-				logrus.Errorf("Failed to invoke Trident: %s; %s", err, out.Report())
-				return fmt.Errorf("failed to invoke Trident: %w", err)
-			}
-		}
+		logrus.Tracef("Trident '%s' details: %s; %s", args, err, out.Report())
 
-		if out.Status == 0 && strings.Contains(out.Stderr, trident.REBOOTING_LOG_MESSAGE) {
+		// If this is not staging only, check and exit if reboot message found in output
+		if !stagingOnly && strings.Contains(out.Stderr, trident.REBOOTING_LOG_MESSAGE) {
 			logrus.Infof("Host rebooted successfully")
 			break
 		}
-
-		if out.Status == 0 && strings.Contains(out.Stderr, "Staging of A/B update succeeded") {
+		// Errors that occur without the reboot message are a test failure
+		if err != nil {
+			return fmt.Errorf("failed to invoke Trident: %w", err)
+		}
+		// If only staging, check for staging success message in output
+		if stagingOnly && out.Status == 0 && strings.Contains(out.Stderr, "Staging of A/B update succeeded") {
 			logrus.Infof("Staging of A/B update succeeded")
 			break
 		}
-
+		// Check for specific failure case representing a retry e2e scenario
 		if out.Status == 2 && strings.Contains(out.Stderr, "Failed to run post-configure script 'fail-on-the-first-run'") {
 			logrus.Infof("Detected intentional failure. Re-running...")
 			continue
 		}
-
-		logrus.Errorf("Trident update failed %s", out.Report())
-
+		// Any case where we end up here is a failure, fail the test
 		tc.Fail(fmt.Sprintf("Trident update failed with status %d", out.Status))
 	}
 

--- a/tools/storm/helpers/ab_update.go
+++ b/tools/storm/helpers/ab_update.go
@@ -347,6 +347,11 @@ func (h *AbUpdateHelper) triggerTridentUpdate(tc storm.TestCase) error {
 			}
 		}
 
+		if out.Status == 0 && strings.Contains(out.Stderr, trident.REBOOTING_LOG_MESSAGE) {
+			logrus.Infof("Host rebooted successfully")
+			break
+		}
+
 		if out.Status == 0 && strings.Contains(out.Stderr, "Staging of A/B update succeeded") {
 			logrus.Infof("Staging of A/B update succeeded")
 			break

--- a/tools/storm/helpers/ab_update.go
+++ b/tools/storm/helpers/ab_update.go
@@ -334,36 +334,28 @@ func (h *AbUpdateHelper) triggerTridentUpdate(tc storm.TestCase) error {
 		logrus.Infof("Invoking Trident attempt #%d with args: %s", i, args)
 
 		out, err := stormtrident.InvokeTrident(h.args.TridentRuntimeType, h.client, h.args.EnvVars, args)
-		if err != nil {
-			if err, ok := err.(*ssh.ExitMissingError); ok && strings.Contains(out.Stderr, trident.REBOOTING_LOG_MESSAGE) {
-				// The connection closed without an exit code, and the output contains REBOOTING_LOG_MESSAGE.
-				// This indicates that the host has rebooted.
-				logrus.Infof("Host rebooted successfully")
-				break
-			} else {
-				// Some unknown error occurred.
-				logrus.Errorf("Failed to invoke Trident: %s; %s", err, out.Report())
-				return fmt.Errorf("failed to invoke Trident: %w", err)
-			}
-		}
+		logrus.Tracef("Trident '%s' details: %s; %s", args, err, out.Report())
 
-		if out.Status == 0 && strings.Contains(out.Stderr, trident.REBOOTING_LOG_MESSAGE) {
+		// If this is not staging only, check and exit if reboot message found in output
+		if h.args.FinalizeAbUpdate && strings.Contains(out.Stderr, trident.REBOOTING_LOG_MESSAGE) {
 			logrus.Infof("Host rebooted successfully")
 			break
 		}
-
-		if out.Status == 0 && strings.Contains(out.Stderr, "Staging of A/B update succeeded") {
+		// Errors that occur without the reboot message are a test failure
+		if err != nil {
+			return fmt.Errorf("failed to invoke Trident: %w", err)
+		}
+		// If only staging, check for staging success message in output
+		if !h.args.FinalizeAbUpdate && out.Status == 0 && strings.Contains(out.Stderr, "Staging of A/B update succeeded") {
 			logrus.Infof("Staging of A/B update succeeded")
 			break
 		}
-
+		// Check for specific failure case representing a retry e2e scenario
 		if out.Status == 2 && strings.Contains(out.Stderr, "Failed to run post-configure script 'fail-on-the-first-run'") {
 			logrus.Infof("Detected intentional failure. Re-running...")
 			continue
 		}
-
-		logrus.Errorf("Trident update failed %s", out.Report())
-
+		// Any case where we end up here is a failure, fail the test
 		tc.Fail(fmt.Sprintf("Trident update failed with status %d", out.Status))
 	}
 

--- a/tools/storm/helpers/manual_rollback.go
+++ b/tools/storm/helpers/manual_rollback.go
@@ -122,6 +122,10 @@ func (h *ManualRollbackHelper) rollback(tc storm.TestCase) error {
 			return fmt.Errorf("failed to invoke Trident: %w", err)
 		}
 	}
+	if out.Status == 0 && strings.Contains(out.Stderr, trident.REBOOTING_LOG_MESSAGE) {
+		logrus.Infof("Host rebooted successfully")
+	}
+
 	logrus.Infof("Trident 'rollback' succeeded:\n%s", out.Stdout)
 
 	if !h.args.ExpectRuntimeRollback {

--- a/tools/storm/helpers/manual_rollback.go
+++ b/tools/storm/helpers/manual_rollback.go
@@ -122,7 +122,6 @@ func (h *ManualRollbackHelper) rollback(tc storm.TestCase) error {
 			return fmt.Errorf("failed to invoke Trident: %w", err)
 		}
 	}
-
 	logrus.Infof("Trident 'rollback' succeeded:\n%s", out.Stdout)
 
 	if !h.args.ExpectRuntimeRollback {

--- a/tools/storm/helpers/manual_rollback.go
+++ b/tools/storm/helpers/manual_rollback.go
@@ -122,9 +122,6 @@ func (h *ManualRollbackHelper) rollback(tc storm.TestCase) error {
 			return fmt.Errorf("failed to invoke Trident: %w", err)
 		}
 	}
-	if out.Status == 0 && strings.Contains(out.Stderr, trident.REBOOTING_LOG_MESSAGE) {
-		logrus.Infof("Host rebooted successfully")
-	}
 
 	logrus.Infof("Trident 'rollback' succeeded:\n%s", out.Stdout)
 


### PR DESCRIPTION
# 🔍 Description
 
Ensure e2e debug log message is sent and read by e2e tests.

Validation with trident-ci: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1086216&view=results