### PR TITLE
feature: Fully enable non-default ESP paths

### DIFF
--- a/crates/docbuilder/src/main.rs
+++ b/crates/docbuilder/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Context, Error};
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use log::info;
 
-use trident_api::constants::ESP_MOUNT_POINT_PATH;
+use trident_api::constants::DEFAULT_ESP_MOUNT_POINT_PATH;
 
 mod clap_model;
 mod host_config;
@@ -229,7 +229,7 @@ fn build_host_config_docs(mut opts: HostConfigMarkdownOpts) -> Result<(), Error>
     // descriptions. They will exists as variables with the exact same name as
     // the constant. For example, `ESP_MOUNT_POINT_PATH` can be used in
     // descriptions as `{{ ESP_MOUNT_POINT_PATH }}`.
-    let variables = string_const_map!(ESP_MOUNT_POINT_PATH);
+    let variables = string_const_map!(DEFAULT_ESP_MOUNT_POINT_PATH);
 
     host_config::docs::build(
         opts.output,

--- a/crates/docbuilder/src/main.rs
+++ b/crates/docbuilder/src/main.rs
@@ -227,8 +227,8 @@ fn build_host_config_docs(mut opts: HostConfigMarkdownOpts) -> Result<(), Error>
 
     // Constants that we are making available to the tera context for rendering
     // descriptions. They will exists as variables with the exact same name as
-    // the constant. For example, `ESP_MOUNT_POINT_PATH` can be used in
-    // descriptions as `{{ ESP_MOUNT_POINT_PATH }}`.
+    // the constant. For example, `DEFAULT_ESP_MOUNT_POINT_PATH` can be used in
+    // descriptions as `{{ DEFAULT_ESP_MOUNT_POINT_PATH }}`.
     let variables = string_const_map!(DEFAULT_ESP_MOUNT_POINT_PATH);
 
     host_config::docs::build(

--- a/crates/osutils/src/tabfile.rs
+++ b/crates/osutils/src/tabfile.rs
@@ -330,7 +330,7 @@ mod tests {
 
     use tempfile::NamedTempFile;
 
-    use trident_api::constants::ESP_MOUNT_POINT_PATH;
+    use trident_api::constants::DEFAULT_ESP_MOUNT_POINT_PATH;
 
     #[test]
     fn test_get_device_path() {
@@ -347,7 +347,7 @@ mod tests {
         tmpfile.flush().unwrap();
 
         assert_eq!(
-            get_device_path(tmpfile.path(), Path::new(ESP_MOUNT_POINT_PATH)).unwrap(),
+            get_device_path(tmpfile.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap(),
             PathBuf::from("/dev/sda1")
         );
 

--- a/crates/trident/src/engine/boot/grub.rs
+++ b/crates/trident/src/engine/boot/grub.rs
@@ -287,7 +287,7 @@ pub(crate) mod functional_test {
             self, AbUpdate, AbVolumePair, Disk, FileSystem, FileSystemSource, HostConfiguration,
             MountOptions, MountPoint, Partition, PartitionType, RaidLevel, SoftwareRaidArray,
         },
-        constants::ESP_MOUNT_POINT_PATH,
+        constants::DEFAULT_ESP_MOUNT_POINT_PATH,
         status::ServicingType,
     };
 
@@ -304,7 +304,7 @@ pub(crate) mod functional_test {
         let grub_esp = include_str!("test_files/grub_esp.cfg");
         let grub_boot = include_str!("test_files/grub_boot.cfg");
 
-        let grub_esp_path = Path::new(ESP_MOUNT_POINT_PATH)
+        let grub_esp_path = Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)
             .join(ESP_EFI_DIRECTORY)
             .join(get_update_esp_dir_name(ctx).expect("Failed to get update esp dir name"))
             .join(GRUB2_CONFIG_FILENAME);

--- a/crates/trident/src/engine/boot/uki.rs
+++ b/crates/trident/src/engine/boot/uki.rs
@@ -42,7 +42,7 @@ pub fn is_staged(esp_dir_path: &Path) -> bool {
 pub fn stage_uki_on_esp(
     temp_mount_dir: &Path,
     mount_point: &Path,
-    esp_mount_path: impl AsRef<Path>,
+    esp_mount_path: &Path,
 ) -> Result<(), Error> {
     let uki_source_dir = temp_mount_dir.join(UKI_DIRECTORY);
     let ukis: Vec<_> = uki_source_dir
@@ -145,10 +145,7 @@ pub fn stage_uki_on_esp(
 }
 
 /// Prepares the ESP directory structure required for UKI boot.
-pub fn prepare_esp_for_uki(
-    root_mount_point: &Path,
-    esp_mount_path: impl AsRef<Path>,
-) -> Result<(), Error> {
+pub fn prepare_esp_for_uki(root_mount_point: &Path, esp_mount_path: &Path) -> Result<(), Error> {
     let esp_root_path = join_relative(root_mount_point, esp_mount_path);
     let esp_uki_directory = esp_root_path.join(UKI_DIRECTORY);
 
@@ -467,13 +464,13 @@ mod tests {
         fs::write(src_uki_dir.join("dummy-uki.efi"), b"uki-content").unwrap();
 
         let mount_point = tempdir().unwrap();
-        prepare_esp_for_uki(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH).unwrap();
+        prepare_esp_for_uki(mount_point.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap();
 
         // Should succeed when exactly one UKI file is present
         stage_uki_on_esp(
             temp_mount.path(),
             mount_point.path(),
-            DEFAULT_ESP_MOUNT_POINT_PATH,
+            Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
         )
         .unwrap();
 
@@ -489,7 +486,7 @@ mod tests {
         stage_uki_on_esp(
             temp_mount.path(),
             mount_point.path(),
-            DEFAULT_ESP_MOUNT_POINT_PATH,
+            Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
         )
         .unwrap_err();
     }
@@ -517,13 +514,13 @@ mod tests {
         fs::write(addon_dir.join("README"), b"ignored").unwrap();
 
         let mount_point = tempdir().unwrap();
-        prepare_esp_for_uki(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH).unwrap();
+        prepare_esp_for_uki(mount_point.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap();
 
         // Should succeed when exactly one UKI file is present
         stage_uki_on_esp(
             temp_mount.path(),
             mount_point.path(),
-            DEFAULT_ESP_MOUNT_POINT_PATH,
+            Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
         )
         .unwrap();
 
@@ -557,7 +554,7 @@ mod tests {
     #[test]
     fn test_prepare_esp_for_uki() {
         let root_mount = tempdir().unwrap();
-        prepare_esp_for_uki(root_mount.path(), DEFAULT_ESP_MOUNT_POINT_PATH).unwrap();
+        prepare_esp_for_uki(root_mount.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap();
 
         let esp_root_path = join_relative(root_mount.path(), DEFAULT_ESP_MOUNT_POINT_PATH);
         assert!(esp_root_path.join(UKI_DIRECTORY).exists());
@@ -713,11 +710,11 @@ mod tests {
 
         // With no regular files present, staging should fail with "No UKI files found"
         let mount_point = tempdir().unwrap();
-        prepare_esp_for_uki(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH).unwrap();
+        prepare_esp_for_uki(mount_point.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap();
         let err = stage_uki_on_esp(
             temp_mount.path(),
             mount_point.path(),
-            DEFAULT_ESP_MOUNT_POINT_PATH,
+            Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
         )
         .unwrap_err();
         assert!(
@@ -730,7 +727,7 @@ mod tests {
         stage_uki_on_esp(
             temp_mount.path(),
             mount_point.path(),
-            DEFAULT_ESP_MOUNT_POINT_PATH,
+            Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
         )
         .unwrap();
 

--- a/crates/trident/src/engine/boot/uki.rs
+++ b/crates/trident/src/engine/boot/uki.rs
@@ -419,7 +419,7 @@ mod tests {
     use super::*;
     use std::fs::File;
     use tempfile::tempdir;
-    use trident_api::constants::ESP_MOUNT_POINT_PATH;
+    use trident_api::constants::DEFAULT_ESP_MOUNT_POINT_PATH;
 
     /// Validates that `uki_suffix` produces the correct A/B suffix based on
     /// the active volume and install index.
@@ -467,13 +467,18 @@ mod tests {
         fs::write(src_uki_dir.join("dummy-uki.efi"), b"uki-content").unwrap();
 
         let mount_point = tempdir().unwrap();
-        prepare_esp_for_uki(mount_point.path(), ESP_MOUNT_POINT_PATH).unwrap();
+        prepare_esp_for_uki(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH).unwrap();
 
         // Should succeed when exactly one UKI file is present
-        stage_uki_on_esp(temp_mount.path(), mount_point.path(), ESP_MOUNT_POINT_PATH).unwrap();
+        stage_uki_on_esp(
+            temp_mount.path(),
+            mount_point.path(),
+            DEFAULT_ESP_MOUNT_POINT_PATH,
+        )
+        .unwrap();
 
         // Check that the file was copied to the correct destination
-        let dest_uki_file = join_relative(mount_point.path(), ESP_MOUNT_POINT_PATH)
+        let dest_uki_file = join_relative(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH)
             .join(UKI_DIRECTORY)
             .join(TMP_UKI_NAME);
         assert_eq!(fs::read(&dest_uki_file).unwrap(), b"uki-content");
@@ -481,7 +486,12 @@ mod tests {
         // Should fail if there are multiple UKI files
         let extra_uki_file = src_uki_dir.join("another.efi");
         fs::write(&extra_uki_file, b"other").unwrap();
-        stage_uki_on_esp(temp_mount.path(), mount_point.path(), ESP_MOUNT_POINT_PATH).unwrap_err();
+        stage_uki_on_esp(
+            temp_mount.path(),
+            mount_point.path(),
+            DEFAULT_ESP_MOUNT_POINT_PATH,
+        )
+        .unwrap_err();
     }
 
     /// Validates that `stage_uki_on_esp` copies both the UKI file and its
@@ -507,19 +517,24 @@ mod tests {
         fs::write(addon_dir.join("README"), b"ignored").unwrap();
 
         let mount_point = tempdir().unwrap();
-        prepare_esp_for_uki(mount_point.path(), ESP_MOUNT_POINT_PATH).unwrap();
+        prepare_esp_for_uki(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH).unwrap();
 
         // Should succeed when exactly one UKI file is present
-        stage_uki_on_esp(temp_mount.path(), mount_point.path(), ESP_MOUNT_POINT_PATH).unwrap();
+        stage_uki_on_esp(
+            temp_mount.path(),
+            mount_point.path(),
+            DEFAULT_ESP_MOUNT_POINT_PATH,
+        )
+        .unwrap();
 
         // Check that the UKI file was copied to the correct destination
-        let dest_uki_file = join_relative(mount_point.path(), ESP_MOUNT_POINT_PATH)
+        let dest_uki_file = join_relative(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH)
             .join(UKI_DIRECTORY)
             .join(TMP_UKI_NAME);
         assert_eq!(fs::read(&dest_uki_file).unwrap(), b"uki-content");
 
         // Check that the addon files were copied to the correct destination
-        let dest_addon_dir = join_relative(mount_point.path(), ESP_MOUNT_POINT_PATH)
+        let dest_addon_dir = join_relative(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH)
             .join(UKI_DIRECTORY)
             .join(TMP_UKI_ADDON_DIR_NAME);
         assert_eq!(
@@ -542,9 +557,9 @@ mod tests {
     #[test]
     fn test_prepare_esp_for_uki() {
         let root_mount = tempdir().unwrap();
-        prepare_esp_for_uki(root_mount.path(), ESP_MOUNT_POINT_PATH).unwrap();
+        prepare_esp_for_uki(root_mount.path(), DEFAULT_ESP_MOUNT_POINT_PATH).unwrap();
 
-        let esp_root_path = join_relative(root_mount.path(), ESP_MOUNT_POINT_PATH);
+        let esp_root_path = join_relative(root_mount.path(), DEFAULT_ESP_MOUNT_POINT_PATH);
         assert!(esp_root_path.join(UKI_DIRECTORY).exists());
         assert!(esp_root_path.join("loader").exists());
         assert!(esp_root_path.join("loader/entries.srel").exists());
@@ -698,9 +713,13 @@ mod tests {
 
         // With no regular files present, staging should fail with "No UKI files found"
         let mount_point = tempdir().unwrap();
-        prepare_esp_for_uki(mount_point.path(), ESP_MOUNT_POINT_PATH).unwrap();
-        let err = stage_uki_on_esp(temp_mount.path(), mount_point.path(), ESP_MOUNT_POINT_PATH)
-            .unwrap_err();
+        prepare_esp_for_uki(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH).unwrap();
+        let err = stage_uki_on_esp(
+            temp_mount.path(),
+            mount_point.path(),
+            DEFAULT_ESP_MOUNT_POINT_PATH,
+        )
+        .unwrap_err();
         assert!(
             err.to_string().contains("No UKI files found"),
             "Expected 'No UKI files found' error, got: {err}"
@@ -708,9 +727,14 @@ mod tests {
 
         // Now add exactly one regular file — staging should succeed
         fs::write(src_uki_dir.join("real-uki.efi"), b"uki-content").unwrap();
-        stage_uki_on_esp(temp_mount.path(), mount_point.path(), ESP_MOUNT_POINT_PATH).unwrap();
+        stage_uki_on_esp(
+            temp_mount.path(),
+            mount_point.path(),
+            DEFAULT_ESP_MOUNT_POINT_PATH,
+        )
+        .unwrap();
 
-        let dest_uki_file = join_relative(mount_point.path(), ESP_MOUNT_POINT_PATH)
+        let dest_uki_file = join_relative(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH)
             .join(UKI_DIRECTORY)
             .join(TMP_UKI_NAME);
         assert_eq!(fs::read(&dest_uki_file).unwrap(), b"uki-content");

--- a/crates/trident/src/engine/boot/uki.rs
+++ b/crates/trident/src/engine/boot/uki.rs
@@ -16,10 +16,7 @@ use osutils::{
 use trident_api::error::{
     InternalError, ReportError, ServicingError, TridentError, TridentResultExt,
 };
-use trident_api::{
-    constants::{ESP_EFI_DIRECTORY, ESP_MOUNT_POINT_PATH},
-    status::AbVolumeSelection,
-};
+use trident_api::{constants::ESP_EFI_DIRECTORY, status::AbVolumeSelection};
 
 use crate::engine::EngineContext;
 
@@ -42,7 +39,11 @@ pub fn is_staged(esp_dir_path: &Path) -> bool {
 }
 
 /// Copies the UKI file from the mounted image to the ESP directory.
-pub fn stage_uki_on_esp(temp_mount_dir: &Path, mount_point: &Path) -> Result<(), Error> {
+pub fn stage_uki_on_esp(
+    temp_mount_dir: &Path,
+    mount_point: &Path,
+    esp_mount_path: impl AsRef<Path>,
+) -> Result<(), Error> {
     let uki_source_dir = temp_mount_dir.join(UKI_DIRECTORY);
     let ukis: Vec<_> = uki_source_dir
         .read_dir()
@@ -59,7 +60,7 @@ pub fn stage_uki_on_esp(temp_mount_dir: &Path, mount_point: &Path) -> Result<(),
     ensure!(ukis.len() == 1, "Multiple UKI files found within the image");
 
     // Path to stage the UKI file on the ESP, e.g. <mount_point>/EFI/Linux/vmlinuz-0.efi.staged
-    let staging_uki_path = join_relative(mount_point, ESP_MOUNT_POINT_PATH).join(UKI_DIRECTORY);
+    let staging_uki_path = join_relative(mount_point, esp_mount_path).join(UKI_DIRECTORY);
 
     let dest_path = staging_uki_path.join(TMP_UKI_NAME);
     debug!("Staging UKI file at '{}'", dest_path.display());
@@ -144,8 +145,11 @@ pub fn stage_uki_on_esp(temp_mount_dir: &Path, mount_point: &Path) -> Result<(),
 }
 
 /// Prepares the ESP directory structure required for UKI boot.
-pub fn prepare_esp_for_uki(root_mount_point: &Path) -> Result<(), Error> {
-    let esp_root_path = join_relative(root_mount_point, ESP_MOUNT_POINT_PATH);
+pub fn prepare_esp_for_uki(
+    root_mount_point: &Path,
+    esp_mount_path: impl AsRef<Path>,
+) -> Result<(), Error> {
+    let esp_root_path = join_relative(root_mount_point, esp_mount_path);
     let esp_uki_directory = esp_root_path.join(UKI_DIRECTORY);
 
     fs::create_dir_all(&esp_uki_directory)
@@ -415,6 +419,7 @@ mod tests {
     use super::*;
     use std::fs::File;
     use tempfile::tempdir;
+    use trident_api::constants::ESP_MOUNT_POINT_PATH;
 
     /// Validates that `uki_suffix` produces the correct A/B suffix based on
     /// the active volume and install index.
@@ -462,10 +467,10 @@ mod tests {
         fs::write(src_uki_dir.join("dummy-uki.efi"), b"uki-content").unwrap();
 
         let mount_point = tempdir().unwrap();
-        prepare_esp_for_uki(mount_point.path()).unwrap();
+        prepare_esp_for_uki(mount_point.path(), ESP_MOUNT_POINT_PATH).unwrap();
 
         // Should succeed when exactly one UKI file is present
-        stage_uki_on_esp(temp_mount.path(), mount_point.path()).unwrap();
+        stage_uki_on_esp(temp_mount.path(), mount_point.path(), ESP_MOUNT_POINT_PATH).unwrap();
 
         // Check that the file was copied to the correct destination
         let dest_uki_file = join_relative(mount_point.path(), ESP_MOUNT_POINT_PATH)
@@ -476,7 +481,7 @@ mod tests {
         // Should fail if there are multiple UKI files
         let extra_uki_file = src_uki_dir.join("another.efi");
         fs::write(&extra_uki_file, b"other").unwrap();
-        stage_uki_on_esp(temp_mount.path(), mount_point.path()).unwrap_err();
+        stage_uki_on_esp(temp_mount.path(), mount_point.path(), ESP_MOUNT_POINT_PATH).unwrap_err();
     }
 
     /// Validates that `stage_uki_on_esp` copies both the UKI file and its
@@ -502,10 +507,10 @@ mod tests {
         fs::write(addon_dir.join("README"), b"ignored").unwrap();
 
         let mount_point = tempdir().unwrap();
-        prepare_esp_for_uki(mount_point.path()).unwrap();
+        prepare_esp_for_uki(mount_point.path(), ESP_MOUNT_POINT_PATH).unwrap();
 
         // Should succeed when exactly one UKI file is present
-        stage_uki_on_esp(temp_mount.path(), mount_point.path()).unwrap();
+        stage_uki_on_esp(temp_mount.path(), mount_point.path(), ESP_MOUNT_POINT_PATH).unwrap();
 
         // Check that the UKI file was copied to the correct destination
         let dest_uki_file = join_relative(mount_point.path(), ESP_MOUNT_POINT_PATH)
@@ -537,7 +542,7 @@ mod tests {
     #[test]
     fn test_prepare_esp_for_uki() {
         let root_mount = tempdir().unwrap();
-        prepare_esp_for_uki(root_mount.path()).unwrap();
+        prepare_esp_for_uki(root_mount.path(), ESP_MOUNT_POINT_PATH).unwrap();
 
         let esp_root_path = join_relative(root_mount.path(), ESP_MOUNT_POINT_PATH);
         assert!(esp_root_path.join(UKI_DIRECTORY).exists());
@@ -693,8 +698,9 @@ mod tests {
 
         // With no regular files present, staging should fail with "No UKI files found"
         let mount_point = tempdir().unwrap();
-        prepare_esp_for_uki(mount_point.path()).unwrap();
-        let err = stage_uki_on_esp(temp_mount.path(), mount_point.path()).unwrap_err();
+        prepare_esp_for_uki(mount_point.path(), ESP_MOUNT_POINT_PATH).unwrap();
+        let err = stage_uki_on_esp(temp_mount.path(), mount_point.path(), ESP_MOUNT_POINT_PATH)
+            .unwrap_err();
         assert!(
             err.to_string().contains("No UKI files found"),
             "Expected 'No UKI files found' error, got: {err}"
@@ -702,7 +708,7 @@ mod tests {
 
         // Now add exactly one regular file — staging should succeed
         fs::write(src_uki_dir.join("real-uki.efi"), b"uki-content").unwrap();
-        stage_uki_on_esp(temp_mount.path(), mount_point.path()).unwrap();
+        stage_uki_on_esp(temp_mount.path(), mount_point.path(), ESP_MOUNT_POINT_PATH).unwrap();
 
         let dest_uki_file = join_relative(mount_point.path(), ESP_MOUNT_POINT_PATH)
             .join(UKI_DIRECTORY)

--- a/crates/trident/src/engine/bootentries.rs
+++ b/crates/trident/src/engine/bootentries.rs
@@ -702,7 +702,7 @@ mod tests {
     use super::*;
     use boot::get_update_esp_dir_name;
 
-    use constants::ESP_MOUNT_POINT_PATH;
+    use constants::DEFAULT_ESP_MOUNT_POINT_PATH;
 
     /// Validates logic for determining which A/B volume to use for updates
     #[test]
@@ -844,7 +844,7 @@ mod tests {
                         source: FileSystemSource::Image,
                         device_id: Some("esp".to_string()),
                         mount_point: Some(MountPoint {
-                            path: ESP_MOUNT_POINT_PATH.into(),
+                            path: DEFAULT_ESP_MOUNT_POINT_PATH.into(),
                             options: MountOptions::defaults(),
                         }),
                         is_esp: true,
@@ -900,7 +900,7 @@ mod tests {
                         source: FileSystemSource::Image,
                         device_id: Some("esp".to_string()),
                         mount_point: Some(MountPoint {
-                            path: ESP_MOUNT_POINT_PATH.into(),
+                            path: DEFAULT_ESP_MOUNT_POINT_PATH.into(),
                             options: MountOptions::defaults(),
                         }),
                         is_esp: true,
@@ -1029,7 +1029,7 @@ mod functional_test {
             self, Disk, HostConfiguration, ImageSha384, MountOptions, MountPoint, OsImage,
             Partition, PartitionSize, PartitionType,
         },
-        constants::ESP_MOUNT_POINT_PATH,
+        constants::DEFAULT_ESP_MOUNT_POINT_PATH,
     };
 
     use crate::engine::{storage::partitioning, EngineContext};
@@ -1415,7 +1415,7 @@ mod functional_test {
                         source: config::FileSystemSource::Image,
                         device_id: Some("esp".to_string()),
                         mount_point: Some(MountPoint {
-                            path: ESP_MOUNT_POINT_PATH.into(),
+                            path: DEFAULT_ESP_MOUNT_POINT_PATH.into(),
                             options: MountOptions::defaults(),
                         }),
                         is_esp: true,

--- a/crates/trident/src/engine/context/mod.rs
+++ b/crates/trident/src/engine/context/mod.rs
@@ -107,9 +107,9 @@ pub struct EngineContext {
 #[cfg(any(test, feature = "functional-test"))]
 impl Default for EngineContext {
     fn default() -> Self {
-        use trident_api::constants::ESP_MOUNT_POINT_PATH;
+        use trident_api::constants::DEFAULT_ESP_MOUNT_POINT_PATH;
         Self {
-            esp_mount_path: PathBuf::from(ESP_MOUNT_POINT_PATH),
+            esp_mount_path: PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH),
             spec: Default::default(),
             spec_old: Default::default(),
             servicing_type: Default::default(),

--- a/crates/trident/src/engine/install_index.rs
+++ b/crates/trident/src/engine/install_index.rs
@@ -68,14 +68,14 @@ mod tests {
 
     use tempfile::TempDir;
 
-    use trident_api::{constants::ESP_MOUNT_POINT_PATH, error::ErrorKind};
+    use trident_api::{constants::DEFAULT_ESP_MOUNT_POINT_PATH, error::ErrorKind};
 
     use crate::engine::boot::make_esp_dir_name_candidates;
 
     // Helper that constructs the ESP EFI path, creates the directories, and returns
     // (full_esp_efi_path, esp_mount_path). The esp_mount_path is what next_install_index expects.
     fn setup_esp_efi_path(mount_point: &Path) -> (PathBuf, PathBuf) {
-        let esp_mount_path = PathBuf::from(ESP_MOUNT_POINT_PATH);
+        let esp_mount_path = PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH);
         let esp_efi_path =
             path::join_relative(mount_point, &esp_mount_path).join(ESP_EFI_DIRECTORY);
         fs::create_dir_all(&esp_efi_path).unwrap();

--- a/crates/trident/src/engine/manual_rollback/mod.rs
+++ b/crates/trident/src/engine/manual_rollback/mod.rs
@@ -1,17 +1,12 @@
-use std::{
-    path::{Path, PathBuf},
-    time::Instant,
-};
+use std::{path::PathBuf, time::Instant};
 
 use enumflags2::BitFlags;
 use log::{debug, info, trace, warn};
 
-use osutils::{efivar, pcrlock};
+use osutils::{efivar, path, pcrlock};
 use trident_api::{
     config::Operations,
-    constants::{
-        internal_params::NO_TRANSITION, ESP_RELATIVE_MOUNT_POINT_PATH, ROOT_MOUNT_POINT_PATH,
-    },
+    constants::{internal_params::NO_TRANSITION, ROOT_MOUNT_POINT_PATH},
     error::{InvalidInputError, ReportError, ServicingError, TridentError, TridentResultExt},
     status::{ServicingState, ServicingType},
 };
@@ -286,7 +281,7 @@ fn finalize_rollback(
 
     let root_path = container::get_host_relative_path(PathBuf::from(ROOT_MOUNT_POINT_PATH))
         .message("Failed to get host root path")?;
-    let esp_path = Path::join(&root_path, ESP_RELATIVE_MOUNT_POINT_PATH);
+    let esp_path = path::join_relative(&root_path, engine_context.esp_mount_path.as_path());
 
     // In UKI, find the previous UKI and set it as default boot entry
     if engine_context.is_uki()? {

--- a/crates/trident/src/engine/newroot.rs
+++ b/crates/trident/src/engine/newroot.rs
@@ -780,7 +780,7 @@ mod functional_test {
             self, Disk, FileSystemSource, HostConfiguration, MountOptions, MountPoint, Partition,
             PartitionSize, PartitionType,
         },
-        constants::{ESP_RELATIVE_MOUNT_POINT_PATH, MOUNT_OPTION_READ_ONLY},
+        constants::{DEFAULT_ESP_RELATIVE_MOUNT_POINT_PATH, MOUNT_OPTION_READ_ONLY},
         error::ErrorKind,
     };
 
@@ -948,7 +948,7 @@ mod functional_test {
 
         assert!(root_mount_dir
             .path()
-            .join(ESP_RELATIVE_MOUNT_POINT_PATH)
+            .join(DEFAULT_ESP_RELATIVE_MOUNT_POINT_PATH)
             .join(mock_bootloader_path)
             .exists());
         newroot_mount2.unmount_all().unwrap();

--- a/crates/trident/src/engine/storage/encryption.rs
+++ b/crates/trident/src/engine/storage/encryption.rs
@@ -539,14 +539,14 @@ mod tests {
     use super::*;
 
     use trident_api::{
-        constants::ESP_MOUNT_POINT_PATH,
+        constants::DEFAULT_ESP_MOUNT_POINT_PATH,
         status::{AbVolumeSelection, ServicingType},
     };
 
     #[test]
     fn test_get_bootloader_paths() {
         // Declare ESP path; no need to actually write anything as this func only constructs paths.
-        let esp_path = PathBuf::from(ESP_MOUNT_POINT_PATH);
+        let esp_path = PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH);
 
         let mut ctx = EngineContext {
             ab_active_volume: None,
@@ -722,7 +722,7 @@ mod functional_test {
     use super::*;
 
     use pytest_gen::functional_test;
-    use trident_api::{constants::ESP_MOUNT_POINT_PATH, status::ServicingType};
+    use trident_api::{constants::DEFAULT_ESP_MOUNT_POINT_PATH, status::ServicingType};
 
     #[functional_test(feature = "helpers")]
     fn test_get_uki_paths() {
@@ -734,7 +734,7 @@ mod functional_test {
         };
 
         // Declare ESP path; no need to actually write anything as this func only constructs paths.
-        let esp_path = PathBuf::from(ESP_MOUNT_POINT_PATH);
+        let esp_path = PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH);
         let esp_uki_path = esp_path.join(UKI_DIRECTORY);
 
         // Test case #1: No mount_path, so only one path is returned, i.e. current entry.
@@ -781,7 +781,7 @@ mod functional_test {
 
     #[functional_test(feature = "helpers")]
     fn test_get_binary_paths_pcrlock() {
-        let esp_path = PathBuf::from(ESP_MOUNT_POINT_PATH);
+        let esp_path = PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH);
         let esp_uki_path = esp_path.join(UKI_DIRECTORY);
 
         let mut ctx = EngineContext {

--- a/crates/trident/src/init/offline/mod.rs
+++ b/crates/trident/src/init/offline/mod.rs
@@ -24,8 +24,8 @@ use trident_api::{
         ESP_RELATIVE_MOUNT_POINT_PATH, ROOT_MOUNT_POINT_PATH,
     },
     error::{
-        ExecutionEnvironmentMisconfigurationError, InitializationError, InvalidInputError,
-        ReportError, TridentError, TridentResultExt,
+        ExecutionEnvironmentMisconfigurationError, InitializationError, InternalError,
+        InvalidInputError, ReportError, TridentError, TridentResultExt,
     },
     status::{decode_host_status, AbVolumeSelection, HostStatus, ServicingState},
     BlockDeviceId,
@@ -523,8 +523,19 @@ pub fn execute(
         .map_err(Into::into)
         .message("The provided Host Status has an invalid Host Configuration")?;
 
+    // Find the ESP filesystem mount point path
+    let esp_path = host_status
+        .spec
+        .storage
+        .filesystems
+        .iter()
+        .find(|fs| fs.is_esp)
+        .and_then(|fs| fs.mount_point_path())
+        .ok_or(TridentError::new(InternalError::Internal(
+            "Failed to find ESP filesystem in Host Status, validation should have failed if this was the case",
+        )))?;
+
     // Ensure AZLA/AZLB esp scheme is present by copying boot files from fallback location if needed.
-    let esp_path = PathBuf::from(ROOT_MOUNT_POINT_PATH).join(ESP_RELATIVE_MOUNT_POINT_PATH);
     let azla_esp_path = esp_path.join(ESP_EFI_DIRECTORY).join("AZLA");
     trace!("Checking for AZLA volume ESP path at {:?}", &azla_esp_path);
     if !azla_esp_path.exists() {

--- a/crates/trident/src/init/offline/mod.rs
+++ b/crates/trident/src/init/offline/mod.rs
@@ -21,7 +21,7 @@ use trident_api::{
     },
     constants::{
         internal_params::ENABLE_UKI_SUPPORT, EFI_DEFAULT_BIN_RELATIVE_PATH, ESP_EFI_DIRECTORY,
-        ESP_RELATIVE_MOUNT_POINT_PATH, ROOT_MOUNT_POINT_PATH,
+        ROOT_MOUNT_POINT_PATH,
     },
     error::{
         ExecutionEnvironmentMisconfigurationError, InitializationError, InternalError,

--- a/crates/trident/src/subsystems/esp.rs
+++ b/crates/trident/src/subsystems/esp.rs
@@ -714,7 +714,7 @@ mod tests {
     };
     use trident_api::{
         config::{HostConfiguration, Os},
-        constants::ESP_RELATIVE_MOUNT_POINT_PATH,
+        constants::DEFAULT_ESP_RELATIVE_MOUNT_POINT_PATH,
     };
     use trident_api::{
         constants::GRUB2_RELATIVE_PATH,
@@ -733,7 +733,7 @@ mod tests {
         let test_dir = TempDir::new().unwrap();
         let test_esp_dir = test_dir
             .path()
-            .join(ESP_RELATIVE_MOUNT_POINT_PATH)
+            .join(DEFAULT_ESP_RELATIVE_MOUNT_POINT_PATH)
             .join(ESP_EFI_DIRECTORY);
 
         // Check over several install ESP directory names. The idea is to ensure
@@ -796,7 +796,7 @@ mod tests {
             let test_dir = TempDir::new().unwrap();
             let test_esp_dir = test_dir
                 .path()
-                .join(ESP_RELATIVE_MOUNT_POINT_PATH)
+                .join(DEFAULT_ESP_RELATIVE_MOUNT_POINT_PATH)
                 .join(ESP_EFI_DIRECTORY);
 
             // On a clean state, generate the ESP directory path.
@@ -888,7 +888,7 @@ mod tests {
     ) -> PathBuf {
         let fallback_esp_dir = mount_point
             .path()
-            .join(ESP_RELATIVE_MOUNT_POINT_PATH)
+            .join(DEFAULT_ESP_RELATIVE_MOUNT_POINT_PATH)
             .join(ESP_EFI_DIRECTORY)
             .join(esp_name);
         fs::create_dir_all(&fallback_esp_dir).unwrap();

--- a/crates/trident/src/subsystems/esp.rs
+++ b/crates/trident/src/subsystems/esp.rs
@@ -21,7 +21,7 @@ use trident_api::{
     constants::{
         internal_params::{DISABLE_GRUB_NOPREFIX_CHECK, RAW_COSI_STORAGE},
         EFI_DEFAULT_BIN_DIRECTORY, EFI_DEFAULT_BIN_RELATIVE_PATH, ESP_EFI_DIRECTORY,
-        ESP_RELATIVE_MOUNT_POINT_PATH, GRUB2_CONFIG_FILENAME, GRUB2_CONFIG_RELATIVE_PATH,
+        GRUB2_CONFIG_FILENAME, GRUB2_CONFIG_RELATIVE_PATH,
     },
     error::{InvalidInputError, ReportError, ServicingError, TridentError, TridentResultExt},
     status::{AbVolumeSelection, ServicingState, ServicingType},
@@ -84,6 +84,7 @@ pub fn set_uefi_fallback_contents(
         );
         copy_boot_files_for_uefi_fallback(
             mount_point,
+            ctx.esp_mount_path.as_path(),
             &source_esp_dir_name,
             &ctx.servicing_type,
             ctx.install_index,
@@ -282,10 +283,10 @@ fn copy_file_artifacts(
 
     if ctx.is_uki().unstructured("UKI setting unknown")? {
         // Prepare ESP directory structure for UKI boot
-        uki::prepare_esp_for_uki(mount_point)?;
+        uki::prepare_esp_for_uki(mount_point, &ctx.esp_mount_path)?;
 
         // Copy the UKI from the image into the ESP directory
-        uki::stage_uki_on_esp(temp_mount_dir, mount_point)?;
+        uki::stage_uki_on_esp(temp_mount_dir, mount_point, &ctx.esp_mount_path)?;
     } else {
         // In non-UKI mode, bail if grub_noprefix.efi is not found in the image.
         ensure!(
@@ -407,13 +408,12 @@ fn skip_uefi_fallback_copy(
 /// Copies all files from 'source_esp_name' folder to the UEFI fallback folder.
 fn copy_boot_files_for_uefi_fallback(
     mount_point: &Path,
+    esp_mount_path: &Path,
     source_esp_name: &str,
     servicing_type: &ServicingType,
     install_index: usize,
 ) -> Result<(), Error> {
-    let esp_dir_path = mount_point
-        .join(ESP_RELATIVE_MOUNT_POINT_PATH)
-        .join(ESP_EFI_DIRECTORY);
+    let esp_dir_path = path::join_relative(mount_point, esp_mount_path).join(ESP_EFI_DIRECTORY);
     if skip_uefi_fallback_copy(
         &esp_dir_path,
         source_esp_name,
@@ -689,9 +689,8 @@ fn generate_efi_bin_base_dir_path(
     mount_point: &Path,
 ) -> Result<PathBuf, Error> {
     // Compose the path to the ESP directory
-    let esp_efi_path = mount_point
-        .join(ESP_RELATIVE_MOUNT_POINT_PATH)
-        .join(ESP_EFI_DIRECTORY);
+    let esp_efi_path =
+        path::join_relative(mount_point, ctx.esp_mount_path.as_path()).join(ESP_EFI_DIRECTORY);
 
     // Return the path to the ESP directory with the ESP dir name
     Ok(
@@ -713,7 +712,10 @@ mod tests {
         boot::{get_update_esp_dir_name, make_esp_dir_name_candidates},
         install_index,
     };
-    use trident_api::config::{HostConfiguration, Os};
+    use trident_api::{
+        config::{HostConfiguration, Os},
+        constants::ESP_RELATIVE_MOUNT_POINT_PATH,
+    };
     use trident_api::{
         constants::GRUB2_RELATIVE_PATH,
         status::{AbVolumeSelection, ServicingType},

--- a/crates/trident/src/subsystems/storage/fstab.rs
+++ b/crates/trident/src/subsystems/storage/fstab.rs
@@ -164,7 +164,7 @@ mod tests {
             Storage, VerityDevice,
         },
         constants::{
-            ESP_MOUNT_POINT_PATH, MOUNT_OPTION_READ_ONLY, ROOT_MOUNT_POINT_PATH,
+            DEFAULT_ESP_MOUNT_POINT_PATH, MOUNT_OPTION_READ_ONLY, ROOT_MOUNT_POINT_PATH,
             USR_MOUNT_POINT_PATH,
         },
         status::ServicingType,
@@ -398,7 +398,7 @@ mod tests {
             filesystems: vec![
                 FileSystemDataImage {
                     mount_point: MountPoint {
-                        path: PathBuf::from(ESP_MOUNT_POINT_PATH),
+                        path: PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH),
                         options: "umask=0077".into(),
                     },
                     fs_type: Some(RealFilesystemType::Vfat),
@@ -510,7 +510,7 @@ mod tests {
                 filesystems: vec![
                     FileSystem {
                         mount_point: Some(MountPoint {
-                            path: PathBuf::from(ESP_MOUNT_POINT_PATH),
+                            path: PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH),
                             options: "umask=0077".into(),
                         }),
                         device_id: Some("efi".into()),
@@ -552,7 +552,7 @@ mod tests {
                 None::<&str>,
             ),
             MockImage::new(
-                PathBuf::from(ESP_MOUNT_POINT_PATH),
+                PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH),
                 OsImageFileSystemType::Vfat,
                 DiscoverablePartitionType::Root,
                 Some(Uuid::new_v4().to_string()),
@@ -668,7 +668,7 @@ mod tests {
                     filesystems: vec![
                         FileSystem {
                             mount_point: Some(MountPoint {
-                                path: PathBuf::from(ESP_MOUNT_POINT_PATH),
+                                path: PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH),
                                 options: "umask=0077".into(),
                             }),
                             device_id: Some("efi".into()),
@@ -700,7 +700,7 @@ mod tests {
             })
             .with_image(MockOsImage::new().with_images([
                 MockImage::new(
-                    PathBuf::from(ESP_MOUNT_POINT_PATH),
+                    PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH),
                     OsImageFileSystemType::Vfat,
                     DiscoverablePartitionType::Esp,
                     None::<&str>,

--- a/crates/trident/src/subsystems/storage/osimage.rs
+++ b/crates/trident/src/subsystems/storage/osimage.rs
@@ -517,7 +517,7 @@ mod tests {
             AbUpdate, AbVolumePair, Disk, FileSystem, FileSystemSource, HostConfiguration,
             MountOptions, MountPoint, Partition, PartitionSize, Storage, VerityDevice,
         },
-        constants::{ESP_MOUNT_POINT_PATH, ROOT_MOUNT_POINT_PATH},
+        constants::{DEFAULT_ESP_MOUNT_POINT_PATH, ROOT_MOUNT_POINT_PATH},
         error::ErrorKind,
         misc::IdGenerator,
     };
@@ -696,7 +696,7 @@ mod tests {
                 os_release: OsRelease::default(),
                 images: vec![
                     MockImage {
-                        mount_point: PathBuf::from(ESP_MOUNT_POINT_PATH),
+                        mount_point: PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH),
                         fs_type: OsImageFileSystemType::Vfat,
                         fs_uuid: OsUuid::Uuid(Uuid::new_v4()),
                         part_type: DiscoverablePartitionType::Esp,
@@ -752,7 +752,7 @@ mod tests {
             os_release: OsRelease::default(),
             images: vec![
                 MockImage {
-                    mount_point: PathBuf::from(ESP_MOUNT_POINT_PATH),
+                    mount_point: PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH),
                     fs_type: OsImageFileSystemType::Vfat,
                     fs_uuid: OsUuid::Uuid(Uuid::new_v4()),
                     part_type: DiscoverablePartitionType::Esp,

--- a/crates/trident_api/src/config/host/storage/filesystem.rs
+++ b/crates/trident_api/src/config/host/storage/filesystem.rs
@@ -48,7 +48,7 @@ pub mod fs_serde {
     #[cfg(feature = "schemars")]
     use schemars::JsonSchema;
 
-    use crate::{constants::ESP_MOUNT_POINT_PATH, is_default};
+    use crate::{constants::DEFAULT_ESP_MOUNT_POINT_PATH, is_default};
 
     #[cfg(feature = "schemars")]
     use crate::schema_helpers::block_device_id_schema;
@@ -58,7 +58,7 @@ pub mod fs_serde {
         FileSystemType, MountPoint, NewFileSystemType,
     };
 
-    const DEFAULT_ESP_MOUNT_PATH: &str = ESP_MOUNT_POINT_PATH;
+    const DEFAULT_ESP_MOUNT_PATH: &str = DEFAULT_ESP_MOUNT_POINT_PATH;
 
     #[derive(Deserialize, Serialize, Default, PartialEq, Eq)]
     #[serde(rename_all = "kebab-case", deny_unknown_fields)]
@@ -463,7 +463,7 @@ impl FileSystem {
 mod tests {
     use super::*;
 
-    use crate::constants::ESP_MOUNT_POINT_PATH;
+    use crate::constants::DEFAULT_ESP_MOUNT_POINT_PATH;
 
     #[test]
     fn test_mount_point_from_str() {
@@ -496,7 +496,10 @@ mod tests {
             options: MountOptions::new("defaults"),
         });
         fs.is_esp = true; // Manually set; normally derived during deserialization via overrideEspMount / default mount-point detection.
-        assert_eq!(fs.mount_point_path(), Some(Path::new(ESP_MOUNT_POINT_PATH)));
+        assert_eq!(
+            fs.mount_point_path(),
+            Some(Path::new(DEFAULT_ESP_MOUNT_POINT_PATH))
+        );
         assert!(fs.is_esp);
         assert!(!fs.is_root());
         assert!(!fs.is_read_only());

--- a/crates/trident_api/src/config/host/storage/mod.rs
+++ b/crates/trident_api/src/config/host/storage/mod.rs
@@ -544,7 +544,7 @@ mod tests {
 
     use crate::{
         config::HostConfiguration,
-        constants::{BOOT_MOUNT_POINT_PATH, ESP_MOUNT_POINT_PATH, ROOT_MOUNT_POINT_PATH},
+        constants::{BOOT_MOUNT_POINT_PATH, DEFAULT_ESP_MOUNT_POINT_PATH, ROOT_MOUNT_POINT_PATH},
     };
 
     use self::{
@@ -676,7 +676,7 @@ mod tests {
                     device_id: Some("esp".to_owned()),
                     source: FileSystemSource::Image,
                     mount_point: Some(MountPoint {
-                        path: PathBuf::from(ESP_MOUNT_POINT_PATH),
+                        path: PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH),
                         options: MountOptions::empty(),
                     }),
                     is_esp: true,
@@ -909,7 +909,7 @@ mod tests {
                     device_id: Some("disk1-partition1".to_string()),
                     source: FileSystemSource::Image,
                     mount_point: Some(MountPoint {
-                        path: PathBuf::from(ESP_MOUNT_POINT_PATH),
+                        path: PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH),
                         options: MountOptions::empty(),
                     }),
                     is_esp: true,
@@ -950,7 +950,7 @@ mod tests {
                     device_id: Some("disk1-partition1".to_string()),
                     source: FileSystemSource::Image,
                     mount_point: Some(MountPoint {
-                        path: PathBuf::from(ESP_MOUNT_POINT_PATH),
+                        path: PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH),
                         options: MountOptions::empty(),
                     }),
                     is_esp: true,
@@ -1090,7 +1090,7 @@ mod tests {
                     device_id: Some("part1".to_owned()),
                     source: FileSystemSource::Image,
                     mount_point: Some(MountPoint {
-                        path: PathBuf::from(ESP_MOUNT_POINT_PATH),
+                        path: PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH),
                         options: MountOptions::empty(),
                     }),
                     is_esp: true,
@@ -2394,7 +2394,7 @@ mod tests {
                     source: FileSystemSource::Image,
                     device_id: Some("esp".to_string()),
                     mount_point: Some(MountPoint {
-                        path: ESP_MOUNT_POINT_PATH.into(),
+                        path: DEFAULT_ESP_MOUNT_POINT_PATH.into(),
                         options: MountOptions::defaults(),
                     }),
                     is_esp: true,
@@ -2813,7 +2813,7 @@ mod tests {
             device_id: Some("adopted-esp".into()),
             source: FileSystemSource::Adopted(Default::default()),
             mount_point: Some(MountPoint {
-                path: PathBuf::from(ESP_MOUNT_POINT_PATH),
+                path: PathBuf::from(DEFAULT_ESP_MOUNT_POINT_PATH),
                 options: MountOptions::empty(),
             }),
             is_esp: true,

--- a/crates/trident_api/src/config/host/storage/storage_graph/validation_tests.rs
+++ b/crates/trident_api/src/config/host/storage/storage_graph/validation_tests.rs
@@ -23,7 +23,7 @@ use crate::{
         MountOptions, MountPoint, NewFileSystemType, Partition, PartitionSize, PartitionTableType,
         PartitionType, RaidLevel, SoftwareRaidArray,
     },
-    constants::{ESP_MOUNT_POINT_PATH, ROOT_MOUNT_POINT_PATH},
+    constants::{DEFAULT_ESP_MOUNT_POINT_PATH, ROOT_MOUNT_POINT_PATH},
     storage_graph::{rules::expected_partition_type, types::BlkDevKind},
 };
 
@@ -758,7 +758,7 @@ fn test_esp_enforce_partition_type() {
         device_id: Some("partition".into()),
         source: FileSystemSource::Image,
         mount_point: Some(MountPoint {
-            path: ESP_MOUNT_POINT_PATH.into(),
+            path: DEFAULT_ESP_MOUNT_POINT_PATH.into(),
             options: MountOptions::defaults(),
         }),
         is_esp: true,
@@ -782,8 +782,8 @@ fn test_esp_enforce_partition_type() {
             partition_id: "partition".into(),
             partition_type: PartitionType::LinuxGeneric,
             valid_types: expected_partition_type(
-                Path::new(ESP_MOUNT_POINT_PATH),
-                Some(Path::new(ESP_MOUNT_POINT_PATH))
+                Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
+                Some(Path::new(DEFAULT_ESP_MOUNT_POINT_PATH))
             )
         }
     );
@@ -815,7 +815,7 @@ fn test_filesystem_esp_multiple_fail() {
         device_id: Some("esp1".into()),
         source: FileSystemSource::Image,
         mount_point: Some(MountPoint {
-            path: ESP_MOUNT_POINT_PATH.into(),
+            path: DEFAULT_ESP_MOUNT_POINT_PATH.into(),
             options: MountOptions::defaults(),
         }),
         is_esp: true,

--- a/crates/trident_api/src/constants.rs
+++ b/crates/trident_api/src/constants.rs
@@ -87,12 +87,17 @@ pub const BOOT_RELATIVE_MOUNT_POINT_PATH: &str = BOOT_DIRECTORY;
 pub const BOOT_MOUNT_POINT_PATH: &str =
     formatcp!("{ROOT_MOUNT_POINT_PATH}{BOOT_RELATIVE_MOUNT_POINT_PATH}",);
 
+/// *DO NOT USE IN PRODUCT CODE*
+///
 /// ESP volume relative mount point path (boot/efi) relative to the root mount point.
-pub const ESP_RELATIVE_MOUNT_POINT_PATH: &str = formatcp!("{BOOT_DIRECTORY}/{ROOT_EFI_DIRECTORY}");
+pub const DEFAULT_ESP_RELATIVE_MOUNT_POINT_PATH: &str =
+    formatcp!("{BOOT_DIRECTORY}/{ROOT_EFI_DIRECTORY}");
 
+/// *DO NOT USE IN PRODUCT CODE*
+///
 /// ESP volume mount point path (/boot/efi).
-pub const ESP_MOUNT_POINT_PATH: &str =
-    formatcp!("{ROOT_MOUNT_POINT_PATH}{ESP_RELATIVE_MOUNT_POINT_PATH}");
+pub const DEFAULT_ESP_MOUNT_POINT_PATH: &str =
+    formatcp!("{ROOT_MOUNT_POINT_PATH}{DEFAULT_ESP_RELATIVE_MOUNT_POINT_PATH}");
 
 /// Hardcoded path to the location to store backing of the /etc overlayfs.
 /// Expected to be on top of A/B update volume pair. Relative to root mount point.

--- a/crates/trident_api/src/samples/sample_hc.rs
+++ b/crates/trident_api/src/samples/sample_hc.rs
@@ -60,7 +60,7 @@ pub fn sample_host_configuration(name: &str) -> Result<(&'static str, HostConfig
                     FileSystem {
                         device_id: Some("esp".into()),
                         mount_point: Some(MountPoint {
-                            path: constants::ESP_MOUNT_POINT_PATH.into(),
+                            path: constants::DEFAULT_ESP_MOUNT_POINT_PATH.into(),
                             options: MountOptions::new("umask=0077"),
                         }),
                         source: FileSystemSource::Image,
@@ -115,7 +115,7 @@ pub fn sample_host_configuration(name: &str) -> Result<(&'static str, HostConfig
                         FileSystem {
                             device_id: Some("esp".into()),
                             mount_point: Some(MountPoint {
-                                path: constants::ESP_MOUNT_POINT_PATH.into(),
+                                path: constants::DEFAULT_ESP_MOUNT_POINT_PATH.into(),
                                 options: MountOptions::new("umask=0077"),
                             }),
                             source: FileSystemSource::Image,
@@ -314,7 +314,7 @@ pub fn sample_host_configuration(name: &str) -> Result<(&'static str, HostConfig
                         FileSystem {
                             device_id: Some("esp".into()),
                             mount_point: Some(MountPoint {
-                                path: constants::ESP_MOUNT_POINT_PATH.into(),
+                                path: constants::DEFAULT_ESP_MOUNT_POINT_PATH.into(),
                                 options: MountOptions::new("umask=0077"),
                             }),
                             source: FileSystemSource::Image,
@@ -530,7 +530,7 @@ pub fn sample_host_configuration(name: &str) -> Result<(&'static str, HostConfig
                         FileSystem {
                             device_id: Some("esp".into()),
                             mount_point: Some(MountPoint {
-                                path: constants::ESP_MOUNT_POINT_PATH.into(),
+                                path: constants::DEFAULT_ESP_MOUNT_POINT_PATH.into(),
                                 options: MountOptions::new("umask=0077"),
                             }),
                             source: FileSystemSource::Image,
@@ -998,7 +998,7 @@ pub fn sample_host_configuration(name: &str) -> Result<(&'static str, HostConfig
                         FileSystem {
                             device_id: Some("esp1".into()),
                             mount_point: Some(MountPoint {
-                                path: constants::ESP_MOUNT_POINT_PATH.into(),
+                                path: constants::DEFAULT_ESP_MOUNT_POINT_PATH.into(),
                                 options: MountOptions::new("umask=0077"),
                             }),
                             source: FileSystemSource::Image,
@@ -1213,7 +1213,7 @@ pub fn sample_host_configuration(name: &str) -> Result<(&'static str, HostConfig
                         FileSystem {
                             device_id: Some("esp1".into()),
                             mount_point: Some(MountPoint {
-                                path: constants::ESP_MOUNT_POINT_PATH.into(),
+                                path: constants::DEFAULT_ESP_MOUNT_POINT_PATH.into(),
                                 options: MountOptions::new("umask=0077"),
                             }),
                             source: FileSystemSource::Image,
@@ -1365,7 +1365,7 @@ pub fn sample_host_configuration(name: &str) -> Result<(&'static str, HostConfig
                         FileSystem {
                             device_id: Some("esp".into()),
                             mount_point: Some(MountPoint {
-                                path: constants::ESP_MOUNT_POINT_PATH.into(),
+                                path: constants::DEFAULT_ESP_MOUNT_POINT_PATH.into(),
                                 options: MountOptions::new("umask=0077"),
                             }),
                             source: FileSystemSource::Image,
@@ -1550,7 +1550,7 @@ pub fn sample_host_configuration(name: &str) -> Result<(&'static str, HostConfig
                         FileSystem {
                             device_id: Some("esp".into()),
                             mount_point: Some(MountPoint {
-                                path: constants::ESP_MOUNT_POINT_PATH.into(),
+                                path: constants::DEFAULT_ESP_MOUNT_POINT_PATH.into(),
                                 options: MountOptions::new("umask=0077"),
                             }),
                             source: FileSystemSource::Image,

--- a/report/esp-constant-usages.md
+++ b/report/esp-constant-usages.md
@@ -36,13 +36,8 @@ Summary of the complicated locations.
 | 5b    | `ESP_MOUNT_POINT_PATH`          | trident_api | [filesystem.rs:61](../crates/trident_api/src/config/host/storage/filesystem.rs#L61)               | `fs_serde` (deserialization)  | `DEFAULT_ESP_MOUNT_PATH` alias; used to detect default ESP mount during serde             | ☑️[2]   |
 | 6     | `ESP_MOUNT_POINT_PATH`          | trident     | [context/filesystem.rs:178](../crates/trident/src/engine/context/filesystem.rs#L178)              | `FileSystemData::is_esp`      | Pure method; checks if filesystem mount equals ESP path                                   | ✅      |
 | 7     | `ESP_MOUNT_POINT_PATH`          | trident     | [context/filesystem.rs:258](../crates/trident/src/engine/context/filesystem.rs#L258)              | `FileSystemDataImage::is_esp` | Pure method; checks ESP mount path equality                                               | ✅      |
-| 20    | `ESP_RELATIVE_MOUNT_POINT_PATH` | trident     | [init/offline/mod.rs:527](../crates/trident/src/init/offline/mod.rs#L527)                         | `execute`                     | Top-level offline-init command handler; no `EngineContext` in call chain                  |        |
+| 20    | `ESP_RELATIVE_MOUNT_POINT_PATH` | trident     | [init/offline/mod.rs:527](../crates/trident/src/init/offline/mod.rs#L527)                         | `execute`                     | Top-level offline-init command handler; no `EngineContext` in call chain                  | ✅      |
 | 23    | `ESP_RELATIVE_MOUNT_POINT_PATH` | trident     | [install_index.rs:15](../crates/trident/src/engine/install_index.rs#L15)                          | `next_install_index`          | Pure utility; finds install index from path                                               | ✅      |
-
-See also:
-
-- [Annex: `is_esp()` Usages](#annex-is_esp-usages) for downstream callers of the
-  `is_esp` method.
 
 ---
 
@@ -71,8 +66,8 @@ Defined in [crates/trident_api/src/constants.rs](../crates/trident_api/src/const
 | 12    | trident     | [encryption.rs:455](../crates/trident/src/engine/storage/encryption.rs#L455)                      | `get_bootloader_paths`                           | ✅   | Constructs bootloader paths in target OS during A/B update                              | ✅      |
 | 13    | trident     | [verity.rs:185](../crates/trident/src/engine/storage/verity.rs#L185)                              | `open_verity_device_with_signature`              | ✅   | Validates signature file is NOT on ESP mount point (×2 at L185, L187)                   | ✅      |
 | 14    | trident     | [image.rs:75](../crates/trident/src/engine/storage/image.rs#L75)                                  | `deploy_images`                                  | ✅   | Maps ESP filesystem in raw COSI storage mode                                            | ✅      |
-| 15    | trident     | [uki.rs:62](../crates/trident/src/engine/boot/uki.rs#L62)                                         | `stage_uki_on_esp`                               | 🔗   | UKI staging path construction; caller has `ctx`                                         |        |
-| 16    | trident     | [uki.rs:148](../crates/trident/src/engine/boot/uki.rs#L148)                                       | `prepare_esp_for_uki`                            | 🔗   | ESP preparation for UKI; caller has `ctx`                                               |        |
+| 15    | trident     | [uki.rs:62](../crates/trident/src/engine/boot/uki.rs#L62)                                         | `stage_uki_on_esp`                               | 🔗   | UKI staging path construction; caller has `ctx`                                         | ✅      |
+| 16    | trident     | [uki.rs:148](../crates/trident/src/engine/boot/uki.rs#L148)                                       | `prepare_esp_for_uki`                            | 🔗   | ESP preparation for UKI; caller has `ctx`                                               | ✅      |
 | 17    | trident     | [ab_update.rs:159](../crates/trident/src/engine/ab_update.rs#L159)                                | `finalize_update`                                | ✅   | `ctx` built locally at L144                                                             | ✅      |
 | 18    | trident     | [clean_install.rs:310](../crates/trident/src/engine/clean_install.rs#L310)                        | `finalize_clean_install`                         | ✅   | `ctx` built locally at L283                                                             | ✅      |
 
@@ -86,12 +81,12 @@ Defined in [crates/trident_api/src/constants.rs](../crates/trident_api/src/const
 
 | Item# | Crate       | Location                                                                               | Function                            | Ctx | Notes                                                                    | Status |
 | ----- | ----------- | -------------------------------------------------------------------------------------- | ----------------------------------- | --- | ------------------------------------------------------------------------ | ------ |
-| 19    | trident_api | [constants.rs:95](../crates/trident_api/src/constants.rs#L95)                          | *(const)*                           | ➖   | Used to define `ESP_MOUNT_POINT_PATH`                                    |        |
-| 20    | trident     | [init/offline/mod.rs:527](../crates/trident/src/init/offline/mod.rs#L527)              | `execute`                           | ❌   | Top-level offline-init command handler; no `EngineContext` in call chain |        |
-| 21    | trident     | [esp.rs:415](../crates/trident/src/subsystems/esp.rs#L415)                             | `copy_boot_files_for_uefi_fallback` | 🔗   | Caller `set_uefi_fallback_contents` has `ctx`                            |        |
-| 22    | trident     | [esp.rs:693](../crates/trident/src/subsystems/esp.rs#L693)                             | `generate_efi_bin_base_dir_path`    | ✅   | First param is `ctx: &EngineContext`                                     |        |
+| 19    | trident_api | [constants.rs:95](../crates/trident_api/src/constants.rs#L95)                          | *(const)*                           | ➖   | Used to define `ESP_MOUNT_POINT_PATH`                                    | ☑️      |
+| 20    | trident     | [init/offline/mod.rs:527](../crates/trident/src/init/offline/mod.rs#L527)              | `execute`                           | ❌   | Top-level offline-init command handler; no `EngineContext` in call chain | ✅      |
+| 21    | trident     | [esp.rs:415](../crates/trident/src/subsystems/esp.rs#L415)                             | `copy_boot_files_for_uefi_fallback` | 🔗   | Caller `set_uefi_fallback_contents` has `ctx`                            | ✅      |
+| 22    | trident     | [esp.rs:693](../crates/trident/src/subsystems/esp.rs#L693)                             | `generate_efi_bin_base_dir_path`    | ✅   | First param is `ctx: &EngineContext`                                     | ✅      |
 | 23    | trident     | [install_index.rs:15](../crates/trident/src/engine/install_index.rs#L15)               | `next_install_index`                | ❌   | Pure utility; finds install index from path                              | ✅      |
-| 24    | trident     | [manual_rollback/mod.rs:289](../crates/trident/src/engine/manual_rollback/mod.rs#L289) | `finalize_rollback`                 | ✅   | Param `engine_context: &EngineContext`                                   |        |
+| 24    | trident     | [manual_rollback/mod.rs:289](../crates/trident/src/engine/manual_rollback/mod.rs#L289) | `finalize_rollback`                 | ✅   | Param `engine_context: &EngineContext`                                   | ✅      |
 
 ---
 
@@ -103,7 +98,7 @@ Defined in [crates/trident_api/src/constants.rs](../crates/trident_api/src/const
 
 | Item# | Crate       | Location                                                      | Function  | Ctx | Notes                                          | Status |
 | ----- | ----------- | ------------------------------------------------------------- | --------- | --- | ---------------------------------------------- | ------ |
-| 25    | trident_api | [constants.rs:91](../crates/trident_api/src/constants.rs#L91) | *(const)* | ➖   | Used to define `ESP_RELATIVE_MOUNT_POINT_PATH` |        |
+| 25    | trident_api | [constants.rs:91](../crates/trident_api/src/constants.rs#L91) | *(const)* | ➖   | Used to define `ESP_RELATIVE_MOUNT_POINT_PATH` | ☑️      |
 
 ---
 


### PR DESCRIPTION
# 🔍 Description
 
Final PR in the series to allow for non-default ESP paths. This one gets rids of the last couple of usages of the ESP mount point path constants.

It also renames them and adds a doc comment about not using them in product code. The only remaing places where they are used:

* In HC parsing, when default behavior is desired. (only product code instance)
* In tests.
* In sample HC files.