### PR TITLE
tests: avoid scanning for test pipelines

### DIFF
--- a/.pipelines/testing-trident.yml
+++ b/.pipelines/testing-trident.yml
@@ -63,6 +63,7 @@ parameters:
 trigger: none
 
 variables:
+  # For pipelines that do not produce any production artifacts, disable CodeQL analysis
   - name: Codeql.Enabled
     value: false
   - name: CDP_DEFINITION_BUILD_COUNT

--- a/.pipelines/testing-trident.yml
+++ b/.pipelines/testing-trident.yml
@@ -96,6 +96,9 @@ resources:
       type: git
       ref: refs/heads/main
 
+variables:
+  Codeql.Enabled: false
+
 extends:
   template: templates/MockOB.yml
   parameters:

--- a/.pipelines/testing-trident.yml
+++ b/.pipelines/testing-trident.yml
@@ -63,6 +63,8 @@ parameters:
 trigger: none
 
 variables:
+  - name: Codeql.Enabled
+    value: false
   - name: CDP_DEFINITION_BUILD_COUNT
     value: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   - name: system.debug
@@ -95,9 +97,6 @@ resources:
       name: platform-telemetry
       type: git
       ref: refs/heads/main
-
-variables:
-  Codeql.Enabled: false
 
 extends:
   template: templates/MockOB.yml

--- a/.pipelines/trident-cicd-for-prism.yml
+++ b/.pipelines/trident-cicd-for-prism.yml
@@ -51,6 +51,7 @@ resources:
       ref: refs/heads/main
 
 variables:
+  # For pipelines that do not produce any production artifacts, disable CodeQL analysis
   Codeql.Enabled: false
 
 extends:

--- a/.pipelines/trident-cicd-for-prism.yml
+++ b/.pipelines/trident-cicd-for-prism.yml
@@ -50,6 +50,9 @@ resources:
       type: git
       ref: refs/heads/main
 
+variables:
+  Codeql.Enabled: false
+
 extends:
   template: templates/MockOB.yml
   parameters:

--- a/.pipelines/trident-cicd.yml
+++ b/.pipelines/trident-cicd.yml
@@ -51,6 +51,7 @@ resources:
       ref: refs/heads/main
 
 variables:
+  # For pipelines that do not produce any production artifacts, disable CodeQL analysis
   Codeql.Enabled: false
 
 extends:

--- a/.pipelines/trident-cicd.yml
+++ b/.pipelines/trident-cicd.yml
@@ -50,6 +50,9 @@ resources:
       type: git
       ref: refs/heads/main
 
+variables:
+  Codeql.Enabled: false
+
 extends:
   template: templates/MockOB.yml
   parameters:

--- a/.pipelines/trident-full-validation.yml
+++ b/.pipelines/trident-full-validation.yml
@@ -48,6 +48,9 @@ resources:
       type: git
       ref: refs/heads/main
 
+variables:
+  Codeql.Enabled: false
+
 extends:
   template: templates/MockOB.yml
   parameters:

--- a/.pipelines/trident-full-validation.yml
+++ b/.pipelines/trident-full-validation.yml
@@ -15,6 +15,8 @@ schedules:
 trigger: none
 
 variables:
+  - name: Codeql.Enabled
+    value: false
   - name: CDP_DEFINITION_BUILD_COUNT
     value: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   - name: system.debug
@@ -47,9 +49,6 @@ resources:
       name: platform-telemetry
       type: git
       ref: refs/heads/main
-
-variables:
-  Codeql.Enabled: false
 
 extends:
   template: templates/MockOB.yml

--- a/.pipelines/trident-full-validation.yml
+++ b/.pipelines/trident-full-validation.yml
@@ -15,6 +15,7 @@ schedules:
 trigger: none
 
 variables:
+  # For pipelines that do not produce any production artifacts, disable CodeQL analysis
   - name: Codeql.Enabled
     value: false
   - name: CDP_DEFINITION_BUILD_COUNT

--- a/.pipelines/trident-pr-e2e.yml
+++ b/.pipelines/trident-pr-e2e.yml
@@ -31,6 +31,9 @@ resources:
       type: git
       ref: refs/heads/main
 
+variables:
+  Codeql.Enabled: false
+
 extends:
   template: templates/MockOB.yml
   parameters:

--- a/.pipelines/trident-pr-e2e.yml
+++ b/.pipelines/trident-pr-e2e.yml
@@ -32,6 +32,7 @@ resources:
       ref: refs/heads/main
 
 variables:
+  # For pipelines that do not produce any production artifacts, disable CodeQL analysis
   Codeql.Enabled: false
 
 extends:

--- a/.pipelines/trident-scale.yml
+++ b/.pipelines/trident-scale.yml
@@ -45,6 +45,8 @@ parameters:
 trigger: none
 
 variables:
+  - name: Codeql.Enabled
+    value: false
   - name: CDP_DEFINITION_BUILD_COUNT
     value: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
   - name: system.debug
@@ -91,9 +93,6 @@ resources:
       branch: master
       tags:
         - "3.0-preview"
-
-variables:
-  Codeql.Enabled: false
 
 extends:
   template: templates/MockOB.yml

--- a/.pipelines/trident-scale.yml
+++ b/.pipelines/trident-scale.yml
@@ -92,6 +92,9 @@ resources:
       tags:
         - "3.0-preview"
 
+variables:
+  Codeql.Enabled: false
+
 extends:
   template: templates/MockOB.yml
   parameters:

--- a/.pipelines/trident-scale.yml
+++ b/.pipelines/trident-scale.yml
@@ -45,6 +45,7 @@ parameters:
 trigger: none
 
 variables:
+  # For pipelines that do not produce any production artifacts, disable CodeQL analysis
   - name: Codeql.Enabled
     value: false
   - name: CDP_DEFINITION_BUILD_COUNT


### PR DESCRIPTION
# 🔍 Description
 
In the best case, CodeQL adds 3 minutes to every job.  In the worst passing cases, it adds like 8 minutes.  For pipelines that are just testing, try to explicitly disable it.

Validated approach with prism pipeline: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1095119&view=results (vs current behavior: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1094279&view=results) ... `Create BaseImage config artifact` goes from `5m49s` to `42s`