### PR TITLE
infra: only run codeql on build jobs in trident-ci

### DIFF
--- a/.pipelines/templates/e2e-arm64-template.yml
+++ b/.pipelines/templates/e2e-arm64-template.yml
@@ -77,6 +77,9 @@ stages:
       parameters:
         architecture: arm64
         stageName: BuildingTools_arm64
+        ${{ if eq(parameters.stageType, 'ci') }}:
+          # Run CodeQL for this in CI only
+          runCodeql: true
 
     # Run direct streaming tests for arm64 with streaming images
     - template: direct-streaming-test.yml

--- a/.pipelines/templates/e2e-template.yml
+++ b/.pipelines/templates/e2e-template.yml
@@ -115,6 +115,10 @@ stages:
 
   # Build tools (Go stuff)
   - template: stages/building_tools/building-tools.yml
+    ${{ if eq(parameters.stageType, 'ci') }}:
+      parameters:
+        # Run CodeQL for this in CI only
+        runCodeql: true
 
   # E2E Test Matrix Definition
   - template: stages/testing_e2e/storm_e2e.yml
@@ -126,6 +130,9 @@ stages:
       - template: stages/validate_makefile/dev-build.yml
         parameters:
           osModifierBranch: ${{ parameters.osModifierBranch }}
+          ${{ if eq(parameters.stageType, 'ci') }}:
+            # Run CodeQL for this in CI only
+            runCodeql: true
 
   # Build FT base Image, only for CI or if forceFunctionalTestImageRebuild is true
   - ${{ if or(eq(parameters.stageType, 'ci'), eq(parameters.forceFunctionalTestImageRebuild, true)) }}:
@@ -230,6 +237,9 @@ stages:
           micBuildType: ${{ parameters.micBuildType }}
           micVersion: ${{ parameters.micVersion }}
           dependsOnStage: ${{ parameters.baseImageArtifactStage }}
+          ${{ if eq(parameters.stageType, 'ci') }}:
+            # Run CodeQL for this in CI only
+            runCodeql: true
 
   # dom0 is failing for not known reasons ... comment out for now to unblock, longterm this may
   # be removed from Trident pipelines alltogether in favor of being only test-images

--- a/.pipelines/templates/stages/azl_installer/azl-installer.yml
+++ b/.pipelines/templates/stages/azl_installer/azl-installer.yml
@@ -17,9 +17,15 @@ parameters:
     type: string
     default: ""
 
+  - name: runCodeql
+    type: boolean
+    default: false
+
 stages:
   # Build installer tools
   - template: build-installer-tools.yml
+    parameters:
+      runCodeql: ${{ parameters.runCodeql }}
 
   - stage: AzureLinux_Installer_ISO
     displayName: Build azl-installer-iso

--- a/.pipelines/templates/stages/azl_installer/build-installer-tools.yml
+++ b/.pipelines/templates/stages/azl_installer/build-installer-tools.yml
@@ -27,6 +27,8 @@ stages:
         variables:
           ob_outputDirectory: /tmp/installer-tools
           ob_artifactBaseName: installer-tools
+          # Enable CodeQL for this job as it is building code
+          ob_sdl_codeql_compiled_enabled: true
 
         steps:
           - template: ../common_tasks/checkout_trident.yml

--- a/.pipelines/templates/stages/azl_installer/build-installer-tools.yml
+++ b/.pipelines/templates/stages/azl_installer/build-installer-tools.yml
@@ -11,6 +11,10 @@ parameters:
     type: boolean
     default: true
 
+  - name: runCodeql
+    type: boolean
+    default: false
+
 stages:
   - stage: BuildInstallerTools
     displayName: Build Installer Tools
@@ -27,8 +31,9 @@ stages:
         variables:
           ob_outputDirectory: /tmp/installer-tools
           ob_artifactBaseName: installer-tools
-          # Enable CodeQL for this job as it is building code
-          ob_sdl_codeql_compiled_enabled: true
+          ${{ if parameters.runCodeql }}:
+            # Enable CodeQL for this job as it is building code
+            ob_sdl_codeql_compiled_enabled: true
 
         steps:
           - template: ../common_tasks/checkout_trident.yml

--- a/.pipelines/templates/stages/building_tools/building-tools.yml
+++ b/.pipelines/templates/stages/building_tools/building-tools.yml
@@ -64,6 +64,8 @@ stages:
             artifactName: go-tools
           ob_outputDirectory: /tmp/$(artifactName)
           ob_artifactBaseName: $(artifactName)
+          # Enable CodeQL for this job as it is building code
+          ob_sdl_codeql_compiled_enabled: true
 
         steps:
           - template: ../common_tasks/checkout_trident.yml

--- a/.pipelines/templates/stages/building_tools/building-tools.yml
+++ b/.pipelines/templates/stages/building_tools/building-tools.yml
@@ -39,6 +39,10 @@ parameters:
     type: string
     default: BuildingTools
 
+  - name: runCodeql
+    type: boolean
+    default: false
+
 stages:
   - stage: ${{ parameters.stageName }}
     displayName: Building Tools for ${{ parameters.architecture }}
@@ -46,7 +50,10 @@ stages:
     jobs:
       - job: BuildGoTools_${{ parameters.architecture }}
         displayName: Build Go Tools for ${{ parameters.architecture }}
-        timeoutInMinutes: 10
+        ${{ if parameters.runCodeql }}:
+          timeoutInMinutes: 20
+        ${{ else }}:
+          timeoutInMinutes: 10
         pool:
           ${{ if eq(parameters.architecture, 'amd64') }}:
             type: linux
@@ -64,8 +71,9 @@ stages:
             artifactName: go-tools
           ob_outputDirectory: /tmp/$(artifactName)
           ob_artifactBaseName: $(artifactName)
-          # Enable CodeQL for this job as it is building code
-          ob_sdl_codeql_compiled_enabled: true
+          ${{ if parameters.runCodeql }}:
+            # Enable CodeQL for this job as it is building code
+            ob_sdl_codeql_compiled_enabled: true
 
         steps:
           - template: ../common_tasks/checkout_trident.yml

--- a/.pipelines/templates/stages/trident_rpms/build-source.yml
+++ b/.pipelines/templates/stages/trident_rpms/build-source.yml
@@ -78,6 +78,9 @@ stages:
               type: linux
 
             variables:
+              # Enable CodeQL for this job as it is building code
+              - name: ob_sdl_codeql_compiled_enabled
+                value: true
               - name: ob_artifactBaseName
                 value: ${{ parameters.tridentArtifactName }}
               - name: ob_outputDirectory
@@ -114,6 +117,9 @@ stages:
               hostArchitecture: arm64
 
             variables:
+              # Enable CodeQL for this job as it is building code
+              - name: ob_sdl_codeql_compiled_enabled
+                value: true
               - name: ob_artifactBaseName
                 value: ${{ parameters.tridentArtifactName }}-arm64
               - name: ob_outputDirectory

--- a/.pipelines/templates/stages/trident_rpms/build-source.yml
+++ b/.pipelines/templates/stages/trident_rpms/build-source.yml
@@ -28,6 +28,10 @@ parameters:
       - preview
     default: preview
 
+  - name: runCodeql
+    type: boolean
+    default: false
+
 stages:
   - stage: GetTridentBinaries_rpms_${{ parameters.targetArchitecture }}
     displayName: Trident ${{ parameters.targetArchitecture }} RPMs (Build)
@@ -78,9 +82,10 @@ stages:
               type: linux
 
             variables:
-              # Enable CodeQL for this job as it is building code
-              - name: ob_sdl_codeql_compiled_enabled
-                value: true
+              - ${{ if parameters.runCodeql }}:
+                # Enable CodeQL for this job as it is building code
+                - name: ob_sdl_codeql_compiled_enabled
+                  value: true
               - name: ob_artifactBaseName
                 value: ${{ parameters.tridentArtifactName }}
               - name: ob_outputDirectory
@@ -117,9 +122,10 @@ stages:
               hostArchitecture: arm64
 
             variables:
-              # Enable CodeQL for this job as it is building code
-              - name: ob_sdl_codeql_compiled_enabled
-                value: true
+              - ${{ if parameters.runCodeql }}:
+                # Enable CodeQL for this job as it is building code
+                - name: ob_sdl_codeql_compiled_enabled
+                  value: true
               - name: ob_artifactBaseName
                 value: ${{ parameters.tridentArtifactName }}-arm64
               - name: ob_outputDirectory

--- a/.pipelines/templates/stages/trident_rpms/trident-stage.yml
+++ b/.pipelines/templates/stages/trident_rpms/trident-stage.yml
@@ -64,6 +64,9 @@ stages:
             osModifierBuildType: dev
           ${{ else }}:
             osModifierBuildType: preview
+          ${{ if eq(parameters.stageType, 'ci') }}:
+            # Run CodeQL for this in CI only
+            runCodeql: true
 
   - ${{ elseif and(ne(parameters.tridentBuildOptions, 'prebuilt'), eq(parameters.targetArchitecture, 'amd64')) }}:
       - template: ../download_staged/download-staged.yml

--- a/.pipelines/templates/stages/validate_makefile/dev-build.yml
+++ b/.pipelines/templates/stages/validate_makefile/dev-build.yml
@@ -74,6 +74,8 @@ stages:
 
         variables:
           ob_outputDirectory: /tmp/build
+          # Enable CodeQL for this job as it is building code
+          ob_sdl_codeql_compiled_enabled: true
 
         steps:
           - template: ../common_tasks/checkout_trident.yml

--- a/.pipelines/templates/stages/validate_makefile/dev-build.yml
+++ b/.pipelines/templates/stages/validate_makefile/dev-build.yml
@@ -7,6 +7,10 @@ parameters:
     type: string
     default: ""
 
+  - name: runCodeql
+    type: boolean
+    default: false
+
 stages:
   - stage: MakefileValidation
     displayName: Validate Makefile targets
@@ -74,8 +78,9 @@ stages:
 
         variables:
           ob_outputDirectory: /tmp/build
-          # Enable CodeQL for this job as it is building code
-          ob_sdl_codeql_compiled_enabled: true
+          ${{ if parameters.runCodeql }}:
+            # Enable CodeQL for this job as it is building code
+            ob_sdl_codeql_compiled_enabled: true
 
         steps:
           - template: ../common_tasks/checkout_trident.yml

--- a/.pipelines/trident-ci.yml
+++ b/.pipelines/trident-ci.yml
@@ -72,6 +72,10 @@ extends:
       #   suppressionFile: $(Build.SourcesDirectory)\.gdn\global.gdnsuppress
       cg:
         alertWarningLevel: Medium
+      codeql:
+        compiled:
+          # Disable CodeQL at the pipeline level, enable for jobs that build code
+          enabled: false
     featureFlags:
       runOnHost: true
       EnableCDPxPAT: false

--- a/.pipelines/trident-crate-publish.yml
+++ b/.pipelines/trident-crate-publish.yml
@@ -44,6 +44,10 @@ extends:
       disableLegacyManifest: true
       cg:
         alertWarningLevel: Medium
+      codeql:
+        compiled:
+          # Disable CodeQL at the pipeline level, enable for jobs that build code
+          enabled: false
     featureFlags:
       runOnHost: true
       EnableCDPxPAT: false

--- a/.pipelines/trident-prerelease.yml
+++ b/.pipelines/trident-prerelease.yml
@@ -69,6 +69,10 @@ extends:
       disableLegacyManifest: true
       cg:
         alertWarningLevel: Medium
+      codeql:
+        compiled:
+          # Disable CodeQL at the pipeline level, enable for jobs that build code
+          enabled: false
     featureFlags:
       runOnHost: true
       EnableCDPxPAT: false

--- a/.pipelines/trident-release.yml
+++ b/.pipelines/trident-release.yml
@@ -54,6 +54,10 @@ extends:
       disableLegacyManifest: true
       cg:
         alertWarningLevel: Medium
+      codeql:
+        compiled:
+          # Disable CodeQL at the pipeline level, enable for jobs that build code
+          enabled: false
     featureFlags:
       runOnHost: true
       EnableCDPxPAT: false

--- a/.pipelines/trident-scale-official.yml
+++ b/.pipelines/trident-scale-official.yml
@@ -136,6 +136,10 @@ extends:
       disableLegacyManifest: true
       cg:
         alertWarningLevel: Medium
+      codeql:
+        compiled:
+          # Disable CodeQL at the pipeline level, enable for jobs that build code
+          enabled: false
     featureFlags:
       runOnHost: true
       EnableCDPxPAT: false


### PR DESCRIPTION
# 🔍 Description
 
By default, for all ADO pipelines, turn off CodeQL for all jobs.

For `ci` (only) and for jobs that build Go or Rust binaries, enable CodeQL (and increase timeout if needed)


# Verification
In `ci` pipeline, CodeQL not running in `Get list of tests to run` job: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1095986&view=logs&j=86300ba0-2800-5d6c-11f4-7c7e22419b80

In `ci` pipeline, CodeQL is running in:
1. rust build: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1095986&view=logs&j=89be317f-4095-56c0-24ea-e29ca6e966ca&t=42513706-1293-5639-35ef-21aea35a424a
2. go tools build: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1095986&view=logs&j=ea3ec5e8-205e-5a49-3037-b5437b6a0316&t=42c2c88f-e293-58f4-f0e3-b7472168cc3b
3. go installer tools build: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1095986&view=logs&j=e0f757ea-c002-582b-f787-8d3de6190a31&t=3b37bfac-4724-573a-b8b0-091d1d83747b

In contrast, `prerelease`, CodeQL is not running in:
1. go tools build: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1095987&view=logs&j=ea3ec5e8-205e-5a49-3037-b5437b6a0316