### PR TITLE
tests: more coverage for grpc-client commit

### DIFF
--- a/crates/trident/src/lib.rs
+++ b/crates/trident/src/lib.rs
@@ -233,6 +233,8 @@ impl Trident {
             ));
         }
 
+        tracing::info!(metric_name = "trident_start");
+
         Ok(Self {
             host_config,
             orchestrator,

--- a/crates/trident/src/main.rs
+++ b/crates/trident/src/main.rs
@@ -143,10 +143,6 @@ fn run_trident(
                 )
                 .message("Failed to initialize Trident")?;
 
-                // After initialization, create a trace event for the purpose of
-                // measuring Trident reboot times
-                tracing::info!(metric_name = "trident_start");
-
                 let mut datastore = DataStore::open_or_create(agent_config.datastore_path())
                     .message("Failed to open datastore")?;
 

--- a/tests/images/trident-vm-testimage/base/files/use-grpc-client-commit.conf
+++ b/tests/images/trident-vm-testimage/base/files/use-grpc-client-commit.conf
@@ -1,0 +1,5 @@
+[Service]
+ExecStart=
+ExecStart=trident grpc-client commit
+StandardOutput=journal+console
+StandardError=journal+console

--- a/tests/images/trident-vm-testimage/base/updateimg-grub-verity-azure.yaml
+++ b/tests/images/trident-vm-testimage/base/updateimg-grub-verity-azure.yaml
@@ -131,6 +131,10 @@ os:
       destination: /etc/sudoers.d/wheel
     - source: files/99-dhcp-eth0.network
       destination: /etc/systemd/network/99-dhcp-eth0.network
+    # For tests, override the public trident.service behavior and use
+    # grpc-client commit.
+    - source: files/use-grpc-client-commit.conf
+      destination: /etc/systemd/system/trident.service.d/override.conf
 
   services:
     enable:

--- a/tests/images/trident-vm-testimage/base/updateimg-grub-verity.yaml
+++ b/tests/images/trident-vm-testimage/base/updateimg-grub-verity.yaml
@@ -124,6 +124,10 @@ os:
       destination: /etc/sudoers.d/wheel
     - source: files/99-dhcp-eth0.network
       destination: /etc/systemd/network/99-dhcp-eth0.network
+    # For tests, override the public trident.service behavior and use
+    # grpc-client commit.
+    - source: files/use-grpc-client-commit.conf
+      destination: /etc/systemd/system/trident.service.d/override.conf
 
   services:
     enable:

--- a/tests/images/trident-vm-testimage/base/updateimg-grub.yaml
+++ b/tests/images/trident-vm-testimage/base/updateimg-grub.yaml
@@ -68,6 +68,10 @@ os:
       destination: /etc/sudoers.d/wheel
     - source: files/99-dhcp-eth0.network
       destination: /etc/systemd/network/99-dhcp-eth0.network
+    # For tests, override the public trident.service behavior and use
+    # grpc-client commit.
+    - source: files/use-grpc-client-commit.conf
+      destination: /etc/systemd/system/trident.service.d/override.conf
 
 scripts:
   postCustomization:


### PR DESCRIPTION
# 🔍 Description
 
Update test image configurations to create trident-service override that overrides the standard `trident commit` call with `trident grpc-client commit`.

Our tests currently validate the trident_start metric, so moving this into Trident::new so that CLI commands and grpc-client commands emit it.

Related PR in test-images: https://dev.azure.com/mariner-org/ECF/_git/test-images/pullrequest/26819

Validation: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1096766&view=results