### PR TITLE
engineering: populate spec with local version during build

### DIFF
--- a/packaging/docker/Dockerfile.azl3
+++ b/packaging/docker/Dockerfile.azl3
@@ -16,6 +16,8 @@ ARG RPM_VER=0.1.0
 ARG RPM_REL=1
 
 RUN \
+    sed -i "s/^Version:.*/Version:        $RPM_VER/" trident.spec && \
+    sed -i "s/^Release:.*/Release:        $RPM_REL/" trident.spec && \
     sed -i "s/cargo build/#cargo build/g" trident.spec && \
     rpmbuild -bb --build-in-place trident.spec \
     --define="trident_version $TRIDENT_VERSION" \

--- a/packaging/docker/Dockerfile.full
+++ b/packaging/docker/Dockerfile.full
@@ -29,6 +29,8 @@ RUN if [ "$CARGO_REGISTRIES_FROM_ENV" = "true" ]; then \
 
 RUN --mount=type=secret,id=registry_token \
     export CARGO_REGISTRIES_BMP_PUBLICPACKAGES_TOKEN=$(cat /run/secrets/registry_token) && \
+    sed -i "s/^Version:.*/Version:        $RPM_VER/" trident.spec && \
+    sed -i "s/^Release:.*/Release:        $RPM_REL/" trident.spec && \
     rpmbuild -bb --build-in-place trident.spec \
     --define="trident_version $TRIDENT_VERSION" \
     --define="rpm_ver $RPM_VER" \

--- a/packaging/docker/Dockerfile.full.public
+++ b/packaging/docker/Dockerfile.full.public
@@ -20,7 +20,9 @@ ARG TRIDENT_VERSION=dev-build
 ARG RPM_VER=0.1.0
 ARG RPM_REL=1
 
-RUN rpmbuild -bb --build-in-place trident.spec \
+RUN sed -i "s/^Version:.*/Version:        $RPM_VER/" trident.spec && \
+    sed -i "s/^Release:.*/Release:        $RPM_REL/" trident.spec && \
+    rpmbuild -bb --build-in-place trident.spec \
     --define="trident_version $TRIDENT_VERSION" \
     --define="rpm_ver $RPM_VER" \
     --define="rpm_rel $RPM_REL" && \

--- a/packaging/rpm/trident.spec
+++ b/packaging/rpm/trident.spec
@@ -1,8 +1,13 @@
 # This spec file is used for both the Trident repo builds and as the
-# basis for the azurelinux build. For the Trident repo builds, `rpm_ver`
-# is defined, dictating the build version. If `rpm_ver` is undefined,
-# the spec defines the azurelinux distro build (using source and vendor
-# tarballs, etc)
+# basis for the azurelinux build.
+# For the Trident repo builds:
+#   1. Version & Release are modified at build time to reflect
+#      the current cargo version, date, and git commit.
+#   2. `rpm_ver`is defined, dictating the various RPM build
+#      conditional logic.
+# For azurelinux distro builds:
+#   1. `rpm_ver` is undefined, the build will using source and
+#      vendor tarballs, etc.
 
 %global selinuxtype targeted
 


### PR DESCRIPTION
# 🔍 Description
 
Repo trident.spec is hardcoded with versioning that is used to create rpm filenames. This was previously related to the current cargo version + date + commit. Restore that by modifying our containerized RPM builds to update the hardcoded spec version/release with local build details (cargo version, date, commit).

Validation: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1096931&view=results