### PR TITLE
infra: virtdeploy: Extension for ACL images

### DIFF
--- a/tools/cmd/virtdeploy/main.go
+++ b/tools/cmd/virtdeploy/main.go
@@ -57,18 +57,20 @@ func (c *CleanCmd) Run() error {
 }
 
 type CreateOneCmd struct {
-	Namespace    string `group:"Resource" short:"n" long:"namespace" help:"Namespace to create resources in" default:"${DEFAULT_NAMESPACE}"`
-	Network      string `group:"Resource" short:"N" long:"network" help:"Network to create resources in" default:"${DEFAULT_NETWORK}"`
-	CPUs         uint   `group:"VM" short:"c" long:"cpus" help:"Number of CPUs for the VM" default:"4"`
-	Mem          uint   `group:"VM" short:"m" long:"mem" help:"Memory in GB for the VM" default:"6"`
-	Disks        []uint `group:"VM" short:"d" long:"disk" help:"Disk sizes in GB for the VM" default:"32"`
-	NoSecureBoot bool   `group:"VM" long:"no-secure-boot" help:"Disable secure boot"`
-	NoTpm        bool   `group:"VM" long:"no-tpm" help:"Disable emulated TPM"`
-	OsDisk       string `group:"VM" long:"os-disk" help:"Optional path to an OS disk image to attach to the first disk"`
-	CiUser       string `group:"cloud-init" and:"ci-meta" long:"ci-user" help:"Cloud-init userdata file path" type:"existingfile"`
-	CiMeta       string `group:"cloud-init" and:"ci-user" long:"ci-meta" help:"Cloud-init metadata file path" type:"existingfile"`
-	Json         bool   `group:"Output" short:"J" long:"json" help:"Output resource data as JSON to stdout."`
-	Netlaunch    string `group:"Output" short:"l" long:"netlaunch" type:"path" help:"Produce a netlaunch YAML at the given path" default:"./tools/vm-netlaunch.yaml"`
+	Namespace          string `group:"Resource" short:"n" long:"namespace" help:"Namespace to create resources in" default:"${DEFAULT_NAMESPACE}"`
+	Network            string `group:"Resource" short:"N" long:"network" help:"Network to create resources in" default:"${DEFAULT_NETWORK}"`
+	CPUs               uint   `group:"VM" short:"c" long:"cpus" help:"Number of CPUs for the VM" default:"4"`
+	Mem                uint   `group:"VM" short:"m" long:"mem" help:"Memory in GB for the VM" default:"6"`
+	Disks              []uint `group:"VM" short:"d" long:"disk" help:"Disk sizes in GB for the VM" default:"32"`
+	NoSecureBoot       bool   `group:"VM" long:"no-secure-boot" help:"Disable secure boot"`
+	NoTpm              bool   `group:"VM" long:"no-tpm" help:"Disable emulated TPM"`
+	OsDisk             string `group:"VM" long:"os-disk" help:"Optional path to an OS disk image to attach to the first disk"`
+	CiUser             string `group:"cloud-init" and:"ci-meta" long:"ci-user" help:"Cloud-init userdata file path" type:"existingfile"`
+	CiMeta             string `group:"cloud-init" and:"ci-user" long:"ci-meta" help:"Cloud-init metadata file path" type:"existingfile"`
+	Json               bool   `group:"Output" short:"J" long:"json" help:"Output resource data as JSON to stdout."`
+	Netlaunch          string `group:"Output" short:"l" long:"netlaunch" type:"path" help:"Produce a netlaunch YAML at the given path" default:"./tools/vm-netlaunch.yaml"`
+	IgnitionConfigPath string `group:"Ignition" long:"ignition-config" help:"Path to an Ignition config file to pass to the VM"`
+	Start              bool   `group:"VM" short:"s" long:"start" help:"Start the VM after creating it"`
 }
 
 func (c *CreateOneCmd) Run() error {
@@ -99,16 +101,18 @@ func (c *CreateOneCmd) Run() error {
 		Namespace:    c.Namespace,
 		IPNet:        *network,
 		NatInterface: virtdeploy.AutoDetectNatInterface,
+		StartVMs:     c.Start,
 		VMs: []virtdeploy.VirtDeployVM{
 			{
-				Cpus:        c.CPUs,
-				Mem:         c.Mem,
-				Disks:       c.Disks,
-				SecureBoot:  !c.NoSecureBoot,
-				EmulatedTPM: !c.NoTpm,
-				OsDiskPath:  c.OsDisk,
-				CloudInit:   cloudInitConfig,
-				Arch:        runtime.GOARCH,
+				Cpus:               c.CPUs,
+				Mem:                c.Mem,
+				Disks:              c.Disks,
+				SecureBoot:         !c.NoSecureBoot,
+				EmulatedTPM:        !c.NoTpm,
+				OsDiskPath:         c.OsDisk,
+				CloudInit:          cloudInitConfig,
+				Arch:               runtime.GOARCH,
+				IgnitionConfigPath: c.IgnitionConfigPath,
 			},
 		},
 	})

--- a/tools/cmd/virtdeploy/main.go
+++ b/tools/cmd/virtdeploy/main.go
@@ -35,6 +35,7 @@ func main() {
 		kong.Vars{
 			"DEFAULT_NAMESPACE": DEFAULT_NAMESPACE,
 			"DEFAULT_NETWORK":   DEFAULT_NETWORK,
+			"GOARCH":            runtime.GOARCH,
 		},
 	)
 	log.SetLevel(cli.Verbosity)
@@ -71,6 +72,7 @@ type CreateOneCmd struct {
 	Netlaunch          string `group:"Output" short:"l" long:"netlaunch" type:"path" help:"Produce a netlaunch YAML at the given path" default:"./tools/vm-netlaunch.yaml"`
 	IgnitionConfigPath string `group:"Ignition" long:"ignition-config" help:"Path to an Ignition config file to pass to the VM"`
 	Start              bool   `group:"VM" short:"s" long:"start" help:"Start the VM after creating it"`
+	Arch               string `group:"VM" long:"arch" help:"Architecture of the VM (amd64 or arm64)" default:"${GOARCH}"`
 }
 
 func (c *CreateOneCmd) Run() error {
@@ -111,7 +113,7 @@ func (c *CreateOneCmd) Run() error {
 				EmulatedTPM:        !c.NoTpm,
 				OsDiskPath:         c.OsDisk,
 				CloudInit:          cloudInitConfig,
-				Arch:               runtime.GOARCH,
+				Arch:               c.Arch,
 				IgnitionConfigPath: c.IgnitionConfigPath,
 			},
 		},

--- a/tools/pkg/virtdeploy/config.go
+++ b/tools/pkg/virtdeploy/config.go
@@ -23,6 +23,9 @@ type VirtDeployConfig struct {
 
 	// List of VMs to create
 	VMs []VirtDeployVM
+
+	// Start the VMs after creation
+	StartVMs bool
 }
 
 func (c VirtDeployConfig) validate() error {
@@ -74,6 +77,12 @@ type VirtDeployVM struct {
 	nvramFile string
 	nvramPath string
 
+	// Ignition config file volume path
+	ignitionVolume string
+
+	// Network name to attach the VM to
+	networkName string
+
 	// Final domain definition at creation time
 	domainDefinition *libvirtxml.Domain
 
@@ -103,6 +112,9 @@ type VirtDeployVM struct {
 
 	// Architecture of the VM (amd64 or arm64)
 	Arch string
+
+	// Ignition config file to pass to the VM (for ACL)
+	IgnitionConfigPath string
 }
 
 func (vm VirtDeployVM) validate() error {

--- a/tools/pkg/virtdeploy/config.go
+++ b/tools/pkg/virtdeploy/config.go
@@ -139,6 +139,31 @@ func (vm VirtDeployVM) validate() error {
 		}
 	}
 
+	if vm.CloudInit != nil {
+		if vm.CloudInit.Userdata == "" {
+			return fmt.Errorf("cloud-init user file path must be specified if cloud-init config is provided")
+		}
+		if vm.CloudInit.Metadata == "" {
+			return fmt.Errorf("cloud-init metadata file path must be specified if cloud-init config is provided")
+		}
+		if _, err := os.Stat(vm.CloudInit.Userdata); err != nil {
+			return fmt.Errorf("cloud-init user file path is invalid: %w", err)
+		}
+		if _, err := os.Stat(vm.CloudInit.Metadata); err != nil {
+			return fmt.Errorf("cloud-init metadata file path is invalid: %w", err)
+		}
+	}
+
+	if vm.Arch != "amd64" && vm.Arch != "arm64" {
+		return fmt.Errorf("unsupported architecture '%s'", vm.Arch)
+	}
+
+	if vm.IgnitionConfigPath != "" {
+		if _, err := os.Stat(vm.IgnitionConfigPath); err != nil {
+			return fmt.Errorf("ignition config path is invalid: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/tools/pkg/virtdeploy/config.go
+++ b/tools/pkg/virtdeploy/config.go
@@ -111,6 +111,7 @@ type VirtDeployVM struct {
 	EmulatedTPM bool
 
 	// Architecture of the VM (amd64 or arm64)
+	// Defaults to the architecture of the host if not specified.
 	Arch string
 
 	// Ignition config file to pass to the VM (for ACL)

--- a/tools/pkg/virtdeploy/resources.go
+++ b/tools/pkg/virtdeploy/resources.go
@@ -30,6 +30,7 @@ type virtDeployResourceConfig struct {
 	nvramPool storagePool
 	vms       []VirtDeployVM
 	lv        *libvirt.Libvirt
+	startVms  bool
 }
 
 func newVirtDeployResourceConfig(config VirtDeployConfig) (*virtDeployResourceConfig, error) {
@@ -65,6 +66,7 @@ func newVirtDeployResourceConfig(config VirtDeployConfig) (*virtDeployResourceCo
 		nvramPool: nvramPool,
 		vms:       config.VMs,
 		lv:        lvConn,
+		startVms:  config.StartVMs,
 	}
 
 	// Initialize all VMs
@@ -77,8 +79,13 @@ func newVirtDeployResourceConfig(config VirtDeployConfig) (*virtDeployResourceCo
 			return nil, fmt.Errorf("lease IP for VM %s: %w", vm.name, err)
 		}
 		vm.ipAddr = lease
+		vm.networkName = r.network.name
 
 		vm.nvramFile = fmt.Sprintf("%s_VARS.fd", vm.name)
+
+		if vm.IgnitionConfigPath != "" {
+			vm.ignitionVolume = fmt.Sprintf("%s_ignition.ign", vm.name)
+		}
 
 		if vm.SecureBoot {
 			if vm.isArm64() {
@@ -499,6 +506,24 @@ func (rc *virtDeployResourceConfig) setupVm(vm *VirtDeployVM) error {
 		return fmt.Errorf("upload NVRAM template to volume: %w", err)
 	}
 
+	// Set up ignition volume if needed
+	if vm.ignitionVolume != "" {
+		ignVol := newSimpleVolumeMode(vm.ignitionVolume, 0, "raw", "0644")
+		err = rc.setupVolume(&ignVol, rc.pool)
+		if err != nil {
+			return fmt.Errorf("setup ignition volume: %w", err)
+		}
+
+		// Update the VM's ignition volume path to the created volume's path
+		vm.ignitionVolume = ignVol.path
+
+		log.Debugf("Uploading Ignition config from %s to %s", vm.IgnitionConfigPath, ignVol.path)
+		err = rc.uploadFileToVolume(ignVol.lvVol, vm.IgnitionConfigPath)
+		if err != nil {
+			return fmt.Errorf("upload Ignition config to volume: %w", err)
+		}
+	}
+
 	for i := range vm.volumes {
 		vol := &vm.volumes[i]
 		diskDevicePrefix := "sd"
@@ -573,7 +598,7 @@ func (rc *virtDeployResourceConfig) setupVm(vm *VirtDeployVM) error {
 	}
 
 	// Generate the final domain definition, and store it in the VM struct
-	domainXML, err := vm.asXml(rc.network, rc.nvramPool)
+	domainXML, err := vm.asXml()
 	if err != nil {
 		return fmt.Errorf("failed to produce domain XML: %w", err)
 	}
@@ -604,6 +629,15 @@ func (rc *virtDeployResourceConfig) setupVm(vm *VirtDeployVM) error {
 	}
 
 	log.Infof("Created domain '%s'", vm.name)
+
+	if rc.startVms {
+		err = rc.lv.DomainCreate(vm.domain)
+		if err != nil {
+			return fmt.Errorf("start domain: %w", err)
+		}
+
+		log.Infof("Started domain '%s'", vm.name)
+	}
 
 	return nil
 }

--- a/tools/pkg/virtdeploy/virtdeploy.go
+++ b/tools/pkg/virtdeploy/virtdeploy.go
@@ -1,8 +1,18 @@
 package virtdeploy
 
-import "fmt"
+import (
+	"fmt"
+	"runtime"
+)
 
 func CreateResources(config VirtDeployConfig) (*VirtDeployStatus, error) {
+	// Initialize VM architecture to host architecture if not set
+	for i := range config.VMs {
+		if config.VMs[i].Arch == "" {
+			config.VMs[i].Arch = runtime.GOARCH
+		}
+	}
+
 	err := config.validate()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize config: %w", err)

--- a/tools/pkg/virtdeploy/vm.go
+++ b/tools/pkg/virtdeploy/vm.go
@@ -16,11 +16,11 @@ func (vm *VirtDeployVM) isArm64() bool {
 // It translates the earlier XML template into structured Go objects.
 // Some low-level address/controller elements are omitted for brevity; libvirt
 // will auto-assign them. Extend if deterministic addressing is required.
-func (vm *VirtDeployVM) asXml(network *virtDeployNetwork, nvramPool storagePool) (string, error) {
+func (vm *VirtDeployVM) asXml() (string, error) {
 	if vm.isArm64() {
-		return vm.asArm64Xml(network, nvramPool)
+		return vm.asArm64Xml()
 	}
-	return vm.asAmd64Xml(network, nvramPool)
+	return vm.asAmd64Xml()
 }
 
 func (vm *VirtDeployVM) configureDisks() []libvirtxml.DomainDisk {
@@ -102,7 +102,6 @@ func (vm *VirtDeployVM) configureTpms() []libvirtxml.DomainTPM {
 }
 
 func (vm *VirtDeployVM) createDomain(
-	network *virtDeployNetwork, nvramPool storagePool,
 	domainType string,
 	osType libvirtxml.DomainOSType,
 	cpuModel libvirtxml.DomainCPUModel,
@@ -114,6 +113,27 @@ func (vm *VirtDeployVM) createDomain(
 	vmPort *libvirtxml.DomainFeatureState,
 	controllers []libvirtxml.DomainController,
 ) libvirtxml.Domain {
+	var networkInterfaces []libvirtxml.DomainInterface
+	if vm.networkName != "" {
+		networkInterfaces = []libvirtxml.DomainInterface{{
+			Model: &libvirtxml.DomainInterfaceModel{Type: "virtio"},
+			MAC:   &libvirtxml.DomainInterfaceMAC{Address: vm.mac.String()},
+			Source: &libvirtxml.DomainInterfaceSource{
+				Network: &libvirtxml.DomainInterfaceSourceNetwork{
+					Network: vm.networkName,
+				},
+			},
+		}}
+	}
+
+	var qemuExtraArgs []libvirtxml.DomainQEMUCommandlineArg
+	if vm.ignitionVolume != "" {
+		qemuExtraArgs = []libvirtxml.DomainQEMUCommandlineArg{
+			{Value: "-fw_cfg"},
+			{Value: fmt.Sprintf("name=opt/org.flatcar-linux/config,file=%s", vm.ignitionVolume)},
+		}
+	}
+
 	return libvirtxml.Domain{
 		Type:   domainType,
 		Name:   vm.name,
@@ -158,15 +178,7 @@ func (vm *VirtDeployVM) createDomain(
 			Emulator:    emulator,
 			Disks:       vm.configureDisks(),
 			Controllers: controllers,
-			Interfaces: []libvirtxml.DomainInterface{{
-				Model: &libvirtxml.DomainInterfaceModel{Type: "virtio"},
-				MAC:   &libvirtxml.DomainInterfaceMAC{Address: vm.mac.String()},
-				Source: &libvirtxml.DomainInterfaceSource{
-					Network: &libvirtxml.DomainInterfaceSourceNetwork{
-						Network: network.name,
-					},
-				},
-			}},
+			Interfaces:  networkInterfaces,
 			Consoles: []libvirtxml.DomainConsole{{
 				Source: &libvirtxml.DomainChardevSource{
 					Pty: &libvirtxml.DomainChardevSourcePty{},
@@ -183,6 +195,22 @@ func (vm *VirtDeployVM) createDomain(
 				},
 			}},
 			Inputs: []libvirtxml.DomainInput{{Type: "tablet", Bus: "usb"}},
+			Graphics: []libvirtxml.DomainGraphic{{
+				Spice: &libvirtxml.DomainGraphicSpice{
+					Port:     -1,
+					TLSPort:  -1,
+					AutoPort: "yes",
+					Image: &libvirtxml.DomainGraphicSpiceImage{
+						Compression: "off",
+					},
+				},
+			}},
+			Sounds: []libvirtxml.DomainSound{{
+				Model: "ich6",
+			}},
+			Videos: []libvirtxml.DomainVideo{{
+				Model: libvirtxml.DomainVideoModel{Type: "qxl"},
+			}},
 			RedirDevs: []libvirtxml.DomainRedirDev{
 				{Bus: "usb", Source: &libvirtxml.DomainChardevSource{
 					SpiceVMC: &libvirtxml.DomainChardevSourceSpiceVMC{},
@@ -202,14 +230,18 @@ func (vm *VirtDeployVM) createDomain(
 			}},
 			TPMs: vm.configureTpms(),
 		},
+		QEMUCommandline: &libvirtxml.DomainQEMUCommandline{
+			Args: qemuExtraArgs,
+		},
+		SecLabel: []libvirtxml.DomainSecLabel{
+			{Type: "none"},
+		},
 	}
 }
 
-func (vm *VirtDeployVM) asAmd64Xml(network *virtDeployNetwork, nvramPool storagePool) (string, error) {
+func (vm *VirtDeployVM) asAmd64Xml() (string, error) {
 	// AMD64-specific domain XML
 	dom := vm.createDomain(
-		network,
-		nvramPool,
 		"kvm",
 		libvirtxml.DomainOSType{Arch: "x86_64", Machine: "q35", Type: "hvm"},
 		libvirtxml.DomainCPUModel{Fallback: "allow", Value: "Broadwell-IBRS"},
@@ -253,11 +285,9 @@ func (vm *VirtDeployVM) asAmd64Xml(network *virtDeployNetwork, nvramPool storage
 	return xml, nil
 }
 
-func (vm *VirtDeployVM) asArm64Xml(network *virtDeployNetwork, nvramPool storagePool) (string, error) {
+func (vm *VirtDeployVM) asArm64Xml() (string, error) {
 	// ARM64-specific domain XML
 	dom := vm.createDomain(
-		network,
-		nvramPool,
 		"qemu",
 		libvirtxml.DomainOSType{Arch: "aarch64", Machine: "virt-6.2", Type: "hvm"},
 		libvirtxml.DomainCPUModel{Fallback: "forbid", Value: "cortex-a57"},

--- a/tools/pkg/virtdeploy/vm.go
+++ b/tools/pkg/virtdeploy/vm.go
@@ -7,22 +7,333 @@ import (
 	"libvirt.org/go/libvirtxml"
 )
 
-// Helper to check VM architecture
-func (vm *VirtDeployVM) isArm64() bool {
-	return vm.Arch == "arm64"
-}
-
 // asXml renders the libvirt domain XML corresponding to the VM definition.
 // It translates the earlier XML template into structured Go objects.
 // Some low-level address/controller elements are omitted for brevity; libvirt
 // will auto-assign them. Extend if deterministic addressing is required.
 func (vm *VirtDeployVM) asXml() (string, error) {
-	if vm.isArm64() {
-		return vm.asArm64Xml()
+	dom := vm.createDomain()
+	xml, err := dom.Marshal()
+	if err != nil {
+		return "", fmt.Errorf("marshal domain to XML: %w", err)
 	}
-	return vm.asAmd64Xml()
+	return xml, nil
 }
 
+// createDomain assembles the full libvirt Domain struct from the VM's
+// configuration. Each arch-dependent field is populated by a dedicated
+// configure method.
+func (vm *VirtDeployVM) createDomain() libvirtxml.Domain {
+	var networkInterfaces []libvirtxml.DomainInterface
+	if vm.networkName != "" {
+		networkInterfaces = []libvirtxml.DomainInterface{{
+			Model: &libvirtxml.DomainInterfaceModel{Type: "virtio"},
+			MAC:   &libvirtxml.DomainInterfaceMAC{Address: vm.mac.String()},
+			Source: &libvirtxml.DomainInterfaceSource{
+				Network: &libvirtxml.DomainInterfaceSourceNetwork{
+					Network: vm.networkName,
+				},
+			},
+		}}
+	}
+
+	var secLabels []libvirtxml.DomainSecLabel
+	var qemuExtraArgs []libvirtxml.DomainQEMUCommandlineArg
+	if vm.ignitionVolume != "" {
+		qemuExtraArgs = []libvirtxml.DomainQEMUCommandlineArg{
+			{Value: "-fw_cfg"},
+			{Value: fmt.Sprintf("name=opt/org.flatcar-linux/config,file=%s", vm.ignitionVolume)},
+		}
+
+		// If we're passing an Ignition config, we need to disable apparmor
+		// isolation to allow QEMU to read the config file from the host
+		// filesystem.
+		secLabels = []libvirtxml.DomainSecLabel{
+			{Type: "none"},
+		}
+	}
+
+	osType := vm.configureOSType()
+	cpuModel := vm.configureCPUModel()
+
+	return libvirtxml.Domain{
+		Type:   vm.configureDomainType(),
+		Name:   vm.name,
+		Memory: &libvirtxml.DomainMemory{Unit: "GiB", Value: vm.Mem},
+		VCPU:   &libvirtxml.DomainVCPU{Value: vm.Cpus},
+		OS: &libvirtxml.DomainOS{
+
+			Type:   &osType,
+			SMBios: &libvirtxml.DomainSMBios{Mode: "sysinfo"},
+			Loader: &libvirtxml.DomainLoader{Path: vm.firmwareLoaderPath, Type: "pflash", Readonly: "yes"},
+			NVRam: &libvirtxml.DomainNVRam{
+				NVRam:    vm.nvramPath,
+				Template: vm.firmwareVarsTemplatePath,
+			},
+		},
+		SysInfo: []libvirtxml.DomainSysInfo{
+			{
+				SMBIOS: &libvirtxml.DomainSysInfoSMBIOS{
+					OEMStrings: &libvirtxml.DomainSysInfoOEMStrings{
+						Entry: []string{"virtdeploy:1"},
+					},
+				},
+			},
+		},
+		Features: &libvirtxml.DomainFeatureList{
+			ACPI:   &libvirtxml.DomainFeature{},
+			APIC:   vm.configureAPIC(),
+			VMPort: vm.configureVMPort(),
+		},
+		CPU: &libvirtxml.DomainCPU{
+			Match:    "exact",
+			Check:    "none",
+			Model:    &cpuModel,
+			Features: vm.configureCPUFeatures(),
+		},
+		Clock: &libvirtxml.DomainClock{
+			Offset: "utc",
+			Timer:  vm.configureTimers(),
+		},
+		PM: vm.configurePM(),
+		Devices: &libvirtxml.DomainDeviceList{
+			Emulator:    vm.configureEmulator(),
+			Disks:       vm.configureDisks(),
+			Controllers: vm.configureControllers(),
+			Interfaces:  networkInterfaces,
+			Consoles: []libvirtxml.DomainConsole{{
+				Source: &libvirtxml.DomainChardevSource{
+					Pty: &libvirtxml.DomainChardevSourcePty{},
+				},
+			}},
+			Channels:  vm.configureChannels(),
+			Inputs:    []libvirtxml.DomainInput{{Type: "tablet", Bus: "usb"}},
+			Graphics:  vm.configureGraphics(),
+			Sounds:    vm.configureSounds(),
+			Videos:    vm.configureVideos(),
+			RedirDevs: vm.configureRedirDevs(),
+			Serials: []libvirtxml.DomainSerial{{
+				Source: &libvirtxml.DomainChardevSource{
+					Pty: &libvirtxml.DomainChardevSourcePty{
+						Path: "/dev/pts/2",
+					},
+				},
+				Target: &libvirtxml.DomainSerialTarget{Port: new(uint)},
+				Log:    &libvirtxml.DomainChardevLog{File: fmt.Sprintf("/tmp/%s-serial0.log", vm.name), Append: "off"},
+			}},
+			TPMs: vm.configureTpms(),
+		},
+		QEMUCommandline: &libvirtxml.DomainQEMUCommandline{
+			Args: qemuExtraArgs,
+		},
+		SecLabel: secLabels,
+	}
+}
+
+// isArm64 reports whether the VM targets the ARM64 architecture.
+func (vm *VirtDeployVM) isArm64() bool {
+	return vm.Arch == "arm64"
+}
+
+// configureChannels returns SPICE channels for AMD64 VMs only.
+// ARM64's virt machine type does not support SPICE, so no channels are needed.
+func (vm *VirtDeployVM) configureChannels() []libvirtxml.DomainChannel {
+	if vm.isArm64() {
+		return nil
+	}
+	return []libvirtxml.DomainChannel{{
+		Source: &libvirtxml.DomainChardevSource{
+			SpiceVMC: &libvirtxml.DomainChardevSourceSpiceVMC{},
+		},
+		Target: &libvirtxml.DomainChannelTarget{
+			VirtIO: &libvirtxml.DomainChannelTargetVirtIO{
+				Name: "com.redhat.spice.0",
+			},
+		},
+	}}
+}
+
+// configureGraphics returns SPICE graphics for AMD64 VMs only.
+// ARM64's virt machine type does not support SPICE graphics.
+func (vm *VirtDeployVM) configureGraphics() []libvirtxml.DomainGraphic {
+	if vm.isArm64() {
+		return nil
+	}
+	return []libvirtxml.DomainGraphic{{
+		Spice: &libvirtxml.DomainGraphicSpice{
+			Port:     -1,
+			TLSPort:  -1,
+			AutoPort: "yes",
+			Image: &libvirtxml.DomainGraphicSpiceImage{
+				Compression: "off",
+			},
+		},
+	}}
+}
+
+// configureSounds returns sound devices for AMD64 VMs only.
+// The ich6 sound device is not available on ARM64's virt machine type.
+func (vm *VirtDeployVM) configureSounds() []libvirtxml.DomainSound {
+	if vm.isArm64() {
+		return nil
+	}
+	return []libvirtxml.DomainSound{{Model: "ich6"}}
+}
+
+// configureVideos returns QXL video for AMD64 VMs only.
+// The QXL video device is not supported on ARM64's virt machine type.
+func (vm *VirtDeployVM) configureVideos() []libvirtxml.DomainVideo {
+	if vm.isArm64() {
+		return nil
+	}
+	return []libvirtxml.DomainVideo{{
+		Model: libvirtxml.DomainVideoModel{Type: "qxl"},
+	}}
+}
+
+// configureRedirDevs returns SPICE USB redirect devices for AMD64 VMs only.
+// These require SPICE graphics which are not available on ARM64.
+func (vm *VirtDeployVM) configureRedirDevs() []libvirtxml.DomainRedirDev {
+	if vm.isArm64() {
+		return nil
+	}
+	return []libvirtxml.DomainRedirDev{
+		{Bus: "usb", Source: &libvirtxml.DomainChardevSource{
+			SpiceVMC: &libvirtxml.DomainChardevSourceSpiceVMC{},
+		}},
+		{Bus: "usb", Source: &libvirtxml.DomainChardevSource{
+			SpiceVMC: &libvirtxml.DomainChardevSourceSpiceVMC{},
+		}},
+	}
+}
+
+// configureDomainType returns the libvirt domain type.
+// AMD64 uses KVM (hardware-accelerated). ARM64 uses plain QEMU (TCG) because
+// we cross-compile on an x86 host where KVM is not available for aarch64.
+func (vm *VirtDeployVM) configureDomainType() string {
+	if vm.isArm64() {
+		return "qemu"
+	}
+	return "kvm"
+}
+
+// configureOSType returns the OS type element for the domain.
+// AMD64 uses the q35 machine type (modern Intel chipset with PCIe).
+// ARM64 uses the virt-6.2 machine type (minimal ARM virtual platform).
+func (vm *VirtDeployVM) configureOSType() libvirtxml.DomainOSType {
+	if vm.isArm64() {
+		return libvirtxml.DomainOSType{Arch: "aarch64", Machine: "virt-6.2", Type: "hvm"}
+	}
+	return libvirtxml.DomainOSType{Arch: "x86_64", Machine: "q35", Type: "hvm"}
+}
+
+// configureCPUModel returns the CPU model for the domain.
+// AMD64 uses Broadwell-IBRS (widely compatible Intel model with Spectre mitigations).
+// ARM64 uses cortex-a57 with fallback=forbid (must match exactly since TCG
+// emulation requires a specific ARM core model).
+func (vm *VirtDeployVM) configureCPUModel() libvirtxml.DomainCPUModel {
+	if vm.isArm64() {
+		return libvirtxml.DomainCPUModel{Fallback: "forbid", Value: "cortex-a57"}
+	}
+	return libvirtxml.DomainCPUModel{Fallback: "allow", Value: "Broadwell-IBRS"}
+}
+
+// configureCPUFeatures returns required CPU features.
+// AMD64 requires VMX (nested virtualization support).
+// ARM64 has no additional CPU feature requirements.
+func (vm *VirtDeployVM) configureCPUFeatures() []libvirtxml.DomainCPUFeature {
+	if vm.isArm64() {
+		return nil
+	}
+	return []libvirtxml.DomainCPUFeature{{Policy: "require", Name: "vmx"}}
+}
+
+// configurePM returns power management settings.
+// AMD64 explicitly disables suspend-to-mem and suspend-to-disk.
+// ARM64's virt machine does not support ACPI power management.
+func (vm *VirtDeployVM) configurePM() *libvirtxml.DomainPM {
+	if vm.isArm64() {
+		return nil
+	}
+	return &libvirtxml.DomainPM{
+		SuspendToMem:  &libvirtxml.DomainPMPolicy{Enabled: "no"},
+		SuspendToDisk: &libvirtxml.DomainPMPolicy{Enabled: "no"},
+	}
+}
+
+// configureTimers returns clock timer configuration.
+// AMD64 configures RTC, PIT, and HPET timers (standard x86 timer stack).
+// ARM64 uses the ARM architectural timer (built-in), so no explicit timers are needed.
+func (vm *VirtDeployVM) configureTimers() []libvirtxml.DomainTimer {
+	if vm.isArm64() {
+		return nil
+	}
+	return []libvirtxml.DomainTimer{
+		{Name: "rtc", TickPolicy: "catchup"},
+		{Name: "pit", TickPolicy: "delay"},
+		{Name: "hpet", Present: "no"},
+	}
+}
+
+// configureEmulator returns the path to the QEMU binary for the target architecture.
+func (vm *VirtDeployVM) configureEmulator() string {
+	if vm.isArm64() {
+		return "/usr/bin/qemu-system-aarch64"
+	}
+	return "/usr/bin/qemu-system-x86_64"
+}
+
+// configureAPIC returns the APIC feature for AMD64 VMs.
+// APIC is an x86-specific interrupt controller; ARM64 uses GIC instead,
+// which is implicitly configured by the virt machine type.
+func (vm *VirtDeployVM) configureAPIC() *libvirtxml.DomainFeatureAPIC {
+	if vm.isArm64() {
+		return nil
+	}
+	return &libvirtxml.DomainFeatureAPIC{}
+}
+
+// configureVMPort returns the VMware port feature state.
+// Disabled on AMD64 (not needed outside VMware). Not applicable on ARM64.
+func (vm *VirtDeployVM) configureVMPort() *libvirtxml.DomainFeatureState {
+	if vm.isArm64() {
+		return nil
+	}
+	return &libvirtxml.DomainFeatureState{State: "off"}
+}
+
+// configureControllers returns USB controllers for the domain.
+// AMD64 uses ich9-ehci1 + three ich9-uhci companions (q35 chipset USB 2.0 stack).
+// ARM64 uses a single qemu-xhci controller (USB 3.0, supported by virt machine).
+func (vm *VirtDeployVM) configureControllers() []libvirtxml.DomainController {
+	if vm.isArm64() {
+		return []libvirtxml.DomainController{
+			{Type: "usb", Index: new(uint), Model: "qemu-xhci", Alias: &libvirtxml.DomainAlias{Name: "usb"}},
+		}
+	}
+	return []libvirtxml.DomainController{
+		{Type: "usb", Index: new(uint), Model: "ich9-ehci1"},
+		{Type: "usb", Index: new(uint), Model: "ich9-uhci1", USB: &libvirtxml.DomainControllerUSB{
+			Master: &libvirtxml.DomainControllerUSBMaster{
+				StartPort: 0,
+			},
+		}},
+		{Type: "usb", Index: new(uint), Model: "ich9-uhci2", USB: &libvirtxml.DomainControllerUSB{
+			Master: &libvirtxml.DomainControllerUSBMaster{
+				StartPort: 2,
+			},
+		}},
+		{Type: "usb", Index: new(uint), Model: "ich9-uhci3", USB: &libvirtxml.DomainControllerUSB{
+			Master: &libvirtxml.DomainControllerUSBMaster{
+				StartPort: 4,
+			},
+		}},
+	}
+}
+
+// configureDisks returns disk and CDROM devices for the domain.
+// AMD64 uses SATA disks (native to q35). ARM64 uses virtio disks because
+// SATA + QCOW2 on the virt machine type causes EFI firmware loading failures.
 func (vm *VirtDeployVM) configureDisks() []libvirtxml.DomainDisk {
 	disks := make([]libvirtxml.DomainDisk, 0, len(vm.volumes)+len(vm.cdroms))
 	for i, vol := range vm.volumes {
@@ -40,6 +351,7 @@ func (vm *VirtDeployVM) configureDisks() []libvirtxml.DomainDisk {
 			},
 			Address: &libvirtxml.DomainAddress{},
 		}
+
 		// ARM64 + SATA + QCOW2 seems to have issues: the EFI files are not loaded.
 		// Because of this, we use virtio for disks (not CDs) on ARM64
 		if vm.isArm64() {
@@ -82,9 +394,11 @@ func (vm *VirtDeployVM) configureDisks() []libvirtxml.DomainDisk {
 		}
 		disks = append(disks, d)
 	}
+
 	return disks
 }
 
+// configureTpms returns an emulated TPM 2.0 device if enabled.
 func (vm *VirtDeployVM) configureTpms() []libvirtxml.DomainTPM {
 	// Optional TPM
 	var tpms []libvirtxml.DomainTPM
@@ -98,213 +412,6 @@ func (vm *VirtDeployVM) configureTpms() []libvirtxml.DomainTPM {
 			},
 		}}
 	}
+
 	return tpms
-}
-
-func (vm *VirtDeployVM) createDomain(
-	domainType string,
-	osType libvirtxml.DomainOSType,
-	cpuModel libvirtxml.DomainCPUModel,
-	cpuFeatures []libvirtxml.DomainCPUFeature,
-	pm *libvirtxml.DomainPM,
-	timer []libvirtxml.DomainTimer,
-	emulator string,
-	apic *libvirtxml.DomainFeatureAPIC,
-	vmPort *libvirtxml.DomainFeatureState,
-	controllers []libvirtxml.DomainController,
-) libvirtxml.Domain {
-	var networkInterfaces []libvirtxml.DomainInterface
-	if vm.networkName != "" {
-		networkInterfaces = []libvirtxml.DomainInterface{{
-			Model: &libvirtxml.DomainInterfaceModel{Type: "virtio"},
-			MAC:   &libvirtxml.DomainInterfaceMAC{Address: vm.mac.String()},
-			Source: &libvirtxml.DomainInterfaceSource{
-				Network: &libvirtxml.DomainInterfaceSourceNetwork{
-					Network: vm.networkName,
-				},
-			},
-		}}
-	}
-
-	var qemuExtraArgs []libvirtxml.DomainQEMUCommandlineArg
-	if vm.ignitionVolume != "" {
-		qemuExtraArgs = []libvirtxml.DomainQEMUCommandlineArg{
-			{Value: "-fw_cfg"},
-			{Value: fmt.Sprintf("name=opt/org.flatcar-linux/config,file=%s", vm.ignitionVolume)},
-		}
-	}
-
-	return libvirtxml.Domain{
-		Type:   domainType,
-		Name:   vm.name,
-		Memory: &libvirtxml.DomainMemory{Unit: "GiB", Value: vm.Mem},
-		VCPU:   &libvirtxml.DomainVCPU{Value: vm.Cpus},
-		OS: &libvirtxml.DomainOS{
-
-			Type:   &osType,
-			SMBios: &libvirtxml.DomainSMBios{Mode: "sysinfo"},
-			Loader: &libvirtxml.DomainLoader{Path: vm.firmwareLoaderPath, Type: "pflash", Readonly: "yes"},
-			NVRam: &libvirtxml.DomainNVRam{
-				NVRam:    vm.nvramPath,
-				Template: vm.firmwareVarsTemplatePath,
-			},
-		},
-		SysInfo: []libvirtxml.DomainSysInfo{
-			{
-				SMBIOS: &libvirtxml.DomainSysInfoSMBIOS{
-					OEMStrings: &libvirtxml.DomainSysInfoOEMStrings{
-						Entry: []string{"virtdeploy:1"},
-					},
-				},
-			},
-		},
-		Features: &libvirtxml.DomainFeatureList{
-			ACPI:   &libvirtxml.DomainFeature{},
-			APIC:   apic,
-			VMPort: vmPort,
-		},
-		CPU: &libvirtxml.DomainCPU{
-			Match:    "exact",
-			Check:    "none",
-			Model:    &cpuModel,
-			Features: cpuFeatures,
-		},
-		Clock: &libvirtxml.DomainClock{
-			Offset: "utc",
-			Timer:  timer,
-		},
-		PM: pm,
-		Devices: &libvirtxml.DomainDeviceList{
-			Emulator:    emulator,
-			Disks:       vm.configureDisks(),
-			Controllers: controllers,
-			Interfaces:  networkInterfaces,
-			Consoles: []libvirtxml.DomainConsole{{
-				Source: &libvirtxml.DomainChardevSource{
-					Pty: &libvirtxml.DomainChardevSourcePty{},
-				},
-			}},
-			Channels: []libvirtxml.DomainChannel{{
-				Source: &libvirtxml.DomainChardevSource{
-					SpiceVMC: &libvirtxml.DomainChardevSourceSpiceVMC{},
-				},
-				Target: &libvirtxml.DomainChannelTarget{
-					VirtIO: &libvirtxml.DomainChannelTargetVirtIO{
-						Name: "com.redhat.spice.0",
-					},
-				},
-			}},
-			Inputs: []libvirtxml.DomainInput{{Type: "tablet", Bus: "usb"}},
-			Graphics: []libvirtxml.DomainGraphic{{
-				Spice: &libvirtxml.DomainGraphicSpice{
-					Port:     -1,
-					TLSPort:  -1,
-					AutoPort: "yes",
-					Image: &libvirtxml.DomainGraphicSpiceImage{
-						Compression: "off",
-					},
-				},
-			}},
-			Sounds: []libvirtxml.DomainSound{{
-				Model: "ich6",
-			}},
-			Videos: []libvirtxml.DomainVideo{{
-				Model: libvirtxml.DomainVideoModel{Type: "qxl"},
-			}},
-			RedirDevs: []libvirtxml.DomainRedirDev{
-				{Bus: "usb", Source: &libvirtxml.DomainChardevSource{
-					SpiceVMC: &libvirtxml.DomainChardevSourceSpiceVMC{},
-				}},
-				{Bus: "usb", Source: &libvirtxml.DomainChardevSource{
-					SpiceVMC: &libvirtxml.DomainChardevSourceSpiceVMC{},
-				}},
-			},
-			Serials: []libvirtxml.DomainSerial{{
-				Source: &libvirtxml.DomainChardevSource{
-					Pty: &libvirtxml.DomainChardevSourcePty{
-						Path: "/dev/pts/2",
-					},
-				},
-				Target: &libvirtxml.DomainSerialTarget{Port: new(uint)},
-				Log:    &libvirtxml.DomainChardevLog{File: fmt.Sprintf("/tmp/%s-serial0.log", vm.name), Append: "off"},
-			}},
-			TPMs: vm.configureTpms(),
-		},
-		QEMUCommandline: &libvirtxml.DomainQEMUCommandline{
-			Args: qemuExtraArgs,
-		},
-		SecLabel: []libvirtxml.DomainSecLabel{
-			{Type: "none"},
-		},
-	}
-}
-
-func (vm *VirtDeployVM) asAmd64Xml() (string, error) {
-	// AMD64-specific domain XML
-	dom := vm.createDomain(
-		"kvm",
-		libvirtxml.DomainOSType{Arch: "x86_64", Machine: "q35", Type: "hvm"},
-		libvirtxml.DomainCPUModel{Fallback: "allow", Value: "Broadwell-IBRS"},
-		[]libvirtxml.DomainCPUFeature{{Policy: "require", Name: "vmx"}},
-		&libvirtxml.DomainPM{
-			SuspendToMem:  &libvirtxml.DomainPMPolicy{Enabled: "no"},
-			SuspendToDisk: &libvirtxml.DomainPMPolicy{Enabled: "no"},
-		},
-		[]libvirtxml.DomainTimer{
-			{Name: "rtc", TickPolicy: "catchup"},
-			{Name: "pit", TickPolicy: "delay"},
-			{Name: "hpet", Present: "no"},
-		},
-		"/usr/bin/qemu-system-x86_64",
-		&libvirtxml.DomainFeatureAPIC{},
-		&libvirtxml.DomainFeatureState{State: "off"},
-		[]libvirtxml.DomainController{
-			{Type: "usb", Index: new(uint), Model: "ich9-ehci1"},
-			{Type: "usb", Index: new(uint), Model: "ich9-uhci1", USB: &libvirtxml.DomainControllerUSB{
-				Master: &libvirtxml.DomainControllerUSBMaster{
-					StartPort: 0,
-				},
-			}},
-			{Type: "usb", Index: new(uint), Model: "ich9-uhci2", USB: &libvirtxml.DomainControllerUSB{
-				Master: &libvirtxml.DomainControllerUSBMaster{
-					StartPort: 2,
-				},
-			}},
-			{Type: "usb", Index: new(uint), Model: "ich9-uhci3", USB: &libvirtxml.DomainControllerUSB{
-				Master: &libvirtxml.DomainControllerUSBMaster{
-					StartPort: 4,
-				},
-			}},
-		},
-	)
-
-	xml, err := dom.Marshal()
-	if err != nil {
-		return "", fmt.Errorf("marshal amd64 domain to XML: %w", err)
-	}
-	return xml, nil
-}
-
-func (vm *VirtDeployVM) asArm64Xml() (string, error) {
-	// ARM64-specific domain XML
-	dom := vm.createDomain(
-		"qemu",
-		libvirtxml.DomainOSType{Arch: "aarch64", Machine: "virt-6.2", Type: "hvm"},
-		libvirtxml.DomainCPUModel{Fallback: "forbid", Value: "cortex-a57"},
-		[]libvirtxml.DomainCPUFeature{},
-		nil,
-		[]libvirtxml.DomainTimer{},
-		"/usr/bin/qemu-system-aarch64",
-		nil,
-		nil,
-		[]libvirtxml.DomainController{
-			{Type: "usb", Index: new(uint), Model: "qemu-xhci", Alias: &libvirtxml.DomainAlias{Name: "usb"}},
-		},
-	)
-
-	xml, err := dom.Marshal()
-	if err != nil {
-		return "", fmt.Errorf("marshal arm64 domain to XML: %w", err)
-	}
-	return xml, nil
 }

--- a/tools/pkg/virtdeploy/vm.go
+++ b/tools/pkg/virtdeploy/vm.go
@@ -207,9 +207,8 @@ func (vm *VirtDeployVM) configureRedirDevs() []libvirtxml.DomainRedirDev {
 	}
 }
 
-// configureDomainType returns the libvirt domain type.
-// AMD64 uses KVM (hardware-accelerated). ARM64 uses plain QEMU (TCG) because
-// we cross-compile on an x86 host where KVM is not available for aarch64.
+// configureDomainType returns the libvirt domain type. AMD64 uses KVM
+// (hardware-accelerated). ARM64 uses plain QEMU for compatibility.
 func (vm *VirtDeployVM) configureDomainType() string {
 	if vm.isArm64() {
 		return "qemu"


### PR DESCRIPTION
# 🔍 Description
 
Add support for amd64 ACL images with new:
- `-s` auto start the vm after it is created
- `--ignition-config=/path/to/config.ign`

Example:
```bash
./bin/virtdeploy create-one -n acl --no-secure-boot -s --ignition-config=/tmp/acl-ignition.ign --os-disk=/path/to/acl_vm.img
```
