### PR TITLE
tests: fix artifact handling in azl-isntaller test

### DIFF
--- a/.pipelines/templates/stages/azl_installer/validate-azl-installer-iso.yml
+++ b/.pipelines/templates/stages/azl_installer/validate-azl-installer-iso.yml
@@ -125,3 +125,8 @@ steps:
     timeoutInMinutes: 5
     displayName: "Capture azl-installer VHD"
     condition: failed()
+
+  - template: ../testing_common/fix-output-directory-for-one-branch-step.yml
+    parameters:
+      outputDir: $(ob_outputDirectory)
+      condition: always()


### PR DESCRIPTION
# 🔍 Description
 
azl-installer test is creating warning in pipeline runs.  Use template to fix artifact ownership.

Validation: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1097501&view=results