### PR TITLE
engineering: Surface image os-release in engine context

### DIFF
--- a/crates/osutils/src/osrelease.rs
+++ b/crates/osutils/src/osrelease.rs
@@ -130,7 +130,7 @@ impl OsRelease {
         ))
     }
 
-    /// Returns the distribution of the host.
+    /// Returns the distribution represented by this `OsRelease` instance.
     pub fn get_distro(&self) -> Distro {
         match self.id.as_deref() {
             Some(AZURE_LINUX_DISTRO_ID)

--- a/crates/osutils/src/osrelease.rs
+++ b/crates/osutils/src/osrelease.rs
@@ -10,6 +10,17 @@ use crate::path;
 /// Absolute path to the /etc/os-release file.
 pub const OS_RELEASE_PATH: &str = "/etc/os-release";
 
+// Distro consts
+
+/// Azure Linux distro ID
+pub const AZURE_LINUX_DISTRO_ID: &str = "azurelinux";
+/// CBL-Mariner distro ID
+pub const CBL_MARINER_DISTRO_ID: &str = "mariner";
+/// Ubuntu distro ID
+pub const UBUNTU_DISTRO_ID: &str = "ubuntu";
+/// Azure Container Linux variant ID
+pub const AZURE_CONTAINER_LINUX_VARIANT_ID: &str = "azurecontainerlinux";
+
 /// Returns whether the host is running Azure Linux 2.
 pub fn is_azl2() -> Result<bool, Error> {
     Ok(OsRelease::read()?.get_distro().is_azl2())
@@ -67,6 +78,41 @@ pub struct OsRelease {
 }
 
 impl OsRelease {
+    /// Represents an empty OsRelease, where all fields are set to None.
+    pub const EMPTY: Self = Self {
+        name: None,
+        id: None,
+        id_like: None,
+        pretty_name: None,
+        cpe_name: None,
+        variant: None,
+        variant_id: None,
+        version: None,
+        version_id: None,
+        version_codename: None,
+        build_id: None,
+        image_id: None,
+        image_version: None,
+        release_type: None,
+        home_url: None,
+        documentation_url: None,
+        support_url: None,
+        bug_report_url: None,
+        privacy_policy_url: None,
+        support_end: None,
+        logo: None,
+        ansi_color: None,
+        ansi_color_reverse: None,
+        vendor_name: None,
+        vendor_url: None,
+        experiment: None,
+        experiment_url: None,
+        default_hostname: None,
+        architecture: None,
+        sysext_level: None,
+        confext_level: None,
+    };
+
     /// Reads the contents of /etc/os-release and parses it into an OsRelease struct.
     pub fn read() -> Result<Self, Error> {
         Ok(Self::parse(
@@ -87,7 +133,12 @@ impl OsRelease {
     /// Returns the distribution of the host.
     pub fn get_distro(&self) -> Distro {
         match self.id.as_deref() {
-            Some("mariner") | Some("azurelinux") => Distro::AzureLinux(
+            Some(AZURE_LINUX_DISTRO_ID)
+                if self.variant_id.as_deref() == Some(AZURE_CONTAINER_LINUX_VARIANT_ID) =>
+            {
+                Distro::AzureContainerLinux
+            }
+            Some(CBL_MARINER_DISTRO_ID) | Some(AZURE_LINUX_DISTRO_ID) => Distro::AzureLinux(
                 self.version_id
                     .as_deref()
                     .map(|v| {
@@ -102,6 +153,7 @@ impl OsRelease {
                     })
                     .unwrap_or_default(),
             ),
+            Some(UBUNTU_DISTRO_ID) => Distro::Ubuntu,
             _ => Distro::Other,
         }
     }
@@ -176,6 +228,12 @@ impl<'de> Deserialize<'de> for OsRelease {
         D: Deserializer<'de>,
     {
         Ok(OsRelease::parse(&String::deserialize(deserializer)?))
+    }
+}
+
+impl Default for &OsRelease {
+    fn default() -> Self {
+        &OsRelease::EMPTY
     }
 }
 
@@ -256,6 +314,8 @@ impl ExtensionRelease {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Distro {
     AzureLinux(AzureLinuxRelease),
+    AzureContainerLinux,
+    Ubuntu,
     Other,
 }
 
@@ -266,6 +326,10 @@ impl Distro {
 
     pub fn is_azl3(&self) -> bool {
         self == &Distro::AzureLinux(AzureLinuxRelease::AzL3)
+    }
+
+    pub fn is_acl(&self) -> bool {
+        self == &Distro::AzureContainerLinux
     }
 }
 

--- a/crates/osutils/src/osrelease.rs
+++ b/crates/osutils/src/osrelease.rs
@@ -231,12 +231,6 @@ impl<'de> Deserialize<'de> for OsRelease {
     }
 }
 
-impl Default for &OsRelease {
-    fn default() -> Self {
-        &OsRelease::EMPTY
-    }
-}
-
 /// Represents the contents of the extension-release file of a sysext or
 /// confext.
 ///

--- a/crates/osutils/src/osrelease.rs
+++ b/crates/osutils/src/osrelease.rs
@@ -540,4 +540,51 @@ mod tests {
             Distro::AzureLinux(AzureLinuxRelease::AzL3)
         );
     }
+
+    #[test]
+    fn test_get_distro_azure_container_linux() {
+        let data = indoc::indoc! {
+            r#"
+            NAME="Microsoft Azure Linux"
+            VERSION="3.0.20240609"
+            ID=azurelinux
+            VERSION_ID="3.0"
+            VARIANT_ID=azurecontainerlinux
+            PRETTY_NAME="Microsoft Azure Linux 3.0"
+            "#,
+        };
+
+        let os_release = OsRelease::parse(data);
+        assert_eq!(os_release.get_distro(), Distro::AzureContainerLinux);
+    }
+
+    #[test]
+    fn test_get_distro_ubuntu() {
+        let data = indoc::indoc! {
+            r#"
+            NAME="Ubuntu"
+            VERSION="22.04.3 LTS (Jammy Jellyfish)"
+            ID=ubuntu
+            VERSION_ID="22.04"
+            PRETTY_NAME="Ubuntu 22.04.3 LTS"
+            "#,
+        };
+
+        let os_release = OsRelease::parse(data);
+        assert_eq!(os_release.get_distro(), Distro::Ubuntu);
+    }
+
+    #[test]
+    fn test_get_distro_unknown() {
+        let data = indoc::indoc! {
+            r#"
+            NAME="Fedora Linux"
+            ID=fedora
+            VERSION_ID="39"
+            "#,
+        };
+
+        let os_release = OsRelease::parse(data);
+        assert_eq!(os_release.get_distro(), Distro::Other);
+    }
 }

--- a/crates/trident/src/engine/context/mod.rs
+++ b/crates/trident/src/engine/context/mod.rs
@@ -8,6 +8,7 @@ use anyhow::{bail, Context, Error};
 use filesystem::FileSystemData;
 use log::{debug, trace};
 
+use osutils::osrelease::{Distro, OsRelease};
 use trident_api::{
     config::{HostConfiguration, Partition, VerityDevice},
     constants::{
@@ -413,6 +414,20 @@ impl EngineContext {
                     .unwrap_or(STREAM_SLOW_SPEED_REPORTING_INTERVAL_SECONDS_DEFAULT),
             ),
         ))
+    }
+
+    /// Retrieves os-release data from the image.
+    pub(crate) fn image_os_release(&self) -> &OsRelease {
+        self.image
+            .as_ref()
+            .map(|img| img.os_release())
+            .unwrap_or_default()
+    }
+
+    /// Retrieves the distribution of the OS image.
+    #[expect(dead_code)]
+    pub(crate) fn image_distro(&self) -> Distro {
+        self.image_os_release().get_distro()
     }
 }
 

--- a/crates/trident/src/engine/context/mod.rs
+++ b/crates/trident/src/engine/context/mod.rs
@@ -421,7 +421,7 @@ impl EngineContext {
         self.image
             .as_ref()
             .map(|img| img.os_release())
-            .unwrap_or_default()
+            .unwrap_or(&OsRelease::EMPTY)
     }
 
     /// Retrieves the distribution of the OS image.

--- a/crates/trident/src/osimage/mod.rs
+++ b/crates/trident/src/osimage/mod.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 use uuid::Uuid;
 
+use osutils::osrelease::OsRelease;
 use sysdefs::{
     arch::SystemArchitecture, filesystems::RealFilesystemType, osuuid::OsUuid,
     partition_types::DiscoverablePartitionType,
@@ -262,6 +263,15 @@ impl OsImage {
             }),
             #[cfg(test)]
             OsImageInner::Mock(_mock) => None,
+        }
+    }
+
+    /// Retrieves os-release data from the image.
+    pub(crate) fn os_release(&self) -> &OsRelease {
+        match &self.0 {
+            OsImageInner::Cosi(cosi) => &cosi.metadata.os_release,
+            #[cfg(test)]
+            OsImageInner::Mock(mock) => &mock.os_release,
         }
     }
 }


### PR DESCRIPTION
# 🔍 Description
 
Surface os-release and distro info from the image in engine context.
