### PR TITLE
Ensure OsRelease alignment between host and cosi for update

### DIFF
--- a/crates/osutils/src/osrelease.rs
+++ b/crates/osutils/src/osrelease.rs
@@ -231,6 +231,12 @@ impl<'de> Deserialize<'de> for OsRelease {
     }
 }
 
+impl Default for &OsRelease {
+    fn default() -> Self {
+        &OsRelease::EMPTY
+    }
+}
+
 /// Represents the contents of the extension-release file of a sysext or
 /// confext.
 ///

--- a/crates/osutils/src/osrelease.rs
+++ b/crates/osutils/src/osrelease.rs
@@ -158,9 +158,24 @@ impl OsRelease {
         }
     }
 
-    // Ensure that the host OsRelease aligns to a COSI file.
-    pub fn ensure_host_alignment(cosi: &OsRelease) -> Result<(), Error> {
-        OsRelease::read()?.ensure_osrelease_alignment(cosi)
+    /// Ensure that the host OsRelease aligns to a COSI file.
+    pub fn ensure_matching_distro(host: &OsRelease, cosi: &OsRelease) -> Result<(), Error> {
+        // Ensure that the os_releases ids align
+        ensure!(
+            host.id == cosi.id,
+            "Mismatched OS release: host = {:?}, cosi = {:?}",
+            host.id.as_deref().unwrap_or("(blank)"),
+            cosi.id.as_deref().unwrap_or("(blank)"),
+        );
+
+        // Ensure that the os_releases variant ids align
+        ensure!(
+            host.variant_id == cosi.variant_id,
+            "Mismatched OS release variant: host = {:?}, cosi = {:?}",
+            host.variant_id.as_deref().unwrap_or("(blank)"),
+            cosi.variant_id.as_deref().unwrap_or("(blank)"),
+        );
+        Ok(())
     }
 
     /// Parses the input string into an OsRelease struct.
@@ -224,30 +239,6 @@ impl OsRelease {
         }
 
         os_release
-    }
-
-    // Ensure that the host OsRelease aligns to a COSI file.
-    fn ensure_osrelease_alignment(&self, other: &OsRelease) -> Result<(), Error> {
-        // Ensure that the os_releases ids align
-        let id = self.id.clone().unwrap_or("None".to_string());
-        let other_id = other.id.clone().unwrap_or("None".to_string());
-        ensure!(
-            id == other_id,
-            "Mismatched OS release: expected = {:?}, actual = {:?}",
-            id,
-            other_id
-        );
-
-        // Ensure that the os_releases variant ids align
-        let variant_id = self.variant_id.clone().unwrap_or("None".to_string());
-        let other_variant_id = other.variant_id.clone().unwrap_or("None".to_string());
-        ensure!(
-            variant_id == other_variant_id,
-            "Mismatched OS release variant: expected = {:?}, actual = {:?}",
-            variant_id,
-            other_variant_id
-        );
-        Ok(())
     }
 }
 
@@ -635,14 +626,14 @@ mod tests {
             Some("azurelinux".to_string()),
             Some("azurecontainerlinux".to_string()),
         );
-        assert!(os_release1.ensure_osrelease_alignment(&os_release2).is_ok());
+        assert!(OsRelease::ensure_matching_distro(&os_release1, &os_release2).is_ok());
     }
 
     #[test]
     fn test_ensure_osrelease_alignment_matched_no_variant() {
         let os_release1 = create_osrelease(Some("azurelinux".to_string()), None);
         let os_release2 = create_osrelease(Some("azurelinux".to_string()), None);
-        assert!(os_release1.ensure_osrelease_alignment(&os_release2).is_ok());
+        assert!(OsRelease::ensure_matching_distro(&os_release1, &os_release2).is_ok());
     }
 
     #[test]
@@ -655,9 +646,7 @@ mod tests {
             Some("notmatching".to_string()),
             Some("azurecontainerlinux".to_string()),
         );
-        assert!(os_release1
-            .ensure_osrelease_alignment(&os_release2)
-            .is_err());
+        assert!(OsRelease::ensure_matching_distro(&os_release1, &os_release2).is_err());
     }
 
     #[test]
@@ -670,8 +659,6 @@ mod tests {
             Some("azurelinux".to_string()),
             Some("notmatching".to_string()),
         );
-        assert!(os_release1
-            .ensure_osrelease_alignment(&os_release2)
-            .is_err());
+        assert!(OsRelease::ensure_matching_distro(&os_release1, &os_release2).is_err());
     }
 }

--- a/crates/osutils/src/osrelease.rs
+++ b/crates/osutils/src/osrelease.rs
@@ -163,7 +163,7 @@ impl OsRelease {
         // Ensure that the os_releases ids align
         ensure!(
             host.id == cosi.id,
-            "Mismatched OS release: host = {:?}, cosi = {:?}",
+            "Mismatched OS release ID: host = {:?}, cosi = {:?}",
             host.id.as_deref().unwrap_or("(blank)"),
             cosi.id.as_deref().unwrap_or("(blank)"),
         );
@@ -171,7 +171,7 @@ impl OsRelease {
         // Ensure that the os_releases variant ids align
         ensure!(
             host.variant_id == cosi.variant_id,
-            "Mismatched OS release variant: host = {:?}, cosi = {:?}",
+            "Mismatched OS release VARIANT_ID: host = {:?}, cosi = {:?}",
             host.variant_id.as_deref().unwrap_or("(blank)"),
             cosi.variant_id.as_deref().unwrap_or("(blank)"),
         );

--- a/crates/osutils/src/osrelease.rs
+++ b/crates/osutils/src/osrelease.rs
@@ -231,12 +231,6 @@ impl<'de> Deserialize<'de> for OsRelease {
     }
 }
 
-impl Default for &OsRelease {
-    fn default() -> Self {
-        &OsRelease::EMPTY
-    }
-}
-
 /// Represents the contents of the extension-release file of a sysext or
 /// confext.
 ///

--- a/crates/osutils/src/osrelease.rs
+++ b/crates/osutils/src/osrelease.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::{Context, Error};
+use anyhow::{ensure, Context, Error};
 use const_format::formatcp;
 use log::trace;
 use serde::{Deserialize, Deserializer};
@@ -158,6 +158,11 @@ impl OsRelease {
         }
     }
 
+    // Ensure that the host OsRelease aligns to a COSI file.
+    pub fn ensure_host_alignment(cosi: &OsRelease) -> Result<(), Error> {
+        OsRelease::read()?.ensure_osrelease_alignment(cosi)
+    }
+
     /// Parses the input string into an OsRelease struct.
     fn parse(data: &str) -> Self {
         let mut os_release = OsRelease::default();
@@ -219,6 +224,30 @@ impl OsRelease {
         }
 
         os_release
+    }
+
+    // Ensure that the host OsRelease aligns to a COSI file.
+    fn ensure_osrelease_alignment(&self, other: &OsRelease) -> Result<(), Error> {
+        // Ensure that the os_releases ids align
+        let id = self.id.clone().unwrap_or("None".to_string());
+        let other_id = other.id.clone().unwrap_or("None".to_string());
+        ensure!(
+            id == other_id,
+            "Mismatched OS release: expected = {:?}, actual = {:?}",
+            id,
+            other_id
+        );
+
+        // Ensure that the os_releases variant ids align
+        let variant_id = self.variant_id.clone().unwrap_or("None".to_string());
+        let other_variant_id = other.variant_id.clone().unwrap_or("None".to_string());
+        ensure!(
+            variant_id == other_variant_id,
+            "Mismatched OS release variant: expected = {:?}, actual = {:?}",
+            variant_id,
+            other_variant_id
+        );
+        Ok(())
     }
 }
 
@@ -586,5 +615,63 @@ mod tests {
 
         let os_release = OsRelease::parse(data);
         assert_eq!(os_release.get_distro(), Distro::Other);
+    }
+
+    fn create_osrelease(id: Option<String>, variant_id: Option<String>) -> OsRelease {
+        OsRelease {
+            id,
+            variant_id,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_ensure_osrelease_alignment_matched() {
+        let os_release1 = create_osrelease(
+            Some("azurelinux".to_string()),
+            Some("azurecontainerlinux".to_string()),
+        );
+        let os_release2 = create_osrelease(
+            Some("azurelinux".to_string()),
+            Some("azurecontainerlinux".to_string()),
+        );
+        assert!(os_release1.ensure_osrelease_alignment(&os_release2).is_ok());
+    }
+
+    #[test]
+    fn test_ensure_osrelease_alignment_matched_no_variant() {
+        let os_release1 = create_osrelease(Some("azurelinux".to_string()), None);
+        let os_release2 = create_osrelease(Some("azurelinux".to_string()), None);
+        assert!(os_release1.ensure_osrelease_alignment(&os_release2).is_ok());
+    }
+
+    #[test]
+    fn test_ensure_alignment_mismatched_id() {
+        let os_release1 = create_osrelease(
+            Some("azurelinux".to_string()),
+            Some("azurecontainerlinux".to_string()),
+        );
+        let os_release2 = create_osrelease(
+            Some("notmatching".to_string()),
+            Some("azurecontainerlinux".to_string()),
+        );
+        assert!(os_release1
+            .ensure_osrelease_alignment(&os_release2)
+            .is_err());
+    }
+
+    #[test]
+    fn test_ensure_alignment_mismatched_variant_id() {
+        let os_release1 = create_osrelease(
+            Some("azurelinux".to_string()),
+            Some("azurecontainerlinux".to_string()),
+        );
+        let os_release2 = create_osrelease(
+            Some("azurelinux".to_string()),
+            Some("notmatching".to_string()),
+        );
+        assert!(os_release1
+            .ensure_osrelease_alignment(&os_release2)
+            .is_err());
     }
 }

--- a/crates/trident/src/lib.rs
+++ b/crates/trident/src/lib.rs
@@ -619,7 +619,8 @@ impl Trident {
             let image_hash = Some(image.metadata_sha384());
 
             // Ensure that the cosi and host os_release align
-            OsRelease::ensure_host_alignment(image.os_release())
+            let host_os_release = OsRelease::read().unwrap_or_default();
+            OsRelease::ensure_matching_distro(&host_os_release, image.os_release())
                 .structured(InvalidInputError::MismatchedOsRelease)
                 .message("Cannot run A/B Update due to OS release mismatch")?;
 

--- a/crates/trident/src/lib.rs
+++ b/crates/trident/src/lib.rs
@@ -11,7 +11,7 @@ use semver::Version;
 use url::Url;
 
 use engine::{bootentries, EngineContext, EngineContextParams};
-use osutils::{block_devices, container, dependencies::Dependency};
+use osutils::{block_devices, container, dependencies::Dependency, osrelease::OsRelease};
 use trident_api::{
     config::{
         HostConfiguration, HostConfigurationSource, ImageSha384, Operations,
@@ -617,6 +617,11 @@ impl Trident {
 
             let image = Self::get_cosi_image(&mut host_config)?;
             let image_hash = Some(image.metadata_sha384());
+
+            // Ensure that the cosi and host os_release align
+            OsRelease::ensure_host_alignment(image.os_release())
+                .structured(InvalidInputError::MismatchedOsRelease)
+                .message("Cannot run A/B Update due to OS release mismatch")?;
 
             // If HS.spec in the datastore is different from the new HC, need to both stage and
             // finalize the update, regardless of state

--- a/crates/trident_api/src/error.rs
+++ b/crates/trident_api/src/error.rs
@@ -268,6 +268,9 @@ pub enum InvalidInputError {
         os_img_fs_type: String,
     },
 
+    #[error("Host OS release does not match COSI OS release")]
+    MismatchedOsRelease,
+
     #[error("An OS image must be provided.")]
     MissingOsImage,
 


### PR DESCRIPTION
# 🔍 Description
 
Ensure that OsRelease (id and variant_id) match for an update between host and COSI.