### PR TITLE
Avoid hostname carry-over for ACL

### DIFF
--- a/crates/trident/src/engine/boot/grub.rs
+++ b/crates/trident/src/engine/boot/grub.rs
@@ -272,6 +272,7 @@ pub(crate) mod functional_test {
         filesystems::MkfsFileSystemType,
         lsblk::{self, BlockDevice, BlockDeviceType, PartitionTableType},
         mdadm, mkfs,
+        osrelease::OsRelease,
         repart::{RepartEmptyMode, SystemdRepartInvoker},
         testutils::repart::{
             self, DISK_SIZE, PART1_SIZE, PART2_SIZE, PART3_SIZE, TEST_DISK_DEVICE_PATH,
@@ -552,6 +553,7 @@ pub(crate) mod functional_test {
                 "root2".into() => PathBuf::from(formatcp!("{TEST_DISK_DEVICE_PATH}3")),
             },
             is_uki: Some(false),
+            host_os_release: OsRelease::read().unwrap(),
             ..Default::default()
         };
 
@@ -662,6 +664,7 @@ pub(crate) mod functional_test {
                 "boot".into() => PathBuf::from(formatcp!("{TEST_DISK_DEVICE_PATH}1")),
                 "root".into() => PathBuf::from(formatcp!("{TEST_DISK_DEVICE_PATH}2")),
             },
+            host_os_release: OsRelease::read().unwrap(),
             ..Default::default()
         };
 
@@ -748,6 +751,7 @@ pub(crate) mod functional_test {
                 "root-a".into() => PathBuf::from(formatcp!("{TEST_DISK_DEVICE_PATH}2")),
                 "root-b".into() => PathBuf::from(formatcp!("{TEST_DISK_DEVICE_PATH}3")),
             ],
+            host_os_release: OsRelease::read().unwrap(),
             ..Default::default()
         };
 

--- a/crates/trident/src/engine/boot/grub.rs
+++ b/crates/trident/src/engine/boot/grub.rs
@@ -10,7 +10,7 @@ use osutils::{
     grub::GrubConfig,
     grub_mkconfig::GrubMkConfigScript,
     osmodifier::{self, BootConfig, IdentifiedPartition, Overlay, Verity},
-    osrelease::{AzureLinuxRelease, Distro, OsRelease},
+    osrelease::{AzureLinuxRelease, Distro},
 };
 use trident_api::{
     config::Selinux,
@@ -64,9 +64,7 @@ pub(super) fn update_configs(ctx: &EngineContext, os_modifier_path: &Path) -> Re
     let boot_grub_config_path = Path::new(ROOT_MOUNT_POINT_PATH).join(GRUB2_CONFIG_RELATIVE_PATH);
 
     // Update GRUB config on the boot device (volume holding /boot)
-    match OsRelease::read()
-        .context("Failed to read OS release")?
-        .get_distro()
+    match ctx.host_os_release.get_distro()
     {
         Distro::AzureLinux(AzureLinuxRelease::AzL3) => {
             update_grub_config_azl3(

--- a/crates/trident/src/engine/boot/grub.rs
+++ b/crates/trident/src/engine/boot/grub.rs
@@ -64,8 +64,7 @@ pub(super) fn update_configs(ctx: &EngineContext, os_modifier_path: &Path) -> Re
     let boot_grub_config_path = Path::new(ROOT_MOUNT_POINT_PATH).join(GRUB2_CONFIG_RELATIVE_PATH);
 
     // Update GRUB config on the boot device (volume holding /boot)
-    match ctx.host_os_release.get_distro()
-    {
+    match ctx.host_os_release.get_distro() {
         Distro::AzureLinux(AzureLinuxRelease::AzL3) => {
             update_grub_config_azl3(
                 ctx,

--- a/crates/trident/src/engine/context/mod.rs
+++ b/crates/trident/src/engine/context/mod.rs
@@ -147,7 +147,9 @@ impl EngineContext {
                 )))?
                 .to_path_buf();
 
-        let os_release = OsRelease::read().structured(InternalError::Internal("Failed to read OS release information"))?;
+        let os_release = OsRelease::read().structured(InternalError::Internal(
+            "Failed to read OS release information",
+        ))?;
         Ok(Self {
             spec: params.spec,
             spec_old: params.spec_old,

--- a/crates/trident/src/engine/context/mod.rs
+++ b/crates/trident/src/engine/context/mod.rs
@@ -103,6 +103,9 @@ pub struct EngineContext {
 
     /// The mount path of the ESP partition.
     pub esp_mount_path: PathBuf,
+
+    /// Host OsRelease
+    pub host_os_release: OsRelease,
 }
 
 #[cfg(any(test, feature = "functional-test"))]
@@ -122,6 +125,7 @@ impl Default for EngineContext {
             storage_graph: Default::default(),
             filesystems: Default::default(),
             is_uki: Default::default(),
+            host_os_release: Default::default(),
         }
     }
 }
@@ -143,6 +147,7 @@ impl EngineContext {
                 )))?
                 .to_path_buf();
 
+        let os_release = OsRelease::read().structured(InternalError::Internal("Failed to read OS release information"))?;
         Ok(Self {
             spec: params.spec,
             spec_old: params.spec_old,
@@ -156,6 +161,7 @@ impl EngineContext {
             filesystems: Vec::new(),
             is_uki: params.is_uki,
             esp_mount_path,
+            host_os_release: os_release,
         })
     }
 

--- a/crates/trident/src/subsystems/osconfig/mod.rs
+++ b/crates/trident/src/subsystems/osconfig/mod.rs
@@ -382,11 +382,13 @@ impl Subsystem for MosConfigSubsystem {
 mod tests {
     use std::path::PathBuf;
 
+    use osutils::osrelease::OsRelease;
     use trident_api::{
         config::{
             Extension, HostConfiguration, KernelCommandLine, ManagementOs, Module, Os, Password,
             Selinux, Services, UefiFallbackMode, User,
         },
+        constants::internal_params::DISABLE_HOSTNAME_CARRY_OVER,
         primitives::hash::Sha384Hash,
         status::ServicingType,
     };
@@ -655,6 +657,41 @@ mod tests {
             ..Default::default()
         });
         assert!(mos_config_requires_os_modifier(&mos));
+    }
+
+    #[test]
+    fn test_should_carry_over_hostname() {
+        use super::should_carry_over_hostname;
+
+        let mut ctx = EngineContext::default();
+        assert!(
+            !should_carry_over_hostname(&ctx),
+            "Empty context should not carry over hostname"
+        );
+
+        ctx.servicing_type = ServicingType::AbUpdate;
+        assert!(
+            should_carry_over_hostname(&ctx),
+            "Empty AbUpdate context should carry over hostname"
+        );
+
+        let mut acl_os_release = OsRelease::EMPTY;
+        acl_os_release.id = Some("azurelinux".to_string());
+        acl_os_release.variant_id = Some("azurecontainerlinux".to_string());
+        ctx.host_os_release = acl_os_release;
+        assert!(
+            !should_carry_over_hostname(&ctx),
+            "ACL AbUpdate context should not carry over hostname"
+        );
+
+        ctx.host_os_release = OsRelease::EMPTY;
+        ctx.spec
+            .internal_params
+            .set_flag(DISABLE_HOSTNAME_CARRY_OVER);
+        assert!(
+            !should_carry_over_hostname(&ctx),
+            "Empty AbUpdate context with internal_flag.DISABLE_HOSTNAME_CARRY_OVER should not carry over hostname"
+        );
     }
 }
 

--- a/crates/trident/src/subsystems/osconfig/mod.rs
+++ b/crates/trident/src/subsystems/osconfig/mod.rs
@@ -74,6 +74,11 @@ fn mos_config_requires_os_modifier(mos_config: &ManagementOs) -> bool {
 /// If the OS configuration does not specify a hostname, so long as DISABLE_HOSTNAME_CARRY_OVER flag
 /// is not set to true, we want to carry over the existing machine hostname after updating.
 fn should_carry_over_hostname(ctx: &EngineContext) -> bool {
+    if ctx.host_os_release.get_distro().is_acl() {
+        // Skip carry-over name for ACL
+        return false;
+    }
+
     !ctx.spec
         .internal_params
         .get_flag(DISABLE_HOSTNAME_CARRY_OVER)


### PR DESCRIPTION
# 🔍 Description
 
Add OsRelease to EngineContext and avoid hostname carry-over for ACL