### PR TITLE
infra: virt-firmware 26.4 breaks our tests

### DIFF
--- a/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
+++ b/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
@@ -58,7 +58,7 @@ steps:
 
       # Use `-E` to preserve PipAuthenticate connection to
       # internal feed replacing PyPI
-      sudo -E pip3 install virt-firmware -vvv
+      sudo -E pip3 install virt-firmware==26.2 -vvv
     displayName: Install virt-deploy dependencies
     retryCountOnTaskFailure: 3
 

--- a/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
+++ b/.pipelines/templates/stages/testing_vm/netlaunch-prep.yml
@@ -57,7 +57,9 @@ steps:
           imagemagick
 
       # Use `-E` to preserve PipAuthenticate connection to
-      # internal feed replacing PyPI
+      # internal feed replacing PyPI.
+      # Pin to a working version to avoid breaking change
+      # introduced in 26.4.
       sudo -E pip3 install virt-firmware==26.2 -vvv
     displayName: Install virt-deploy dependencies
     retryCountOnTaskFailure: 3

--- a/docs/Development/Building/Dependencies.md
+++ b/docs/Development/Building/Dependencies.md
@@ -29,7 +29,9 @@ Trident's dependencies.
 - Python packages:
 
   ```bash
-  sudo pip3 install virt-firmware
+  # Use version 26.2 to avoid a breaking change
+  # introduced in 26.4.
+  sudo pip3 install virt-firmware==26.2
   ```
 
 ## Code Coverage Dependencies

--- a/tools/storm/e2e/scenario/dependencies.go
+++ b/tools/storm/e2e/scenario/dependencies.go
@@ -90,8 +90,12 @@ func installUbuntuDependencies(osRelease *env.OsReleaseInfo) error {
 	case "jammy":
 		// Use `-E` to preserve PipAuthenticate connection to
 		// internal feed replacing PyPI
-		err = cmd.Run("sudo", "-E", "pip3", "install", "virt-firmware", "-vvv")
+		// Pin to version 26.2 to avoid a breaking change in
+		// 26.4.
+		err = cmd.Run("sudo", "-E", "pip3", "install", "virt-firmware==26.2", "-vvv")
 	case "noble":
+		// noble seems to be using 24.1, which avoids the 26.4
+		// breaking change.
 		err = cmd.Run("sudo", "apt-get", "-y", "install", "python3-virt-firmware")
 	default:
 		return fmt.Errorf("unsupported Ubuntu version for virt-firmware installation: %s", osRelease.VersionCodename)


### PR DESCRIPTION
# 🔍 Description
 
virt-firmware recently released 26.4 which breaks our tests' invocation of `virt-fw-vars --enroll-cert`