### PR TITLE
infra: include arm64 rpms in feed and only build them in trident-ci/trident-pr*

### DIFF
--- a/.pipelines/templates/release-template.yml
+++ b/.pipelines/templates/release-template.yml
@@ -24,6 +24,15 @@ stages:
       artifactName: trident-binaries
       specificVersion: ${{ parameters.specificVersion }}
       packageName: rpms
+      targetArchitecture: amd64
+
+  - template: stages/download_staged/download-staged.yml
+    parameters:
+      stageType: rel
+      artifactName: trident-binaries
+      specificVersion: ${{ parameters.specificVersion }}
+      packageName: rpms
+      targetArchitecture: arm64
 
   - ${{ if ne(parameters.skipPublishing, true) }}:
       - template: stages/publishing/publish.yml

--- a/.pipelines/templates/stages/download_staged/download-staged.yml
+++ b/.pipelines/templates/stages/download_staged/download-staged.yml
@@ -69,10 +69,7 @@ stages:
           - template: ../common_tasks/download-universal-artifact.yml
             parameters:
               tridentSourceDirectory: $(TRIDENT_SOURCE_DIR)
-              ${{ if eq(parameters.targetArchitecture, 'amd64') }}:
-                packageName: ${{ parameters.packageName }}${{ variables.downloadArtifactSuffix }}
-              ${{ else }}:
-                packageName: ${{ parameters.packageName }}-${{ parameters.targetArchitecture }}${{ variables.downloadArtifactSuffix }}
+              packageName: ${{ parameters.packageName }}${{ variables.downloadArtifactSuffix }}
               downloadLocation: $(ob_outputDirectory)
               outputVersionVariable: trident_version
               specificVersion: ${{ parameters.specificVersion }}

--- a/.pipelines/templates/stages/download_staged/download-staged.yml
+++ b/.pipelines/templates/stages/download_staged/download-staged.yml
@@ -69,7 +69,8 @@ stages:
           - template: ../common_tasks/download-universal-artifact.yml
             parameters:
               tridentSourceDirectory: $(TRIDENT_SOURCE_DIR)
-              packageName: ${{ parameters.packageName }}${{ variables.downloadArtifactSuffix }}
+              packageName: rpms-dev
+              feedName: TridentDev
               downloadLocation: $(ob_outputDirectory)
               outputVersionVariable: trident_version
               specificVersion: ${{ parameters.specificVersion }}

--- a/.pipelines/templates/stages/download_staged/download-staged.yml
+++ b/.pipelines/templates/stages/download_staged/download-staged.yml
@@ -69,8 +69,7 @@ stages:
           - template: ../common_tasks/download-universal-artifact.yml
             parameters:
               tridentSourceDirectory: $(TRIDENT_SOURCE_DIR)
-              packageName: rpms-dev
-              feedName: TridentDev
+              packageName: ${{ parameters.packageName }}${{ variables.downloadArtifactSuffix }}
               downloadLocation: $(ob_outputDirectory)
               outputVersionVariable: trident_version
               specificVersion: ${{ parameters.specificVersion }}

--- a/.pipelines/templates/stages/download_staged/download-staged.yml
+++ b/.pipelines/templates/stages/download_staged/download-staged.yml
@@ -27,14 +27,20 @@ parameters:
     type: string
     default: ''
 
+  - name: targetArchitecture
+    type: string
+    values:
+      - amd64
+      - arm64
+
 stages:
-  - stage: GetTridentBinaries_${{ replace(parameters.packageName, '-', '_') }}_amd64
-    displayName: Download staged ${{ parameters.packageName }} for ${{ parameters.stageType }}
+  - stage: GetTridentBinaries_${{ replace(parameters.packageName, '-', '_') }}_${{ parameters.targetArchitecture }}
+    displayName: Download staged ${{ parameters.packageName }} (${{ parameters.targetArchitecture }}) for ${{ parameters.stageType }}
     ${{ if ne(parameters.dependsOnStage, '') }}:
       dependsOn: ${{ parameters.dependsOnStage }}
 
     jobs:
-      - job: DownloadTrident_amd64
+      - job: DownloadTrident_${{ parameters.targetArchitecture }}
         displayName: Download Trident
         pool:
           type: linux
@@ -42,7 +48,10 @@ stages:
         variables:
           # Control the name of the artifact where Trident binaries are stored
           - name: ob_artifactBaseName
-            value: ${{ parameters.artifactName }}
+            ${{ if eq(parameters.targetArchitecture, 'amd64') }}:
+              value: ${{ parameters.artifactName }}
+            ${{ else }}:
+              value: ${{ parameters.artifactName }}-${{ parameters.targetArchitecture }}
           - name: ob_outputDirectory
             value: "/tmp/out"
 
@@ -60,7 +69,10 @@ stages:
           - template: ../common_tasks/download-universal-artifact.yml
             parameters:
               tridentSourceDirectory: $(TRIDENT_SOURCE_DIR)
-              packageName: ${{ parameters.packageName }}${{ variables.downloadArtifactSuffix }}
+              ${{ if eq(parameters.targetArchitecture, 'amd64') }}:
+                packageName: ${{ parameters.packageName }}${{ variables.downloadArtifactSuffix }}
+              ${{ else }}:
+                packageName: ${{ parameters.packageName }}-${{ parameters.targetArchitecture }}${{ variables.downloadArtifactSuffix }}
               downloadLocation: $(ob_outputDirectory)
               outputVersionVariable: trident_version
               specificVersion: ${{ parameters.specificVersion }}

--- a/.pipelines/templates/stages/download_staged/download-staged.yml
+++ b/.pipelines/templates/stages/download_staged/download-staged.yml
@@ -85,6 +85,6 @@ stages:
               displayName: Install native dependencies to extract Trident binary
               retryCountOnTaskFailure: 3
 
-            - script: ./scripts/extract-binary.sh $(ob_outputDirectory) $(ob_outputDirectory)
+            - script: ./scripts/extract-binary.sh $(ob_outputDirectory) $(ob_outputDirectory) ${{ parameters.targetArchitecture }}
               displayName: Extract Trident binary
               workingDirectory: $(TRIDENT_SOURCE_DIR)

--- a/.pipelines/templates/stages/publishing/publish.yml
+++ b/.pipelines/templates/stages/publishing/publish.yml
@@ -64,26 +64,21 @@ stages:
               buildType: current
               patterns: |
                 *.rpm
-              targetPath: /tmp/rpms-arm64
+              targetPath: /tmp/rpms
               artifactName: trident-binaries-arm64
             displayName: "Download Trident RPMs (arm64)"
 
           - script: |
               set -eux
 
-              amd64AlreadyPublished=$(./scripts/get-packages.py --debug \
-                  --package '${{ variables.rpmsPackageBaseName }}${{ variables.artifactSuffix }}' \
-                  --version '$(Build.BuildNumber)' \
-                  --action=exists)
-              arm64AlreadyPublished=$(./scripts/get-packages.py --debug \
+              alreadyPublished=$(./scripts/get-packages.py --debug \
                   --package '${{ variables.rpmsPackageBaseName }}${{ variables.artifactSuffix }}' \
                   --version '$(Build.BuildNumber)' \
                   --action=exists)
 
               # Save variable to know if package needs to be published
               set +x
-              echo "##vso[task.setvariable variable=isAmd64VersionInFeed;]$amd64AlreadyPublished"
-              echo "##vso[task.setvariable variable=isArm64VersionInFeed;]$arm64AlreadyPublished"
+              echo "##vso[task.setvariable variable=isVersionInFeed;]$alreadyPublished"
             displayName: "Check if package version has already been published in the feed."
             workingDirectory: $(TRIDENT_SOURCE_DIR)
             env:
@@ -91,22 +86,11 @@ stages:
 
           - task: UniversalPackages@0
             displayName: "Publish rpms Universal Package"
-            condition: and(succeeded(), eq(variables.isAmd64VersionInFeed, false))
+            condition: and(succeeded(), eq(variables.isVersionInFeed, false))
             inputs:
               command: publish
               vstsFeedPublish: ${{ parameters.feed }}
               vstsFeedPackagePublish: "${{ variables.rpmsPackageBaseName }}${{ variables.artifactSuffix }}"
               publishDirectory: "/tmp/rpms"
-              versionPublish: $(Build.BuildNumber)
-              versionOption: custom
-
-          - task: UniversalPackages@0
-            displayName: "Publish rpms-arm64 Universal Package"
-            condition: and(succeeded(), eq(variables.isArm64VersionInFeed, false))
-            inputs:
-              command: publish
-              vstsFeedPublish: ${{ parameters.feed }}
-              vstsFeedPackagePublish: "${{ variables.rpmsPackageBaseName }}-arm64${{ variables.artifactSuffix }}"
-              publishDirectory: "/tmp/rpms-arm64"
               versionPublish: $(Build.BuildNumber)
               versionOption: custom

--- a/.pipelines/templates/stages/publishing/publish.yml
+++ b/.pipelines/templates/stages/publishing/publish.yml
@@ -25,7 +25,7 @@ stages:
           - BaremetalDeploymentTesting_host
           - BaremetalDeploymentTesting_container
           - ServicingTesting
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main') )
+    # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main') )
 
     jobs:
       - job: Publishing
@@ -89,8 +89,8 @@ stages:
             condition: and(succeeded(), eq(variables.isVersionInFeed, false))
             inputs:
               command: publish
-              vstsFeedPublish: ${{ parameters.feed }}
-              vstsFeedPackagePublish: "${{ variables.rpmsPackageBaseName }}${{ variables.artifactSuffix }}"
+              vstsFeedPublish: ECF/TridentDev
+              vstsFeedPackagePublish: "rpms-dev"
               publishDirectory: "/tmp/rpms"
               versionPublish: $(Build.BuildNumber)
               versionOption: custom

--- a/.pipelines/templates/stages/publishing/publish.yml
+++ b/.pipelines/templates/stages/publishing/publish.yml
@@ -18,13 +18,13 @@ stages:
     dependsOn:
       - GetTridentBinaries_rpms_amd64
       - GetTridentBinaries_rpms_arm64
-      - ${{ if eq(parameters.stageType, 'pre') }}:
-          - DeploymentTesting_host
-          - DeploymentTesting_container
-          - FunctionalTesting
-          - BaremetalDeploymentTesting_host
-          - BaremetalDeploymentTesting_container
-          - ServicingTesting
+    #   - ${{ if eq(parameters.stageType, 'pre') }}:
+    #       - DeploymentTesting_host
+    #       - DeploymentTesting_container
+    #       - FunctionalTesting
+    #       - BaremetalDeploymentTesting_host
+    #       - BaremetalDeploymentTesting_container
+    #       - ServicingTesting
     # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main') )
 
     jobs:

--- a/.pipelines/templates/stages/publishing/publish.yml
+++ b/.pipelines/templates/stages/publishing/publish.yml
@@ -18,14 +18,14 @@ stages:
     dependsOn:
       - GetTridentBinaries_rpms_amd64
       - GetTridentBinaries_rpms_arm64
-    #   - ${{ if eq(parameters.stageType, 'pre') }}:
-    #       - DeploymentTesting_host
-    #       - DeploymentTesting_container
-    #       - FunctionalTesting
-    #       - BaremetalDeploymentTesting_host
-    #       - BaremetalDeploymentTesting_container
-    #       - ServicingTesting
-    # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main') )
+      - ${{ if eq(parameters.stageType, 'pre') }}:
+          - DeploymentTesting_host
+          - DeploymentTesting_container
+          - FunctionalTesting
+          - BaremetalDeploymentTesting_host
+          - BaremetalDeploymentTesting_container
+          - ServicingTesting
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main') )
 
     jobs:
       - job: Publishing
@@ -89,8 +89,8 @@ stages:
             condition: and(succeeded(), eq(variables.isVersionInFeed, false))
             inputs:
               command: publish
-              vstsFeedPublish: ECF/TridentDev
-              vstsFeedPackagePublish: "rpms-dev"
+              vstsFeedPublish: ${{ parameters.feed }}
+              vstsFeedPackagePublish: "${{ variables.rpmsPackageBaseName }}${{ variables.artifactSuffix }}"
               publishDirectory: "/tmp/rpms"
               versionPublish: $(Build.BuildNumber)
               versionOption: custom

--- a/.pipelines/templates/stages/publishing/publish.yml
+++ b/.pipelines/templates/stages/publishing/publish.yml
@@ -17,6 +17,7 @@ stages:
   - stage: Publishing
     dependsOn:
       - GetTridentBinaries_rpms_amd64
+      - GetTridentBinaries_rpms_arm64
       - ${{ if eq(parameters.stageType, 'pre') }}:
           - DeploymentTesting_host
           - DeploymentTesting_container
@@ -58,17 +59,31 @@ stages:
               artifactName: trident-binaries
             displayName: "Download Trident RPMs"
 
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              buildType: current
+              patterns: |
+                *.rpm
+              targetPath: /tmp/rpms-arm64
+              artifactName: trident-binaries-arm64
+            displayName: "Download Trident RPMs (arm64)"
+
           - script: |
               set -eux
 
-              alreadyPublished=$(./scripts/get-packages.py --debug \
+              amd64AlreadyPublished=$(./scripts/get-packages.py --debug \
+                  --package '${{ variables.rpmsPackageBaseName }}${{ variables.artifactSuffix }}' \
+                  --version '$(Build.BuildNumber)' \
+                  --action=exists)
+              arm64AlreadyPublished=$(./scripts/get-packages.py --debug \
                   --package '${{ variables.rpmsPackageBaseName }}${{ variables.artifactSuffix }}' \
                   --version '$(Build.BuildNumber)' \
                   --action=exists)
 
               # Save variable to know if package needs to be published
               set +x
-              echo "##vso[task.setvariable variable=isVersionInFeed;]$alreadyPublished"
+              echo "##vso[task.setvariable variable=isAmd64VersionInFeed;]$amd64AlreadyPublished"
+              echo "##vso[task.setvariable variable=isArm64VersionInFeed;]$arm64AlreadyPublished"
             displayName: "Check if package version has already been published in the feed."
             workingDirectory: $(TRIDENT_SOURCE_DIR)
             env:
@@ -76,11 +91,22 @@ stages:
 
           - task: UniversalPackages@0
             displayName: "Publish rpms Universal Package"
-            condition: and(succeeded(), eq(variables.isVersionInFeed, false))
+            condition: and(succeeded(), eq(variables.isAmd64VersionInFeed, false))
             inputs:
               command: publish
               vstsFeedPublish: ${{ parameters.feed }}
               vstsFeedPackagePublish: "${{ variables.rpmsPackageBaseName }}${{ variables.artifactSuffix }}"
               publishDirectory: "/tmp/rpms"
+              versionPublish: $(Build.BuildNumber)
+              versionOption: custom
+
+          - task: UniversalPackages@0
+            displayName: "Publish rpms-arm64 Universal Package"
+            condition: and(succeeded(), eq(variables.isArm64VersionInFeed, false))
+            inputs:
+              command: publish
+              vstsFeedPublish: ${{ parameters.feed }}
+              vstsFeedPackagePublish: "${{ variables.rpmsPackageBaseName }}-arm64${{ variables.artifactSuffix }}"
+              publishDirectory: "/tmp/rpms-arm64"
               versionPublish: $(Build.BuildNumber)
               versionOption: custom

--- a/.pipelines/templates/stages/publishing/release-artifacts.yml
+++ b/.pipelines/templates/stages/publishing/release-artifacts.yml
@@ -45,6 +45,15 @@ stages:
               artifactName: trident-binaries
             displayName: "Download Trident RPMs"
 
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              buildType: current
+              patterns: |
+                *.rpm
+              targetPath: $(Pipeline.Workspace)/rpms
+              artifactName: trident-binaries-arm64
+            displayName: "Download Trident RPMs (arm64)"
+
           - script: |
               set -eux
 

--- a/.pipelines/templates/stages/trident_rpms/release.yml
+++ b/.pipelines/templates/stages/trident_rpms/release.yml
@@ -73,6 +73,6 @@ steps:
     workingDirectory: ${{ parameters.tridentRepoDirectory }}
     displayName: Build RPMs
 
-  - script: ./scripts/extract-binary.sh ${{ parameters.artifactDirectory }} ${{ parameters.artifactDirectory }}
+  - script: ./scripts/extract-binary.sh ${{ parameters.artifactDirectory }} ${{ parameters.artifactDirectory }} ${{ parameters.targetArchitecture }}
     workingDirectory: ${{ parameters.tridentRepoDirectory }}
     displayName: Extract Trident binary

--- a/.pipelines/templates/stages/trident_rpms/trident-stage.yml
+++ b/.pipelines/templates/stages/trident_rpms/trident-stage.yml
@@ -68,7 +68,7 @@ stages:
             # Run CodeQL for this in CI only
             runCodeql: true
 
-  - ${{ elseif ne(parameters.tridentBuildOptions, 'prebuilt')) }}:
+  - ${{ elseif ne(parameters.tridentBuildOptions, 'prebuilt') }}:
       - template: ../download_staged/download-staged.yml
         parameters:
           artifactName: ${{ parameters.tridentArtifactName }}

--- a/.pipelines/templates/stages/trident_rpms/trident-stage.yml
+++ b/.pipelines/templates/stages/trident_rpms/trident-stage.yml
@@ -51,7 +51,7 @@ stages:
   # one that requires a build (pr, pr-e2e, ci).
   #
   # We do not currently stage arm64 binaries, so always build them for now.
-  - ${{ if or(eq(parameters.tridentBuildOptions, 'forceBuild'), eq(parameters.targetArchitecture, 'arm64'), eq(parameters.stageType, 'pr'), eq(parameters.stageType, 'pr-e2e'), eq(parameters.stageType, 'ci'), eq(parameters.stageType, 'pr-e2e-azure')) }}:
+  - ${{ if or(eq(parameters.tridentBuildOptions, 'forceBuild'), eq(parameters.stageType, 'pr'), eq(parameters.stageType, 'pr-e2e'), eq(parameters.stageType, 'ci'), eq(parameters.stageType, 'pr-e2e-azure')) }}:
       - template: build-source.yml
         parameters:
           tridentArtifactName: ${{ parameters.tridentArtifactName }}
@@ -68,9 +68,10 @@ stages:
             # Run CodeQL for this in CI only
             runCodeql: true
 
-  - ${{ elseif and(ne(parameters.tridentBuildOptions, 'prebuilt'), eq(parameters.targetArchitecture, 'amd64')) }}:
+  - ${{ elseif ne(parameters.tridentBuildOptions, 'prebuilt')) }}:
       - template: ../download_staged/download-staged.yml
         parameters:
           artifactName: ${{ parameters.tridentArtifactName }}
           stageType: ${{ parameters.stageType }}
           packageName: rpms
+          targetArchitecture: ${{ parameters.targetArchitecture }}

--- a/scripts/extract-binary.sh
+++ b/scripts/extract-binary.sh
@@ -6,7 +6,7 @@
 set -eux
 
 TMP_DIR=$(mktemp -d)
-RPM=$(find $1 | grep -P 'trident-\d.*\.rpm')
+RPM=$(find $1 | grep -P 'trident-\d.*\.x86_64\.rpm ')
 
 cp "$RPM" "$TMP_DIR/trident.rpm"
 

--- a/scripts/extract-binary.sh
+++ b/scripts/extract-binary.sh
@@ -6,7 +6,7 @@
 set -eux
 
 TMP_DIR=$(mktemp -d)
-RPM=$(find $1 | grep -P 'trident-\d.*\.x86_64\.rpm ')
+RPM=$(find $1 | grep -P 'trident-\d.*\.x86_64\.rpm')
 
 cp "$RPM" "$TMP_DIR/trident.rpm"
 

--- a/scripts/extract-binary.sh
+++ b/scripts/extract-binary.sh
@@ -5,8 +5,26 @@
 
 set -eux
 
+RPM_DIR=$1
+OUTPUT_PATH=$2
+ARCHITECTURE=$3
+
+RPM_ARCH=""
+case "$ARCHITECTURE" in
+  amd64)
+    RPM_ARCH="x86_64"
+    ;;
+  arm64)
+    RPM_ARCH="aarch64"
+    ;;
+  *)
+    echo "Unsupported architecture: $ARCHITECTURE"
+    exit 1
+    ;;
+esac
+
 TMP_DIR=$(mktemp -d)
-RPM=$(find $1 | grep -P 'trident-\d.*\.x86_64\.rpm')
+RPM=$(find $RPM_DIR | grep -P "trident-\d.*\.${RPM_ARCH}\.rpm")
 
 cp "$RPM" "$TMP_DIR/trident.rpm"
 
@@ -14,4 +32,4 @@ pushd "$TMP_DIR"
 rpm2cpio trident.rpm | cpio -idmv
 popd
 
-mv "$TMP_DIR/usr/bin/trident" $2
+mv "$TMP_DIR/usr/bin/trident" $OUTPUT_PATH


### PR DESCRIPTION
# 🔍 Description
 
arm64 rpms are being built in every pipeline currently.  instead, follow the pattern we have for amd64 rpms and build them in PR* and CI pipelines, then PRERELEASE can pull from the CI feed, RELEASE can pull from the PRERELEASE feed.

CI validation of build/publish: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1106430&view=results
PRERELEASE validation of download/publish: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1106458