### PR TITLE
tests: download staged should remove mismatched arch rpms

### DIFF
--- a/.pipelines/templates/stages/common_tasks/download-universal-artifact.yml
+++ b/.pipelines/templates/stages/common_tasks/download-universal-artifact.yml
@@ -16,6 +16,12 @@ parameters:
     type: string
     displayName: "Output variable containing the version of the downloaded package"
 
+  - name: targetArchitecture
+    type: string
+    values:
+      - amd64
+      - arm64
+
   - name: feedName
     type: string
     displayName: "Name of the feed to download the package from"
@@ -65,3 +71,18 @@ steps:
       vstsFeed: "ECF/${{ parameters.feedName }}"
       vstsFeedPackage: "${{ parameters.packageName }}"
       vstsPackageVersion: "$(${{ parameters.outputVersionVariable }})"
+
+  - script: |
+      set -eux
+
+      OTHER_ARCH_SUFFIX="aarch64.rpm"
+      if [ "${{ parameters.targetArchitecture }}" = "arm64" ]; then
+        OTHER_ARCH_SUFFIX="x86_64.rpm"
+      fi
+
+      find ${{ parameters.downloadLocation }} -name "*.${OTHER_ARCH_SUFFIX}" -type f -delete
+
+      echo "List remaining RPM files:"
+      find ${{ parameters.downloadLocation }} -name "*.rpm" -type f
+
+    displayName: "Remove RPMs for other architectures (if any)"

--- a/.pipelines/templates/stages/common_tasks/download-universal-artifact.yml
+++ b/.pipelines/templates/stages/common_tasks/download-universal-artifact.yml
@@ -72,17 +72,18 @@ steps:
       vstsFeedPackage: "${{ parameters.packageName }}"
       vstsPackageVersion: "$(${{ parameters.outputVersionVariable }})"
 
-  - script: |
-      set -eux
+  - ${{ if eq(parameters.packageName, 'rpms') }}:
+      - script: |
+          set -eux
 
-      OTHER_ARCH_SUFFIX="aarch64.rpm"
-      if [ "${{ parameters.targetArchitecture }}" = "arm64" ]; then
-        OTHER_ARCH_SUFFIX="x86_64.rpm"
-      fi
+          OTHER_ARCH_SUFFIX="aarch64.rpm"
+          if [ "${{ parameters.targetArchitecture }}" = "arm64" ]; then
+            OTHER_ARCH_SUFFIX="x86_64.rpm"
+          fi
 
-      find ${{ parameters.downloadLocation }} -name "*.${OTHER_ARCH_SUFFIX}" -type f -delete
+          find ${{ parameters.downloadLocation }} -name "*.${OTHER_ARCH_SUFFIX}" -type f -delete
 
-      echo "List remaining RPM files:"
-      find ${{ parameters.downloadLocation }} -name "*.rpm" -type f
+          echo "List remaining RPM files:"
+          find ${{ parameters.downloadLocation }} -name "*.rpm" -type f
 
-    displayName: "Remove RPMs for other architectures (if any)"
+        displayName: "Remove RPMs for other architectures (if any)"

--- a/.pipelines/templates/stages/common_tasks/download-universal-artifact.yml
+++ b/.pipelines/templates/stages/common_tasks/download-universal-artifact.yml
@@ -76,14 +76,15 @@ steps:
   - ${{ if startswith(parameters.packageName, 'rpms') }}:
       - script: |
           set -eux
-
+          # For amd64, get ride of *.aarch64.rpm
           OTHER_ARCH_SUFFIX="aarch64.rpm"
           if [ "${{ parameters.targetArchitecture }}" = "arm64" ]; then
+            # For arm64, get ride of *.x86_64.rpm
             OTHER_ARCH_SUFFIX="x86_64.rpm"
           fi
-
+          # Use find to delete all RPM files that match the other architecture suffix
           find ${{ parameters.downloadLocation }} -name "*.${OTHER_ARCH_SUFFIX}" -type f -delete
-
+          # List remaining RPM files to help pipeline debugging
           echo "List remaining RPM files:"
           find ${{ parameters.downloadLocation }} -name "*.rpm" -type f
 

--- a/.pipelines/templates/stages/common_tasks/download-universal-artifact.yml
+++ b/.pipelines/templates/stages/common_tasks/download-universal-artifact.yml
@@ -72,7 +72,8 @@ steps:
       vstsFeedPackage: "${{ parameters.packageName }}"
       vstsPackageVersion: "$(${{ parameters.outputVersionVariable }})"
 
-  - ${{ if eq(parameters.packageName, 'rpms') }}:
+  # For rpms, rpms-ci, etc, only keep RPMs that match the target architecture or are noarch
+  - ${{ if startswith(parameters.packageName, 'rpms') }}:
       - script: |
           set -eux
 

--- a/.pipelines/templates/stages/download_staged/download-staged.yml
+++ b/.pipelines/templates/stages/download_staged/download-staged.yml
@@ -73,6 +73,7 @@ stages:
               downloadLocation: $(ob_outputDirectory)
               outputVersionVariable: trident_version
               specificVersion: ${{ parameters.specificVersion }}
+              targetArchitecture: ${{ parameters.targetArchitecture }}
 
           - task: onebranch.pipeline.version@1
             displayName: "Set build number"


### PR DESCRIPTION
# 🔍 Description
 
Fix test regression introduced when trying to publish arm64 rpms:

* when downloading feed version (now containing arm and amd rpms), only retain intended arch and noarch.