### PR TITLE
engineering: Allow ACL Partition Types Past Static Validation

### DIFF
--- a/crates/trident_api/src/config/host/storage/partitions.rs
+++ b/crates/trident_api/src/config/host/storage/partitions.rs
@@ -7,7 +7,11 @@ use uuid::Uuid;
 #[cfg(feature = "schemars")]
 use schemars::JsonSchema;
 
-use crate::{constants::PARTITION_SIZE_GROW, primitives::bytes::ByteCount, BlockDeviceId};
+use crate::{
+    constants::{ACL_USR_PARTITION_TYPE_UUID, PARTITION_SIZE_GROW},
+    primitives::bytes::ByteCount,
+    BlockDeviceId,
+};
 
 #[cfg(feature = "schemars")]
 use crate::schema::{block_device_id_schema, unit_enum_with_untagged_variant};
@@ -203,6 +207,9 @@ impl PartitionType {
             Self::Root => Some(PartitionType::RootVerity),
             Self::Usr => Some(PartitionType::UsrVerity),
 
+            // Special case for ACL.
+            Self::Unknown(ACL_USR_PARTITION_TYPE_UUID) => Some(PartitionType::UsrVerity),
+
             // We permit the use of the generic Linux partition type for verity
             // partitions because it is the default type.
             Self::LinuxGeneric => Some(Self::LinuxGeneric),
@@ -249,7 +256,11 @@ impl From<PartitionType> for DiscoverablePartitionType {
 
 impl Display for PartitionType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_sdrepart_part_type())
+        if let Self::Unknown(uuid) = self {
+            write!(f, "{uuid}")
+        } else {
+            write!(f, "{}", self.to_sdrepart_part_type())
+        }
     }
 }
 

--- a/crates/trident_api/src/config/host/storage/partitions.rs
+++ b/crates/trident_api/src/config/host/storage/partitions.rs
@@ -179,6 +179,16 @@ pub enum PartitionType {
 }
 
 impl PartitionType {
+    /// Returns the ACL partition type that is treated as USR-like in storage validation.
+    pub fn acl_usr() -> Self {
+        Self::Unknown(ACL_USR_PARTITION_TYPE_UUID)
+    }
+
+    /// Returns true when this partition type is the ACL USR-equivalent partition type.
+    pub fn is_acl_usr(&self) -> bool {
+        matches!(self, Self::Unknown(uuid) if *uuid == ACL_USR_PARTITION_TYPE_UUID)
+    }
+
     /// Helper function that returns PartititionType as a string. Return values
     /// are based on GPT partition type identifiers, as defined in the Type
     /// section of systemd repart.d manual:
@@ -203,12 +213,13 @@ impl PartitionType {
 
     /// Returns the corresponding verity partition type for a given partition type.
     pub fn to_verity(&self) -> Option<Self> {
+        if self.is_acl_usr() {
+            return Some(PartitionType::UsrVerity);
+        }
+
         match self {
             Self::Root => Some(PartitionType::RootVerity),
             Self::Usr => Some(PartitionType::UsrVerity),
-
-            // Special case for ACL.
-            Self::Unknown(ACL_USR_PARTITION_TYPE_UUID) => Some(PartitionType::UsrVerity),
 
             // We permit the use of the generic Linux partition type for verity
             // partitions because it is the default type.

--- a/crates/trident_api/src/config/host/storage/partitions.rs
+++ b/crates/trident_api/src/config/host/storage/partitions.rs
@@ -266,9 +266,11 @@ impl From<PartitionType> for DiscoverablePartitionType {
 }
 
 impl Display for PartitionType {
+    /// Formats known partition types using systemd-repart names and unknown
+    /// partition types as `unknown(<uuid>)` to preserve UUID visibility.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Self::Unknown(uuid) = self {
-            write!(f, "{uuid}")
+            write!(f, "unknown({uuid})")
         } else {
             write!(f, "{}", self.to_sdrepart_part_type())
         }

--- a/crates/trident_api/src/config/host/storage/storage_graph/rules/mod.rs
+++ b/crates/trident_api/src/config/host/storage/storage_graph/rules/mod.rs
@@ -17,11 +17,9 @@ use std::{
 
 use anyhow::{bail, ensure, Error};
 
-use crate::{
-    config::{
-        FileSystemSource, FileSystemType, HostConfigurationStaticValidationError,
-        NewFileSystemType, Partition, PartitionSize, PartitionType, RaidLevel,
-    },
+use crate::config::{
+    FileSystemSource, FileSystemType, HostConfigurationStaticValidationError, NewFileSystemType,
+    Partition, PartitionSize, PartitionType, RaidLevel,
 };
 
 use super::{

--- a/crates/trident_api/src/config/host/storage/storage_graph/rules/mod.rs
+++ b/crates/trident_api/src/config/host/storage/storage_graph/rules/mod.rs
@@ -17,9 +17,12 @@ use std::{
 
 use anyhow::{bail, ensure, Error};
 
-use crate::config::{
-    FileSystemSource, FileSystemType, HostConfigurationStaticValidationError, NewFileSystemType,
-    Partition, PartitionSize, PartitionType, RaidLevel,
+use crate::{
+    config::{
+        FileSystemSource, FileSystemType, HostConfigurationStaticValidationError,
+        NewFileSystemType, Partition, PartitionSize, PartitionType, RaidLevel,
+    },
+    constants::ACL_USR_PARTITION_TYPE_UUID,
 };
 
 use super::{
@@ -470,6 +473,8 @@ impl BlkDevReferrerKind {
                 PartitionType::Usr,
                 PartitionType::UsrVerity,
                 PartitionType::LinuxGeneric,
+                // Special case for ACL.
+                PartitionType::Unknown(ACL_USR_PARTITION_TYPE_UUID),
             ]),
             Self::FileSystemImage => AllowBlockList::Any,
             Self::Swap => AllowBlockList::Allow(vec![PartitionType::Swap]),
@@ -488,6 +493,8 @@ impl SpecialReferenceKind {
                 PartitionType::Root,
                 PartitionType::Usr,
                 PartitionType::LinuxGeneric,
+                // Special case for ACL.
+                PartitionType::Unknown(ACL_USR_PARTITION_TYPE_UUID),
             ])),
             Self::VerityHashDevice => Some(AllowBlockList::Allow(vec![
                 PartitionType::RootVerity,

--- a/crates/trident_api/src/config/host/storage/storage_graph/rules/mod.rs
+++ b/crates/trident_api/src/config/host/storage/storage_graph/rules/mod.rs
@@ -22,7 +22,6 @@ use crate::{
         FileSystemSource, FileSystemType, HostConfigurationStaticValidationError,
         NewFileSystemType, Partition, PartitionSize, PartitionType, RaidLevel,
     },
-    constants::ACL_USR_PARTITION_TYPE_UUID,
 };
 
 use super::{
@@ -474,7 +473,7 @@ impl BlkDevReferrerKind {
                 PartitionType::UsrVerity,
                 PartitionType::LinuxGeneric,
                 // Special case for ACL.
-                PartitionType::Unknown(ACL_USR_PARTITION_TYPE_UUID),
+                PartitionType::acl_usr(),
             ]),
             Self::FileSystemImage => AllowBlockList::Any,
             Self::Swap => AllowBlockList::Allow(vec![PartitionType::Swap]),
@@ -494,7 +493,7 @@ impl SpecialReferenceKind {
                 PartitionType::Usr,
                 PartitionType::LinuxGeneric,
                 // Special case for ACL.
-                PartitionType::Unknown(ACL_USR_PARTITION_TYPE_UUID),
+                PartitionType::acl_usr(),
             ])),
             Self::VerityHashDevice => Some(AllowBlockList::Allow(vec![
                 PartitionType::RootVerity,

--- a/crates/trident_api/src/constants.rs
+++ b/crates/trident_api/src/constants.rs
@@ -190,8 +190,7 @@ pub const VALID_CONFEXT_DIRECTORIES: [&str; 3] = [
 ];
 
 /// ACL USR partition type UUID.
-pub const ACL_USR_PARTITION_TYPE_UUID: Uuid =
-    Uuid::from_u128(0x5dfbf5f4_2848_4bac_aa5e_0d9a20b745a6);
+pub const ACL_USR_PARTITION_TYPE_UUID: Uuid = uuid::uuid!("5dfbf5f4-2848-4bac-aa5e-0d9a20b745a6");
 
 /// Internal-only overrides
 pub mod internal_params {

--- a/crates/trident_api/src/constants.rs
+++ b/crates/trident_api/src/constants.rs
@@ -1,4 +1,5 @@
 use const_format::formatcp;
+use uuid::Uuid;
 
 // Configuration constants
 
@@ -187,6 +188,10 @@ pub const VALID_CONFEXT_DIRECTORIES: [&str; 3] = [
     "/usr/lib/confexts",
     "/usr/local/lib/confexts",
 ];
+
+/// ACL USR partition type UUID.
+pub const ACL_USR_PARTITION_TYPE_UUID: Uuid =
+    Uuid::from_u128(0x5dfbf5f4_2848_4bac_aa5e_0d9a20b745a6);
 
 /// Internal-only overrides
 pub mod internal_params {


### PR DESCRIPTION
# 🔍 Description
 
Support ACL's inherited custom USR partition type: `5dfbf5f4-2848-4bac-aa5e-0d9a20b745a6`
