### PR TITLE
storm: truncate serial log in WaitForLogin to prevent unbounded growth

### DIFF
--- a/.pipelines/templates/stages/testing_servicing/testing-template.yml
+++ b/.pipelines/templates/stages/testing_servicing/testing-template.yml
@@ -198,6 +198,16 @@ jobs:
             sudo apt install -y imagemagick
           displayName: "Install imagemagick for libvirt screenshot capture"
 
+        - bash: |
+            set -eux
+
+            # Disable virtlogd rollover by setting max_size to 0
+            cat /etc/libvirt/virtlogd.conf
+            echo "max_size = 0" | sudo tee -a /etc/libvirt/virtlogd.conf
+            cat /etc/libvirt/virtlogd.conf
+            sudo systemctl restart virtlogd.socket
+          displayName: "Disable virtlogd log rollover"
+
       - bash: |
           echo "##vso[task.setvariable variable=STORM_SCENARIO_FINISHED;]false"
         displayName: "Initialize STORM_SCENARIO_FINISHED=false"

--- a/tools/storm/utils/vm/qemu/qemu.go
+++ b/tools/storm/utils/vm/qemu/qemu.go
@@ -295,10 +295,12 @@ func (cfg QemuConfig) createQemuVM(name string, bootImage string, useVirtInstall
 }
 
 func (cfg QemuConfig) TruncateLog(vmName string) error {
-	// If domain exists, truncate the serial log file
+	// If domain exists and serial log file exists, truncate the serial log file
 	if _, _, err := getLibvirtDomainByname(vmName); err == nil {
-		if err := exec.Command("truncate", "-s", "0", cfg.SerialLog).Run(); err != nil {
-			return fmt.Errorf("failed to truncate log file: %w", err)
+		if _, err := os.Stat(cfg.SerialLog); err == nil {
+			if err := exec.Command("truncate", "-s", "0", cfg.SerialLog).Run(); err != nil {
+				return fmt.Errorf("failed to truncate log file: %w", err)
+			}
 		}
 	}
 	return nil
@@ -319,6 +321,13 @@ func (cfg QemuConfig) WaitForLogin(vmName string, outputPath string, verbose boo
 		if err := exec.Command("cp", localSerialLog, filepath.Join(outputPath, outputFilename)).Run(); err != nil {
 			return fmt.Errorf("failed to copy serial log to output directory: %w", err)
 		}
+	}
+
+	// Truncate the serial log after saving to prevent unbounded growth across iterations.
+	// Without truncation, the serial log accumulates all prior boot sequences, eventually
+	// causing the serial console capture to be cut off mid-boot.
+	if truncErr := cfg.TruncateLog(vmName); truncErr != nil {
+		logrus.Warnf("Failed to truncate serial log after iteration %d: %v", iteration, truncErr)
 	}
 
 	if waitErr != nil {


### PR DESCRIPTION
## Problem

The QEMU serial log file accumulates all boot sequences across update iterations without being truncated. By iteration 9 (~2MB / 10 boot sequences), the serial console capture gets cut off mid-boot, causing `WaitForLogin` to time out waiting for a login prompt that was never recorded — even though the VM boots successfully (confirmed via VGA screenshot).

This is the root cause of **100% qemu failures** in the scale test pipeline, where all qemu jobs fail at update-loop iteration 9 with `timeout waiting for login prompt after 120 seconds`.

## Analysis

| Iteration | Serial Log Lines | Boot Sequences | Reaches Login? |
|-----------|-----------------|----------------|----------------|
| 0 | 1,124 | 1 | Yes |
| 5 | 12,712 | 6 | Yes |
| 8 | 19,691 | 9 | Yes |
| 9 | 21,745 | 10 | No (truncated at 1,183 lines into final boot) |

The `sda11 is in use` fsck error in serial logs is a **red herring** — it appears in every boot including successful ones.

## Fix

Add `cfg.TruncateLog(vmName)` in `WaitForLogin` after the serial log is saved to the output directory. This matches the pattern already used by the rollback tests via `saveSerialAndTruncate` in `tools/storm/rollback/tests/helper.go`.