### PR TITLE
Fix 'YAML is too big' in scale pipeline + truncate serial log

### DIFF
--- a/.pipelines/templates/scale-template.yml
+++ b/.pipelines/templates/scale-template.yml
@@ -106,3 +106,18 @@ stages:
       includeAzure: ${{ parameters.includeAzure }}
       includeUKI: ${{ parameters.includeUKI }}
       dependsOnStage: CreateBaseImageConfig
+      # Split 256 workers into 4 batches of 64 to stay under ADO's per-phase
+      # YAML expansion limit. Each batch becomes a separate parallel job group.
+      workerBatches:
+        - id: "_a"
+          offset: 0
+          size: 64
+        - id: "_b"
+          offset: 64
+          size: 64
+        - id: "_c"
+          offset: 128
+          size: 64
+        - id: "_d"
+          offset: 192
+          size: 64

--- a/.pipelines/templates/scale-template.yml
+++ b/.pipelines/templates/scale-template.yml
@@ -109,15 +109,11 @@ stages:
       # Split 256 workers into 4 batches of 64 to stay under ADO's per-phase
       # YAML expansion limit. Each batch becomes a separate parallel job group.
       workerBatches:
-        - id: "_a"
-          offset: 0
+        - id: 0
           size: 64
-        - id: "_b"
-          offset: 64
+        - id: 1
           size: 64
-        - id: "_c"
-          offset: 128
+        - id: 2
           size: 64
-        - id: "_d"
-          offset: 192
+        - id: 3
           size: 64

--- a/.pipelines/templates/stages/testing_servicing/testing-template.yml
+++ b/.pipelines/templates/stages/testing_servicing/testing-template.yml
@@ -14,15 +14,10 @@ parameters:
     type: number
     default: 1
 
-  - name: workerOffset
-    displayName: "Offset for global worker numbering (batch_index * workers_per_batch)"
-    type: number
-    default: 0
-
   - name: batchId
     displayName: "Batch identifier for unique job naming"
-    type: string
-    default: ""
+    type: number
+    default: 0
 
   - name: updateCheckTimeoutInMinutes
     displayName: "Timeout for checking target OS deployment in minutes"
@@ -66,8 +61,8 @@ parameters:
     default: false
 
 jobs:
-  - job: UpdateTesting_${{ parameters.flavor }}${{ parameters.batchId }}
-    displayName: Update Testing - ${{ parameters.flavor }}${{ parameters.batchId }}
+  - job: UpdateTesting_${{ parameters.flavor }}_${{ parameters.batchId }}
+    displayName: Update Testing - ${{ parameters.flavor }} - ${{ parameters.batchId }}
     timeoutInMinutes: ${{ parameters.updateCheckTimeoutInMinutes }}
     pool:
       type: linux
@@ -80,20 +75,12 @@ jobs:
         - PublishAzureImage
 
     variables:
-      ob_outputDirectory: /tmp/deployment_logs_${{ parameters.flavor }}${{ parameters.batchId }}
-      ob_artifactBaseName: "update-testing-${{ parameters.flavor }}${{ parameters.batchId }}-$(System.JobPositionInPhase)"
-      TEST_RESOURCE_GROUP: trident-vm-servicing-validation-$(Build.BuildId)${{ parameters.batchId }}-$(System.JobPositionInPhase)
-      WORKER_OFFSET: ${{ parameters.workerOffset }}
+      ob_outputDirectory: /tmp/deployment_logs_${{ parameters.flavor }}_${{ parameters.batchId }}
+      ob_artifactBaseName: "update-testing-${{ parameters.flavor }}-${{ parameters.batchId }}-$(System.JobPositionInPhase)"
+      TEST_RESOURCE_GROUP: trident-vm-servicing-validation-$(Build.BuildId)-${{ parameters.batchId }}-$(System.JobPositionInPhase)
 
     steps:
       - template: ../common_tasks/checkout_trident.yml
-      - bash: |
-          GLOBAL_POS=$(( $WORKER_OFFSET + $(System.JobPositionInPhase) ))
-          PADDED=$(printf '%03d' $GLOBAL_POS)
-          echo "##vso[task.setvariable variable=ob_artifactBaseName;]update-testing-${{ parameters.flavor }}-${PADDED}"
-          echo "##vso[task.setvariable variable=TEST_RESOURCE_GROUP;]trident-vm-servicing-validation-$(Build.BuildId)-${PADDED}"
-        displayName: "Set variables"
-
       - ${{ if eq(parameters.platform, 'azure') }}:
           - task: DownloadPipelineArtifact@2
             inputs:

--- a/.pipelines/templates/stages/testing_servicing/testing-template.yml
+++ b/.pipelines/templates/stages/testing_servicing/testing-template.yml
@@ -10,9 +10,19 @@ parameters:
     default: true
 
   - name: workers
-    displayName: "Number of workers to use"
+    displayName: "Number of workers in this batch"
     type: number
     default: 1
+
+  - name: workerOffset
+    displayName: "Offset for global worker numbering (batch_index * workers_per_batch)"
+    type: number
+    default: 0
+
+  - name: batchId
+    displayName: "Batch identifier for unique job naming"
+    type: string
+    default: ""
 
   - name: updateCheckTimeoutInMinutes
     displayName: "Timeout for checking target OS deployment in minutes"
@@ -110,8 +120,8 @@ jobs:
               ARTIFACTS: $(Build.ArtifactStagingDirectory)
               AZCOPY_AUTO_LOGIN_TYPE: "AZCLI"
 
-  - job: UpdateTesting_${{ parameters.flavor }}
-    displayName: Update Testing - ${{ parameters.flavor }}
+  - job: UpdateTesting_${{ parameters.flavor }}${{ parameters.batchId }}
+    displayName: Update Testing - ${{ parameters.flavor }}${{ parameters.batchId }}
     timeoutInMinutes: ${{ parameters.updateCheckTimeoutInMinutes }}
     pool:
       type: linux
@@ -127,12 +137,15 @@ jobs:
       ob_outputDirectory: /tmp/deployment_logs_${{ parameters.flavor }}
       ob_artifactBaseName: "update-testing-${{ parameters.flavor }}-$(System.JobPositionInPhase)"
       TEST_RESOURCE_GROUP: trident-vm-servicing-validation-$(Build.BuildId)-$(System.JobPositionInPhase)
+      WORKER_OFFSET: ${{ parameters.workerOffset }}
 
     steps:
       - template: ../common_tasks/checkout_trident.yml
       - bash: |
-          echo "##vso[task.setvariable variable=ob_artifactBaseName;]update-testing-${{ parameters.flavor }}-$(printf '%03d' $(System.JobPositionInPhase))"
-          echo "##vso[task.setvariable variable=TEST_RESOURCE_GROUP;]trident-vm-servicing-validation-$(Build.BuildId)-$(printf '%03d' $(System.JobPositionInPhase))"
+          GLOBAL_POS=$(( $WORKER_OFFSET + $(System.JobPositionInPhase) ))
+          PADDED=$(printf '%03d' $GLOBAL_POS)
+          echo "##vso[task.setvariable variable=ob_artifactBaseName;]update-testing-${{ parameters.flavor }}-${PADDED}"
+          echo "##vso[task.setvariable variable=TEST_RESOURCE_GROUP;]trident-vm-servicing-validation-$(Build.BuildId)-${PADDED}"
         displayName: "Set variables"
 
       - ${{ if eq(parameters.platform, 'azure') }}:

--- a/.pipelines/templates/stages/testing_servicing/testing-template.yml
+++ b/.pipelines/templates/stages/testing_servicing/testing-template.yml
@@ -61,65 +61,11 @@ parameters:
     type: boolean
     default: true
 
+  - name: dependsOnPublishAzureImage
+    type: boolean
+    default: false
+
 jobs:
-  # For azure tests where there are multiple workers, use a dedicated job to publish the base
-  # image.  Otherwise, the publish will be done as part of the actual test.
-  - ${{ if and(eq(parameters.platform, 'azure'), gt(parameters.workers, 1)) }}:
-      - job: PublishAzureImage
-        displayName: Publish Azure Image
-        timeoutInMinutes: 20
-        pool:
-          type: linux
-          name: ${{ parameters.pool }}
-          hostArchitecture: amd64
-        variables:
-          ob_outputDirectory: /tmp/logs
-        steps:
-          - template: ../common_tasks/checkout_trident.yml
-          - task: DownloadPipelineArtifact@2
-            displayName: "Download go-tools: storm"
-            inputs:
-              buildType: current
-              artifactName: "go-tools"
-              patterns: |
-                storm-trident
-              targetPath: "$(TRIDENT_SOURCE_DIR)/bin"
-          - bash: |
-              set -eux
-              chmod +x $(TRIDENT_SOURCE_DIR)/bin/storm-trident
-              mkdir -p $(ob_outputDirectory)
-            displayName: Make storm executable and create output directory
-          - task: DownloadPipelineArtifact@2
-            inputs:
-              buildType: current
-              artifactName: image-${{ parameters.platform }}-base
-              targetPath: "$(Build.ArtifactStagingDirectory)/"
-            displayName: Download Base Image
-          - task: AzureCLI@2
-            inputs:
-              azureSubscription: trident-servicing-test
-              scriptType: bash
-              scriptLocation: inlineScript
-              inlineScript: |
-                set -eux
-
-                cd $(TRIDENT_SOURCE_DIR)
-                ./bin/storm-trident run servicing -a \
-                  --output-path $(ob_outputDirectory) \
-                  --platform ${{ parameters.platform }} \
-                  --artifacts-dir $ARTIFACTS \
-                  --use-private-ip-address \
-                  --build-id $(Build.BuildId) \
-                  --subscription $(SUBSCRIPTION) \
-                  --image-definition $(IMAGE_DEFINITION) \
-                  --storage-account $(STORAGE_ACCOUNT) \
-                  --storage-account-resource-group $(RESOURCE_GROUP) \
-                  --test-case-to-run publish-sig-image
-            displayName: Publish Base Image
-            env:
-              ARTIFACTS: $(Build.ArtifactStagingDirectory)
-              AZCOPY_AUTO_LOGIN_TYPE: "AZCLI"
-
   - job: UpdateTesting_${{ parameters.flavor }}${{ parameters.batchId }}
     displayName: Update Testing - ${{ parameters.flavor }}${{ parameters.batchId }}
     timeoutInMinutes: ${{ parameters.updateCheckTimeoutInMinutes }}
@@ -129,9 +75,9 @@ jobs:
       hostArchitecture: amd64
     strategy:
       parallel: ${{ parameters.workers }}
-    dependsOn:
-      - ${{ if and(eq(parameters.platform, 'azure'), gt(parameters.workers, 1)) }}:
-          - PublishAzureImage
+    ${{ if eq(parameters.dependsOnPublishAzureImage, true) }}:
+      dependsOn:
+        - PublishAzureImage
 
     variables:
       ob_outputDirectory: /tmp/deployment_logs_${{ parameters.flavor }}

--- a/.pipelines/templates/stages/testing_servicing/testing-template.yml
+++ b/.pipelines/templates/stages/testing_servicing/testing-template.yml
@@ -80,9 +80,9 @@ jobs:
         - PublishAzureImage
 
     variables:
-      ob_outputDirectory: /tmp/deployment_logs_${{ parameters.flavor }}
-      ob_artifactBaseName: "update-testing-${{ parameters.flavor }}-$(System.JobPositionInPhase)"
-      TEST_RESOURCE_GROUP: trident-vm-servicing-validation-$(Build.BuildId)-$(System.JobPositionInPhase)
+      ob_outputDirectory: /tmp/deployment_logs_${{ parameters.flavor }}${{ parameters.batchId }}
+      ob_artifactBaseName: "update-testing-${{ parameters.flavor }}${{ parameters.batchId }}-$(System.JobPositionInPhase)"
+      TEST_RESOURCE_GROUP: trident-vm-servicing-validation-$(Build.BuildId)${{ parameters.batchId }}-$(System.JobPositionInPhase)
       WORKER_OFFSET: ${{ parameters.workerOffset }}
 
     steps:

--- a/.pipelines/templates/stages/testing_servicing/testing-template.yml
+++ b/.pipelines/templates/stages/testing_servicing/testing-template.yml
@@ -198,6 +198,16 @@ jobs:
             sudo apt install -y imagemagick
           displayName: "Install imagemagick for libvirt screenshot capture"
 
+        - bash: |
+            set -eux
+
+            # Disable virtlogd rollover by setting max_size to 0
+            cat /etc/libvirt/virtlogd.conf
+            echo "max_size = 0" | sudo tee -a /etc/libvirt/virtlogd.conf
+            cat /etc/libvirt/virtlogd.conf
+            sudo systemctl restart virtlogd.socket
+          displayName: "Disable virtlogd log rollover"
+
       - bash: |
           echo "##vso[task.setvariable variable=STORM_SCENARIO_FINISHED;]false"
         displayName: "Initialize STORM_SCENARIO_FINISHED=false"

--- a/.pipelines/templates/stages/testing_servicing/vm-testing.yml
+++ b/.pipelines/templates/stages/testing_servicing/vm-testing.yml
@@ -251,6 +251,62 @@ stages:
                   testSecureBoot: ${{ parameters.testSecureBoot }}
 
       - ${{ if eq(parameters.includeAzure, true) }}:
+          # Publish the base image once for all azure workers to share
+          - ${{ if gt(parameters.workers, 1) }}:
+              - job: PublishAzureImage
+                displayName: Publish Azure Image
+                timeoutInMinutes: 20
+                pool:
+                  type: linux
+                  name: trident-ubuntu-official-1es-pool-eastus2
+                  hostArchitecture: amd64
+                variables:
+                  ob_outputDirectory: /tmp/logs
+                steps:
+                  - template: ../common_tasks/checkout_trident.yml
+                  - task: DownloadPipelineArtifact@2
+                    displayName: "Download go-tools: storm"
+                    inputs:
+                      buildType: current
+                      artifactName: "go-tools"
+                      patterns: |
+                        storm-trident
+                      targetPath: "$(TRIDENT_SOURCE_DIR)/bin"
+                  - bash: |
+                      set -eux
+                      chmod +x $(TRIDENT_SOURCE_DIR)/bin/storm-trident
+                      mkdir -p $(ob_outputDirectory)
+                    displayName: Make storm executable and create output directory
+                  - task: DownloadPipelineArtifact@2
+                    inputs:
+                      buildType: current
+                      artifactName: image-azure-base
+                      targetPath: "$(Build.ArtifactStagingDirectory)/"
+                    displayName: Download Base Image
+                  - task: AzureCLI@2
+                    inputs:
+                      azureSubscription: trident-servicing-test
+                      scriptType: bash
+                      scriptLocation: inlineScript
+                      inlineScript: |
+                        set -eux
+
+                        cd $(TRIDENT_SOURCE_DIR)
+                        ./bin/storm-trident run servicing -a \
+                          --output-path $(ob_outputDirectory) \
+                          --platform azure \
+                          --artifacts-dir $ARTIFACTS \
+                          --use-private-ip-address \
+                          --build-id $(Build.BuildId) \
+                          --subscription $(SUBSCRIPTION) \
+                          --image-definition $(IMAGE_DEFINITION) \
+                          --storage-account $(STORAGE_ACCOUNT) \
+                          --storage-account-resource-group $(RESOURCE_GROUP) \
+                          --test-case-to-run publish-sig-image
+                    displayName: Publish Base Image
+                    env:
+                      ARTIFACTS: $(Build.ArtifactStagingDirectory)
+                      AZCOPY_AUTO_LOGIN_TYPE: "AZCLI"
           - ${{ each batch in parameters.workerBatches }}:
               - template: testing-template.yml
                 parameters:
@@ -265,6 +321,7 @@ stages:
                   flavor: azure
                   pool: trident-ubuntu-official-1es-pool-eastus2
                   testSecureBoot: ${{ parameters.testSecureBoot }}
+                  dependsOnPublishAzureImage: ${{ gt(parameters.workers, 1) }}
 
       - ${{ if eq(parameters.includeUKI, true) }}:
           - ${{ each batch in parameters.workerBatches }}:

--- a/.pipelines/templates/stages/testing_servicing/vm-testing.yml
+++ b/.pipelines/templates/stages/testing_servicing/vm-testing.yml
@@ -24,6 +24,19 @@ parameters:
     type: number
     default: 1
 
+  - name: workersPerBatch
+    displayName: "Max workers per batch (splits large worker counts into multiple phases)"
+    type: number
+    default: 64
+
+  - name: workerBatches
+    displayName: "Worker batch definitions (offset and size for each batch)"
+    type: object
+    default:
+      - id: ""
+        offset: 0
+        size: 1
+
   - name: updateCheckTimeoutInMinutes
     displayName: "Timeout for checking target OS deployment in minutes"
     type: number
@@ -223,38 +236,47 @@ stages:
 
     jobs:
       - ${{ if eq(parameters.includeQemu, true) }}:
-          - template: testing-template.yml
-            parameters:
-              updateIterationCount: ${{ parameters.updateIterationCount }}
-              rollbackTesting: ${{ parameters.rollbackTesting }}
-              workers: ${{ parameters.workers }}
-              updateCheckTimeoutInMinutes: ${{ parameters.updateCheckTimeoutInMinutes }}
-              verboseLogging: ${{ parameters.verboseLogging }}
-              platform: qemu
-              flavor: qemu
-              testSecureBoot: ${{ parameters.testSecureBoot }}
+          - ${{ each batch in parameters.workerBatches }}:
+              - template: testing-template.yml
+                parameters:
+                  updateIterationCount: ${{ parameters.updateIterationCount }}
+                  rollbackTesting: ${{ parameters.rollbackTesting }}
+                  workers: ${{ batch.size }}
+                  workerOffset: ${{ batch.offset }}
+                  batchId: ${{ batch.id }}
+                  updateCheckTimeoutInMinutes: ${{ parameters.updateCheckTimeoutInMinutes }}
+                  verboseLogging: ${{ parameters.verboseLogging }}
+                  platform: qemu
+                  flavor: qemu
+                  testSecureBoot: ${{ parameters.testSecureBoot }}
 
       - ${{ if eq(parameters.includeAzure, true) }}:
-          - template: testing-template.yml
-            parameters:
-              updateIterationCount: ${{ parameters.updateIterationCount }}
-              rollbackTesting: ${{ parameters.rollbackTesting }}
-              workers: ${{ parameters.workers }}
-              updateCheckTimeoutInMinutes: ${{ parameters.updateCheckTimeoutInMinutes }}
-              verboseLogging: ${{ parameters.verboseLogging }}
-              platform: azure
-              flavor: azure
-              pool: trident-ubuntu-official-1es-pool-eastus2
-              testSecureBoot: ${{ parameters.testSecureBoot }}
+          - ${{ each batch in parameters.workerBatches }}:
+              - template: testing-template.yml
+                parameters:
+                  updateIterationCount: ${{ parameters.updateIterationCount }}
+                  rollbackTesting: ${{ parameters.rollbackTesting }}
+                  workers: ${{ batch.size }}
+                  workerOffset: ${{ batch.offset }}
+                  batchId: ${{ batch.id }}
+                  updateCheckTimeoutInMinutes: ${{ parameters.updateCheckTimeoutInMinutes }}
+                  verboseLogging: ${{ parameters.verboseLogging }}
+                  platform: azure
+                  flavor: azure
+                  pool: trident-ubuntu-official-1es-pool-eastus2
+                  testSecureBoot: ${{ parameters.testSecureBoot }}
 
       - ${{ if eq(parameters.includeUKI, true) }}:
-          - template: testing-template.yml
-            parameters:
-              updateIterationCount: ${{ parameters.updateIterationCount }}
-              rollbackTesting: ${{ parameters.rollbackTesting }}
-              workers: ${{ parameters.workers }}
-              updateCheckTimeoutInMinutes: ${{ parameters.updateCheckTimeoutInMinutes }}
-              verboseLogging: ${{ parameters.verboseLogging }}
-              platform: qemu
-              flavor: uki
-              testSecureBoot: ${{ parameters.testSecureBoot }}
+          - ${{ each batch in parameters.workerBatches }}:
+              - template: testing-template.yml
+                parameters:
+                  updateIterationCount: ${{ parameters.updateIterationCount }}
+                  rollbackTesting: ${{ parameters.rollbackTesting }}
+                  workers: ${{ batch.size }}
+                  workerOffset: ${{ batch.offset }}
+                  batchId: ${{ batch.id }}
+                  updateCheckTimeoutInMinutes: ${{ parameters.updateCheckTimeoutInMinutes }}
+                  verboseLogging: ${{ parameters.verboseLogging }}
+                  platform: qemu
+                  flavor: uki
+                  testSecureBoot: ${{ parameters.testSecureBoot }}

--- a/.pipelines/templates/stages/testing_servicing/vm-testing.yml
+++ b/.pipelines/templates/stages/testing_servicing/vm-testing.yml
@@ -30,11 +30,10 @@ parameters:
     default: 64
 
   - name: workerBatches
-    displayName: "Worker batch definitions (offset and size for each batch)"
+    displayName: "Worker batch definitions for splitting parallel jobs"
     type: object
     default:
-      - id: ""
-        offset: 0
+      - id: 0
         size: 1
 
   - name: updateCheckTimeoutInMinutes
@@ -242,7 +241,6 @@ stages:
                   updateIterationCount: ${{ parameters.updateIterationCount }}
                   rollbackTesting: ${{ parameters.rollbackTesting }}
                   workers: ${{ batch.size }}
-                  workerOffset: ${{ batch.offset }}
                   batchId: ${{ batch.id }}
                   updateCheckTimeoutInMinutes: ${{ parameters.updateCheckTimeoutInMinutes }}
                   verboseLogging: ${{ parameters.verboseLogging }}
@@ -313,7 +311,6 @@ stages:
                   updateIterationCount: ${{ parameters.updateIterationCount }}
                   rollbackTesting: ${{ parameters.rollbackTesting }}
                   workers: ${{ batch.size }}
-                  workerOffset: ${{ batch.offset }}
                   batchId: ${{ batch.id }}
                   updateCheckTimeoutInMinutes: ${{ parameters.updateCheckTimeoutInMinutes }}
                   verboseLogging: ${{ parameters.verboseLogging }}
@@ -330,7 +327,6 @@ stages:
                   updateIterationCount: ${{ parameters.updateIterationCount }}
                   rollbackTesting: ${{ parameters.rollbackTesting }}
                   workers: ${{ batch.size }}
-                  workerOffset: ${{ batch.offset }}
                   batchId: ${{ batch.id }}
                   updateCheckTimeoutInMinutes: ${{ parameters.updateCheckTimeoutInMinutes }}
                   verboseLogging: ${{ parameters.verboseLogging }}

--- a/tools/storm/utils/vm/qemu/qemu.go
+++ b/tools/storm/utils/vm/qemu/qemu.go
@@ -295,10 +295,12 @@ func (cfg QemuConfig) createQemuVM(name string, bootImage string, useVirtInstall
 }
 
 func (cfg QemuConfig) TruncateLog(vmName string) error {
-	// If domain exists, truncate the serial log file
+	// If domain exists and serial log file exists, truncate the serial log file
 	if _, _, err := getLibvirtDomainByname(vmName); err == nil {
-		if err := exec.Command("truncate", "-s", "0", cfg.SerialLog).Run(); err != nil {
-			return fmt.Errorf("failed to truncate log file: %w", err)
+		if _, err := os.Stat(cfg.SerialLog); err == nil {
+			if err := exec.Command("truncate", "-s", "0", cfg.SerialLog).Run(); err != nil {
+				return fmt.Errorf("failed to truncate log file: %w", err)
+			}
 		}
 	}
 	return nil
@@ -319,6 +321,13 @@ func (cfg QemuConfig) WaitForLogin(vmName string, outputPath string, verbose boo
 		if err := exec.Command("cp", localSerialLog, filepath.Join(outputPath, outputFilename)).Run(); err != nil {
 			return fmt.Errorf("failed to copy serial log to output directory: %w", err)
 		}
+	}
+
+	// Truncate the serial log after saving to prevent unbounded growth across iterations.
+	// Without truncation, the serial log accumulates all prior boot sequences, eventually
+	// causing the serial console capture to be cut off mid-boot.
+	if truncErr := cfg.TruncateLog(vmName); truncErr != nil {
+		logrus.Warnf("Failed to truncate serial log after iteration %d: %v", iteration, truncErr)
 	}
 
 	if waitErr != nil {


### PR DESCRIPTION
## Problem

The `[GITHUB]-trident-scale-official` pipeline (definition 5076) fails on every run with:

> Your YAML is too large. Reduce the size of your YAML pipeline.

Additionally, all qemu scale test jobs fail at update-loop iteration 9 due to unbounded serial log growth causing `WaitForLogin` timeouts.

**Supersedes #629 and #630** — this PR combines both fixes in a minimal, targeted approach.

---

## Root Cause: YAML Too Big

The error is **not** about compiled YAML text size — it's about per-phase runtime expansion when `strategy: parallel: N` is used.

| Pipeline | Compiled YAML | `parallel:` | Per-Phase Expansion | Result |
|----------|--------------|-------------|---------------------|--------|
| ci | 1,737 KB | 1 | ~1.7 MB | ✅ OK |
| pre | 1,455 KB | 1 | ~1.5 MB | ✅ OK |
| scale-official | ~480 KB | 256 | ~5.5 MB (256 × ~21 KB) | ❌ Too big |

ADO's per-phase expansion limit appears to be ~3 MB.

## Fix: Split Workers Into Batches

Instead of one job with `parallel: 256`, split into **4 batches of 64**:

- Each batch becomes a separate ADO Job with `strategy: parallel: 64`
- Per-phase expansion: 64 × ~21 KB ≈ **1.4 MB** (well under the ~3 MB limit)
- Total coverage: 4 × 64 = **256 workers** (unchanged)

### Architecture

`scale-template.yml` passes `workerBatches` to `vm-testing.yml`:

```yaml
workerBatches:
  - id: 0
    size: 64
  - id: 1
    size: 64
  - id: 2
    size: 64
  - id: 3
    size: 64
```

`vm-testing.yml` iterates batches, generating a separate `testing-template.yml` call per batch. Non-scale callers (pr-e2e, ci, etc.) use the default single batch `[{id: 0, size: 1}]` — no change to their behavior.

### Naming Conventions

`System.JobPositionInPhase` resets to 1 per job, so `batchId` is included in all names:

| Element | Format | Example |
|---------|--------|---------|
| Job ID | `UpdateTesting_{flavor}_{batchId}` | `UpdateTesting_qemu_2` |
| Display name | `Update Testing - {flavor} - {batchId}` | `Update Testing - qemu - 2` |
| Artifact | `update-testing-{flavor}-{batchId}-{position}` | `update-testing-qemu-2-16` |
| Resource group | `trident-vm-...-{buildId}-{batchId}-{position}` | `trident-vm-...-12345-2-16` |

### PublishAzureImage

Moved from `testing-template.yml` (where it would run per-batch) to `vm-testing.yml` (runs once). Azure test batches depend on `PublishAzureImage` via `dependsOnPublishAzureImage` parameter.

---

## Fix: Serial Log Truncation

### Problem

The QEMU serial log accumulates all boot sequences without truncation. By iteration 9 (~2 MB / 10 boots), the serial console capture is cut off mid-boot, causing `WaitForLogin` to timeout — even though the VM boots successfully.

### Fix

- Call `cfg.TruncateLog(vmName)` in `WaitForLogin` after saving the serial log
- Add a guard for missing serial log files in `TruncateLog`
- Disable virtlogd log rollover in the pipeline (`max_size = 0`)

---

## Validation

- **Pipeline preview:** All 12 pipelines compile clean (`make check-pipelines` equivalent)
- **Scale run (build 1112515):** All 256 jobs scheduled and ran — **YAML too big is fixed!**
  - Azure jobs failed due to `SkuNotAvailable` (capacity issue, unrelated)
- **pr-e2e (build 1112514):** Validates non-scale callers are unaffected

## Files Changed

| File | Change |
|------|--------|
| `.pipelines/templates/scale-template.yml` | Pass 4 workerBatches to vm-testing |
| `.pipelines/templates/stages/testing_servicing/vm-testing.yml` | Iterate batches, host PublishAzureImage |
| `.pipelines/templates/stages/testing_servicing/testing-template.yml` | Accept batchId, update naming, remove PublishAzureImage |
| `tools/storm/utils/vm/qemu/qemu.go` | Truncate serial log in WaitForLogin |
