### PR TITLE
fix: mitigate stale disk UUIDs in initramfs and add diagnostics

### DIFF
--- a/crates/osutils/src/mkinitrd.rs
+++ b/crates/osutils/src/mkinitrd.rs
@@ -46,17 +46,14 @@ fi
 /// If mkinitrd is available, it will be used. Azl 3.0 doesn't have mkinitrd anymore, so dracut is
 /// used instead.
 ///
-/// Before regenerating, triggers a udev rescan and waits for it to settle. This ensures dracut
-/// sees the current partition table and UUIDs rather than stale entries from a previous OS
-/// installation. Without this, dracut can embed references to old partition UUIDs, causing
-/// initramfs to hang at boot waiting for devices that no longer exist.
+/// A udev rescan is performed as defense-in-depth before regenerating. The primary rescan happens
+/// earlier in storage::initialize_block_devices(), but this ensures dracut sees clean state even
+/// if that earlier rescan was skipped or failed.
 pub fn execute(debug: bool) -> Result<(), TridentError> {
-    // Ensure the kernel's device table is up-to-date before dracut scans it.
-    // dracut in host-only mode reads /dev/disk/by-uuid/ and /dev/disk/by-partuuid/ to determine
-    // which devices to embed in initramfs. If stale UUIDs from a previous installation are still
-    // visible, dracut will embed them, causing the initramfs to wait for non-existent devices
-    // on boot (manifesting as a "stuck in initramfs" hang).
-    info!("Triggering udev rescan before initrd regeneration to clear stale device entries");
+    // Defense-in-depth: ensure the kernel's device table is current before dracut scans it.
+    // The primary udev rescan runs after block device setup (storage/mod.rs), but we repeat
+    // it here in case mkinitrd is called from a different path or the earlier rescan failed.
+    info!("Triggering udev rescan before initrd regeneration (defense-in-depth)");
     if let Err(e) = udevadm::trigger() {
         info!("udevadm trigger failed (non-fatal, continuing): {e}");
     }

--- a/crates/osutils/src/mkinitrd.rs
+++ b/crates/osutils/src/mkinitrd.rs
@@ -1,7 +1,7 @@
 use std::{io::Write, os::unix::fs::PermissionsExt, path::Path};
 
 use anyhow::{Context, Error};
-use log::info;
+use log::debug;
 use tempfile::NamedTempFile;
 
 use trident_api::error::{ReportError, ServicingError, TridentError};
@@ -46,19 +46,19 @@ fi
 /// If mkinitrd is available, it will be used. Azl 3.0 doesn't have mkinitrd anymore, so dracut is
 /// used instead.
 ///
-/// A udev rescan is performed as defense-in-depth before regenerating. The primary rescan happens
+/// A udev rescan is performed before regenerating. The primary rescan happens
 /// earlier in storage::initialize_block_devices(), but this ensures dracut sees clean state even
 /// if that earlier rescan was skipped or failed.
 pub fn execute(debug: bool) -> Result<(), TridentError> {
-    // Defense-in-depth: ensure the kernel's device table is current before dracut scans it.
+    // Ensure the kernel's device table is current before dracut scans it.
     // The primary udev rescan runs after block device setup (storage/mod.rs), but we repeat
     // it here in case mkinitrd is called from a different path or the earlier rescan failed.
-    info!("Triggering udev rescan before initrd regeneration (defense-in-depth)");
+    debug!("Triggering udev rescan before initrd regeneration");
     if let Err(e) = udevadm::trigger() {
-        info!("udevadm trigger failed (non-fatal, continuing): {e}");
+        debug!("udevadm trigger failed, continuing: {e}");
     }
     if let Err(e) = udevadm::settle() {
-        info!("udevadm settle failed (non-fatal, continuing): {e}");
+        debug!("udevadm settle failed, continuing: {e}");
     }
 
     if Path::new("/usr/bin/mkinitrd").exists() {

--- a/crates/osutils/src/mkinitrd.rs
+++ b/crates/osutils/src/mkinitrd.rs
@@ -1,11 +1,12 @@
 use std::{io::Write, os::unix::fs::PermissionsExt, path::Path};
 
 use anyhow::{Context, Error};
+use log::info;
 use tempfile::NamedTempFile;
 
 use trident_api::error::{ReportError, ServicingError, TridentError};
 
-use crate::dependencies::Dependency;
+use crate::{dependencies::Dependency, udevadm};
 
 /// Verity workaround script
 ///
@@ -44,7 +45,25 @@ fi
 ///
 /// If mkinitrd is available, it will be used. Azl 3.0 doesn't have mkinitrd anymore, so dracut is
 /// used instead.
+///
+/// Before regenerating, triggers a udev rescan and waits for it to settle. This ensures dracut
+/// sees the current partition table and UUIDs rather than stale entries from a previous OS
+/// installation. Without this, dracut can embed references to old partition UUIDs, causing
+/// initramfs to hang at boot waiting for devices that no longer exist.
 pub fn execute(debug: bool) -> Result<(), TridentError> {
+    // Ensure the kernel's device table is up-to-date before dracut scans it.
+    // dracut in host-only mode reads /dev/disk/by-uuid/ and /dev/disk/by-partuuid/ to determine
+    // which devices to embed in initramfs. If stale UUIDs from a previous installation are still
+    // visible, dracut will embed them, causing the initramfs to wait for non-existent devices
+    // on boot (manifesting as a "stuck in initramfs" hang).
+    info!("Triggering udev rescan before initrd regeneration to clear stale device entries");
+    if let Err(e) = udevadm::trigger() {
+        info!("udevadm trigger failed (non-fatal, continuing): {e}");
+    }
+    if let Err(e) = udevadm::settle() {
+        info!("udevadm settle failed (non-fatal, continuing): {e}");
+    }
+
     if Path::new("/usr/bin/mkinitrd").exists() {
         Dependency::Mkinitrd
             .cmd()

--- a/crates/osutils/src/udevadm.rs
+++ b/crates/osutils/src/udevadm.rs
@@ -17,6 +17,7 @@ pub fn trigger() -> Result<(), Error> {
     Dependency::Udevadm
         .cmd()
         .arg("trigger")
+        .arg("--subsystem-match=block")
         .run_and_check()
         .context("Failed trigger udev")
 }

--- a/crates/osutils/src/udevadm.rs
+++ b/crates/osutils/src/udevadm.rs
@@ -8,7 +8,6 @@ pub fn settle() -> Result<(), Error> {
     Dependency::Udevadm
         .cmd()
         .arg("settle")
-        .arg("--timeout=30")
         .run_and_check()
         .context("Failed settle udev setup")
 }
@@ -17,7 +16,6 @@ pub fn trigger() -> Result<(), Error> {
     Dependency::Udevadm
         .cmd()
         .arg("trigger")
-        .arg("--subsystem-match=block")
         .run_and_check()
         .context("Failed trigger udev")
 }

--- a/crates/osutils/src/udevadm.rs
+++ b/crates/osutils/src/udevadm.rs
@@ -8,6 +8,7 @@ pub fn settle() -> Result<(), Error> {
     Dependency::Udevadm
         .cmd()
         .arg("settle")
+        .arg("--timeout=30")
         .run_and_check()
         .context("Failed settle udev setup")
 }

--- a/crates/trident/src/engine/storage/mod.rs
+++ b/crates/trident/src/engine/storage/mod.rs
@@ -1,6 +1,6 @@
 use log::{debug, info, trace, warn};
 
-use osutils::{e2fsck, lsblk};
+use osutils::{e2fsck, lsblk, udevadm};
 use sysdefs::filesystems::{KernelFilesystemType, RealFilesystemType};
 use trident_api::{
     constants::internal_params::PRE_REBOOT_CHECKS,
@@ -73,6 +73,19 @@ pub(super) fn initialize_block_devices(ctx: &EngineContext) -> Result<(), Triden
     // Assumes that images are already in place (data and hash), so that it can
     // assemble the verity devices.
     verity::setup_verity_devices(ctx).structured(ServicingError::CreateVerity)?;
+
+    // Force the kernel to rescan all block devices and wait for udev to process the events.
+    // This clears stale partition UUIDs from previous installations that may still be in
+    // the device table. Without this, dracut (called later during initrd regeneration) can
+    // embed references to old UUIDs, causing initramfs to hang at boot waiting for devices
+    // that no longer exist (bug 15086).
+    info!("Triggering udev rescan after block device setup to clear stale device entries");
+    if let Err(e) = udevadm::trigger() {
+        warn!("udevadm trigger failed (non-fatal): {e}");
+    }
+    if let Err(e) = udevadm::settle() {
+        warn!("udevadm settle failed (non-fatal): {e}");
+    }
 
     Ok(())
 }

--- a/crates/trident/src/engine/storage/mod.rs
+++ b/crates/trident/src/engine/storage/mod.rs
@@ -81,10 +81,10 @@ pub(super) fn initialize_block_devices(ctx: &EngineContext) -> Result<(), Triden
     // that no longer exist (bug 15086).
     info!("Triggering udev rescan after block device setup to clear stale device entries");
     if let Err(e) = udevadm::trigger() {
-        warn!("udevadm trigger failed (non-fatal): {e}");
+        warn!("udevadm trigger failed: {e}");
     }
     if let Err(e) = udevadm::settle() {
-        warn!("udevadm settle failed (non-fatal): {e}");
+        warn!("udevadm settle failed: {e}");
     }
 
     Ok(())

--- a/tools/storm/servicing/tests/update.go
+++ b/tools/storm/servicing/tests/update.go
@@ -356,8 +356,10 @@ func innerUpdateLoop(testConfig stormsvcconfig.TestConfig, vmConfig stormvmconfi
 						logrus.Warnf("failed to capture screenshot: %v", captureErr)
 					}
 					// Check serial log for dracut-initqueue timeout patterns that indicate
-					// stale disk UUIDs in initramfs (see bug 15086)
-					checkSerialLogForDracutIssues(vmConfig.QemuConfig.SerialLog, i)
+					// stale disk UUIDs in initramfs (see bug 15086).
+					// Use the saved copy since WaitForLogin truncates the original.
+					savedSerialLog := filepath.Join(testConfig.OutputPath, fmt.Sprintf("%03d-serial.log", i))
+					checkSerialLogForDracutIssues(savedSerialLog, i)
 					return fmt.Errorf("VM did not come back up after update for iteration %d: %w", i, err)
 				}
 				logrus.Warnf("SSH fallback succeeded for iteration %d — VM is healthy but serial-getty did not start (ttyS0 device likely skipped by systemd)", i)

--- a/tools/storm/servicing/tests/update.go
+++ b/tools/storm/servicing/tests/update.go
@@ -358,8 +358,10 @@ func innerUpdateLoop(testConfig stormsvcconfig.TestConfig, vmConfig stormvmconfi
 					// Check serial log for dracut-initqueue timeout patterns that indicate
 					// stale disk UUIDs in initramfs (see bug 15086).
 					// Use the saved copy since WaitForLogin truncates the original.
-					savedSerialLog := filepath.Join(testConfig.OutputPath, fmt.Sprintf("%03d-serial.log", i))
-					checkSerialLogForDracutIssues(savedSerialLog, i)
+					if testConfig.OutputPath != "" {
+						savedSerialLog := filepath.Join(testConfig.OutputPath, fmt.Sprintf("%03d-serial.log", i))
+						checkSerialLogForDracutIssues(savedSerialLog, i)
+					}
 					return fmt.Errorf("VM did not come back up after update for iteration %d: %w", i, err)
 				}
 				logrus.Warnf("SSH fallback succeeded for iteration %d — VM is healthy but serial-getty did not start (ttyS0 device likely skipped by systemd)", i)

--- a/tools/storm/servicing/tests/update.go
+++ b/tools/storm/servicing/tests/update.go
@@ -285,6 +285,19 @@ func innerUpdateLoop(testConfig stormsvcconfig.TestConfig, vmConfig stormvmconfi
 			logrus.Tracef("Pre-reboot uptime --since for iteration %d: %s", i, preRebootUptime)
 		}
 
+		// Capture block device state before finalize/reboot for initramfs diagnostics.
+		// If dracut embedded stale UUIDs, comparing pre-reboot blkid with post-reboot
+		// lsinitrd can prove the mismatch.
+		padIteration := fmt.Sprintf("%03d", i)
+		if blkidOut, blkidErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo blkid"); blkidErr == nil {
+			if testConfig.OutputPath != "" {
+				blkidPath := filepath.Join(testConfig.OutputPath, padIteration+"-pre-reboot-blkid.log")
+				if writeErr := os.WriteFile(blkidPath, []byte(blkidOut), 0644); writeErr != nil {
+					logrus.Warnf("Failed to write pre-reboot blkid log: %v", writeErr)
+				}
+			}
+		}
+
 		combinedFinalizeOutput, finalizeErr := stormssh.SshCommandCombinedOutput(vmConfig.VMConfig, vmIP, fmt.Sprintf("sudo trident grpc-client update %s %s --allowed-operations finalize", tridentLoggingArg, updateConfig))
 		if testConfig.Verbose {
 			logrus.Tracef("Finalize output for iteration %d:\n%s\n%v", i, combinedFinalizeOutput, finalizeErr)
@@ -342,6 +355,9 @@ func innerUpdateLoop(testConfig stormsvcconfig.TestConfig, vmConfig stormvmconfi
 					); captureErr != nil {
 						logrus.Warnf("failed to capture screenshot: %v", captureErr)
 					}
+					// Check serial log for dracut-initqueue timeout patterns that indicate
+					// stale disk UUIDs in initramfs (see bug 15086)
+					checkSerialLogForDracutIssues(vmConfig.QemuConfig.SerialLog, i)
 					return fmt.Errorf("VM did not come back up after update for iteration %d: %w", i, err)
 				}
 				logrus.Warnf("SSH fallback succeeded for iteration %d — VM is healthy but serial-getty did not start (ttyS0 device likely skipped by systemd)", i)
@@ -523,4 +539,37 @@ func validateRollback(cfg stormvmconfig.VMConfig, vmIP string) error {
 
 	logrus.Info("Rollback validation succeeded")
 	return nil
+}
+
+// checkSerialLogForDracutIssues scans the serial log for patterns that indicate
+// initramfs is stuck waiting for a device, which is the symptom of bug 15086
+// (stale disk UUIDs embedded in initramfs by dracut).
+func checkSerialLogForDracutIssues(serialLogPath string, iteration int) {
+	if serialLogPath == "" {
+		return
+	}
+	data, err := os.ReadFile(serialLogPath)
+	if err != nil {
+		logrus.Warnf("Could not read serial log for dracut analysis: %v", err)
+		return
+	}
+	content := string(data)
+
+	dracutPatterns := []struct {
+		pattern string
+		message string
+	}{
+		{"dracut-initqueue", "dracut-initqueue activity detected — initramfs may be waiting for a device"},
+		{"Could not boot", "dracut 'Could not boot' error detected"},
+		{"Starting dracut emergency shell", "dracut emergency shell activated — boot failed in initramfs"},
+		{"Warning: /dev/disk/by", "dracut warning about /dev/disk/by-* path — possible stale UUID reference"},
+		{"rd.break", "rd.break detected — initramfs dropped to debug shell"},
+		{"Timed out waiting for device", "dracut timed out waiting for device — likely stale UUID in initramfs (bug 15086)"},
+	}
+
+	for _, dp := range dracutPatterns {
+		if strings.Contains(content, dp.pattern) {
+			logrus.Errorf("INITRAMFS DIAGNOSTIC (iteration %d): %s (matched '%s' in serial log)", iteration, dp.message, dp.pattern)
+		}
+	}
 }

--- a/tools/storm/servicing/tests/update.go
+++ b/tools/storm/servicing/tests/update.go
@@ -288,9 +288,9 @@ func innerUpdateLoop(testConfig stormsvcconfig.TestConfig, vmConfig stormvmconfi
 		// Capture block device state before finalize/reboot for initramfs diagnostics.
 		// If dracut embedded stale UUIDs, comparing pre-reboot blkid with post-reboot
 		// lsinitrd can prove the mismatch.
-		padIteration := fmt.Sprintf("%03d", i)
-		if blkidOut, blkidErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo blkid"); blkidErr == nil {
-			if testConfig.OutputPath != "" {
+		if testConfig.OutputPath != "" {
+			padIteration := fmt.Sprintf("%03d", i)
+			if blkidOut, blkidErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo blkid"); blkidErr == nil {
 				blkidPath := filepath.Join(testConfig.OutputPath, padIteration+"-pre-reboot-blkid.log")
 				if writeErr := os.WriteFile(blkidPath, []byte(blkidOut), 0644); writeErr != nil {
 					logrus.Warnf("Failed to write pre-reboot blkid log: %v", writeErr)

--- a/tools/storm/servicing/tests/update.go
+++ b/tools/storm/servicing/tests/update.go
@@ -563,7 +563,7 @@ func checkSerialLogForDracutIssues(serialLogPath string, iteration int) {
 		pattern string
 		message string
 	}{
-		{"dracut-initqueue", "dracut-initqueue activity detected — initramfs may be waiting for a device"},
+		{"dracut-initqueue[", "dracut-initqueue warning detected — initramfs may be waiting for a device"},
 		{"Could not boot", "dracut 'Could not boot' error detected"},
 		{"Starting dracut emergency shell", "dracut emergency shell activated — boot failed in initramfs"},
 		{"Warning: /dev/disk/by", "dracut warning about /dev/disk/by-* path — possible stale UUID reference"},

--- a/tools/storm/utils/vm/logs.go
+++ b/tools/storm/utils/vm/logs.go
@@ -23,7 +23,7 @@ func FetchLogs(vmConfig stormvmconfig.AllVMConfig, outputPath string) error {
 
 	// Best effort: capture block device UUIDs for initramfs debugging
 	logrus.Tracef("Capturing blkid output for initramfs diagnostics")
-	if blkidOut, blkidErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo blkid | sudo tee /tmp/blkid.log && sudo chmod 644 /tmp/blkid.log"); blkidErr == nil {
+	if blkidOut, blkidErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo bash -o pipefail -c 'blkid | tee /tmp/blkid.log' && sudo chmod 644 /tmp/blkid.log"); blkidErr == nil {
 		logrus.Tracef("blkid output: %s", blkidOut)
 		stormssh.ScpDownloadFile(vmConfig.VMConfig, vmIP, "/tmp/blkid.log", outputPath+"/blkid.log")
 	}

--- a/tools/storm/utils/vm/logs.go
+++ b/tools/storm/utils/vm/logs.go
@@ -30,6 +30,8 @@ func FetchLogs(vmConfig stormvmconfig.AllVMConfig, outputPath string) error {
 		if err := os.WriteFile(filepath.Join(outputPath, "blkid.log"), []byte(blkidOut), 0644); err != nil {
 			logrus.Warnf("Failed to write blkid.log: %v", err)
 		}
+	} else {
+		logrus.Warnf("Failed to capture blkid output: %v", blkidErr)
 	}
 
 	// Best effort: capture initramfs contents to detect stale UUID references
@@ -38,6 +40,8 @@ func FetchLogs(vmConfig stormvmconfig.AllVMConfig, outputPath string) error {
 		if err := os.WriteFile(filepath.Join(outputPath, "lsinitrd.log"), []byte(lsinitrdOut), 0644); err != nil {
 			logrus.Warnf("Failed to write lsinitrd.log: %v", err)
 		}
+	} else {
+		logrus.Warnf("Failed to capture lsinitrd output: %v", lsinitrdErr)
 	}
 
 	// Best effort: capture dracut-related journal entries for initramfs boot analysis
@@ -46,6 +50,8 @@ func FetchLogs(vmConfig stormvmconfig.AllVMConfig, outputPath string) error {
 		if err := os.WriteFile(filepath.Join(outputPath, "dracut-journal.log"), []byte(dracutOut), 0644); err != nil {
 			logrus.Warnf("Failed to write dracut-journal.log: %v", err)
 		}
+	} else {
+		logrus.Warnf("Failed to capture dracut journal: %v", dracutErr)
 	}
 
 	// Download crashdumps (simplified)

--- a/tools/storm/utils/vm/logs.go
+++ b/tools/storm/utils/vm/logs.go
@@ -32,7 +32,7 @@ func FetchLogs(vmConfig stormvmconfig.AllVMConfig, outputPath string) error {
 
 	// Best effort: capture initramfs contents to detect stale UUID references
 	logrus.Tracef("Capturing lsinitrd output for initramfs diagnostics")
-	if lsinitrdOut, lsinitrdErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo lsinitrd 2>/dev/null"); lsinitrdErr == nil {
+	if lsinitrdOut, lsinitrdErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo lsinitrd"); lsinitrdErr == nil {
 		os.WriteFile(filepath.Join(outputPath, "lsinitrd.log"), []byte(lsinitrdOut), 0644)
 	}
 

--- a/tools/storm/utils/vm/logs.go
+++ b/tools/storm/utils/vm/logs.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"os"
+	"path/filepath"
 	stormssh "tridenttools/storm/utils/ssh"
 	stormvmconfig "tridenttools/storm/utils/vm/config"
 
@@ -23,9 +25,9 @@ func FetchLogs(vmConfig stormvmconfig.AllVMConfig, outputPath string) error {
 
 	// Best effort: capture block device UUIDs for initramfs debugging
 	logrus.Tracef("Capturing blkid output for initramfs diagnostics")
-	if blkidOut, blkidErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo bash -o pipefail -c 'blkid | tee /tmp/blkid.log' && sudo chmod 644 /tmp/blkid.log"); blkidErr == nil {
+	if blkidOut, blkidErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo blkid"); blkidErr == nil {
 		logrus.Tracef("blkid output: %s", blkidOut)
-		stormssh.ScpDownloadFile(vmConfig.VMConfig, vmIP, "/tmp/blkid.log", outputPath+"/blkid.log")
+		os.WriteFile(filepath.Join(outputPath, "blkid.log"), []byte(blkidOut), 0644)
 	}
 
 	// Best effort: capture initramfs contents to detect stale UUID references

--- a/tools/storm/utils/vm/logs.go
+++ b/tools/storm/utils/vm/logs.go
@@ -20,6 +20,26 @@ func FetchLogs(vmConfig stormvmconfig.AllVMConfig, outputPath string) error {
 		logrus.Tracef("Downloading journal log from VM '%s' to local machine", vmConfig.VMConfig.Name)
 		stormssh.ScpDownloadFile(vmConfig.VMConfig, vmIP, "/tmp/journal.log", outputPath+"/journal.log")
 	}
+
+	// Best effort: capture block device UUIDs for initramfs debugging
+	logrus.Tracef("Capturing blkid output for initramfs diagnostics")
+	if blkidOut, blkidErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo blkid > /tmp/blkid.log 2>&1 && sudo chmod 644 /tmp/blkid.log"); blkidErr == nil {
+		logrus.Tracef("blkid output: %s", blkidOut)
+		stormssh.ScpDownloadFile(vmConfig.VMConfig, vmIP, "/tmp/blkid.log", outputPath+"/blkid.log")
+	}
+
+	// Best effort: capture initramfs contents to detect stale UUID references
+	logrus.Tracef("Capturing lsinitrd output for initramfs diagnostics")
+	if _, lsinitrdErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo lsinitrd 2>/dev/null > /tmp/lsinitrd.log 2>&1 && sudo chmod 644 /tmp/lsinitrd.log"); lsinitrdErr == nil {
+		stormssh.ScpDownloadFile(vmConfig.VMConfig, vmIP, "/tmp/lsinitrd.log", outputPath+"/lsinitrd.log")
+	}
+
+	// Best effort: capture dracut-related journal entries for initramfs boot analysis
+	logrus.Tracef("Capturing dracut journal entries")
+	if _, dracutErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo journalctl --no-pager -u dracut* -u systemd-udevd > /tmp/dracut-journal.log 2>&1 && sudo chmod 644 /tmp/dracut-journal.log"); dracutErr == nil {
+		stormssh.ScpDownloadFile(vmConfig.VMConfig, vmIP, "/tmp/dracut-journal.log", outputPath+"/dracut-journal.log")
+	}
+
 	// Download crashdumps (simplified)
 	logrus.Tracef("Check for crash dumps on VM")
 	crashDumpOutput, err := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "ls /var/crash/*")

--- a/tools/storm/utils/vm/logs.go
+++ b/tools/storm/utils/vm/logs.go
@@ -27,19 +27,25 @@ func FetchLogs(vmConfig stormvmconfig.AllVMConfig, outputPath string) error {
 	logrus.Tracef("Capturing blkid output for initramfs diagnostics")
 	if blkidOut, blkidErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo blkid"); blkidErr == nil {
 		logrus.Tracef("blkid output: %s", blkidOut)
-		os.WriteFile(filepath.Join(outputPath, "blkid.log"), []byte(blkidOut), 0644)
+		if err := os.WriteFile(filepath.Join(outputPath, "blkid.log"), []byte(blkidOut), 0644); err != nil {
+			logrus.Warnf("Failed to write blkid.log: %v", err)
+		}
 	}
 
 	// Best effort: capture initramfs contents to detect stale UUID references
 	logrus.Tracef("Capturing lsinitrd output for initramfs diagnostics")
 	if lsinitrdOut, lsinitrdErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo lsinitrd"); lsinitrdErr == nil {
-		os.WriteFile(filepath.Join(outputPath, "lsinitrd.log"), []byte(lsinitrdOut), 0644)
+		if err := os.WriteFile(filepath.Join(outputPath, "lsinitrd.log"), []byte(lsinitrdOut), 0644); err != nil {
+			logrus.Warnf("Failed to write lsinitrd.log: %v", err)
+		}
 	}
 
 	// Best effort: capture dracut-related journal entries for initramfs boot analysis
 	logrus.Tracef("Capturing dracut journal entries")
 	if dracutOut, dracutErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo journalctl --no-pager -u 'dracut*' -u systemd-udevd 2>/dev/null"); dracutErr == nil {
-		os.WriteFile(filepath.Join(outputPath, "dracut-journal.log"), []byte(dracutOut), 0644)
+		if err := os.WriteFile(filepath.Join(outputPath, "dracut-journal.log"), []byte(dracutOut), 0644); err != nil {
+			logrus.Warnf("Failed to write dracut-journal.log: %v", err)
+		}
 	}
 
 	// Download crashdumps (simplified)

--- a/tools/storm/utils/vm/logs.go
+++ b/tools/storm/utils/vm/logs.go
@@ -32,14 +32,14 @@ func FetchLogs(vmConfig stormvmconfig.AllVMConfig, outputPath string) error {
 
 	// Best effort: capture initramfs contents to detect stale UUID references
 	logrus.Tracef("Capturing lsinitrd output for initramfs diagnostics")
-	if _, lsinitrdErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo lsinitrd 2>/dev/null > /tmp/lsinitrd.log 2>&1 && sudo chmod 644 /tmp/lsinitrd.log"); lsinitrdErr == nil {
-		stormssh.ScpDownloadFile(vmConfig.VMConfig, vmIP, "/tmp/lsinitrd.log", outputPath+"/lsinitrd.log")
+	if lsinitrdOut, lsinitrdErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo lsinitrd 2>/dev/null"); lsinitrdErr == nil {
+		os.WriteFile(filepath.Join(outputPath, "lsinitrd.log"), []byte(lsinitrdOut), 0644)
 	}
 
 	// Best effort: capture dracut-related journal entries for initramfs boot analysis
 	logrus.Tracef("Capturing dracut journal entries")
-	if _, dracutErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo journalctl --no-pager -u 'dracut*' -u systemd-udevd > /tmp/dracut-journal.log 2>&1 && sudo chmod 644 /tmp/dracut-journal.log"); dracutErr == nil {
-		stormssh.ScpDownloadFile(vmConfig.VMConfig, vmIP, "/tmp/dracut-journal.log", outputPath+"/dracut-journal.log")
+	if dracutOut, dracutErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo journalctl --no-pager -u 'dracut*' -u systemd-udevd 2>/dev/null"); dracutErr == nil {
+		os.WriteFile(filepath.Join(outputPath, "dracut-journal.log"), []byte(dracutOut), 0644)
 	}
 
 	// Download crashdumps (simplified)

--- a/tools/storm/utils/vm/logs.go
+++ b/tools/storm/utils/vm/logs.go
@@ -23,7 +23,7 @@ func FetchLogs(vmConfig stormvmconfig.AllVMConfig, outputPath string) error {
 
 	// Best effort: capture block device UUIDs for initramfs debugging
 	logrus.Tracef("Capturing blkid output for initramfs diagnostics")
-	if blkidOut, blkidErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo blkid > /tmp/blkid.log 2>&1 && sudo chmod 644 /tmp/blkid.log"); blkidErr == nil {
+	if blkidOut, blkidErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo blkid | sudo tee /tmp/blkid.log"); blkidErr == nil {
 		logrus.Tracef("blkid output: %s", blkidOut)
 		stormssh.ScpDownloadFile(vmConfig.VMConfig, vmIP, "/tmp/blkid.log", outputPath+"/blkid.log")
 	}

--- a/tools/storm/utils/vm/logs.go
+++ b/tools/storm/utils/vm/logs.go
@@ -23,7 +23,7 @@ func FetchLogs(vmConfig stormvmconfig.AllVMConfig, outputPath string) error {
 
 	// Best effort: capture block device UUIDs for initramfs debugging
 	logrus.Tracef("Capturing blkid output for initramfs diagnostics")
-	if blkidOut, blkidErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo blkid | sudo tee /tmp/blkid.log"); blkidErr == nil {
+	if blkidOut, blkidErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo blkid | sudo tee /tmp/blkid.log && sudo chmod 644 /tmp/blkid.log"); blkidErr == nil {
 		logrus.Tracef("blkid output: %s", blkidOut)
 		stormssh.ScpDownloadFile(vmConfig.VMConfig, vmIP, "/tmp/blkid.log", outputPath+"/blkid.log")
 	}
@@ -36,7 +36,7 @@ func FetchLogs(vmConfig stormvmconfig.AllVMConfig, outputPath string) error {
 
 	// Best effort: capture dracut-related journal entries for initramfs boot analysis
 	logrus.Tracef("Capturing dracut journal entries")
-	if _, dracutErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo journalctl --no-pager -u dracut* -u systemd-udevd > /tmp/dracut-journal.log 2>&1 && sudo chmod 644 /tmp/dracut-journal.log"); dracutErr == nil {
+	if _, dracutErr := stormssh.SshCommand(vmConfig.VMConfig, vmIP, "sudo journalctl --no-pager -u 'dracut*' -u systemd-udevd > /tmp/dracut-journal.log 2>&1 && sudo chmod 644 /tmp/dracut-journal.log"); dracutErr == nil {
 		stormssh.ScpDownloadFile(vmConfig.VMConfig, vmIP, "/tmp/dracut-journal.log", outputPath+"/dracut-journal.log")
 	}
 

--- a/tools/storm/utils/vm/qemu/qemu.go
+++ b/tools/storm/utils/vm/qemu/qemu.go
@@ -425,7 +425,7 @@ func (cfg QemuConfig) WaitForLogin(vmName string, outputPath string, verbose boo
 		// VM has no DHCP lease, or has a stale lease but SSH is unreachable —
 		// it's genuinely stuck (failed to boot after reboot).
 		logrus.Errorf("Failed to reach login prompt for the VM for iteration %d: %v", iteration, waitErr)
-		if err := analyzeSerialLog(cfg.SerialLog); err != nil {
+		if err := analyzeSerialLog(localSerialLog); err != nil {
 			return err
 		}
 

--- a/tools/storm/utils/vm/qemu/qemu.go
+++ b/tools/storm/utils/vm/qemu/qemu.go
@@ -447,12 +447,55 @@ func (cfg QemuConfig) WaitForLogin(vmName string, outputPath string, verbose boo
 }
 
 func analyzeSerialLog(serial string) error {
-	// Read the last line of the serial log
 	lastLines, err := exec.Command("tail", "-n", "100", serial).Output()
-	// Watch for specific failures and create error messages accordingly
-	if err == nil && strings.Contains(string(lastLines), "tpm tpm0: Operation Timed out") {
+	if err != nil {
+		logrus.Warnf("Failed to read serial log tail: %v", err)
+		return nil
+	}
+	serialTail := string(lastLines)
+
+	// Always print the serial log tail on failure to aid diagnosis.
+	// Without this output, boot failures are nearly impossible to root-cause
+	// because the serial log is only available inside large pipeline artifacts.
+	logrus.Infof("Serial log tail (last 100 lines):\n%s", serialTail)
+
+	// Check for known boot failure patterns and return a specific error
+	// if one is found, so the failure category is clear in pipeline results.
+
+	if strings.Contains(serialTail, "tpm tpm0: Operation Timed out") {
 		return fmt.Errorf("tpm tpm0: Operation Timed out")
 	}
+
+	// Dracut/initramfs emergency shell — VM booted but initramfs could not
+	// mount the root filesystem or a required module was missing.
+	// See ADO#10589 for an example caused by dracut temp-dir name collision.
+	if strings.Contains(serialTail, "Entering emergency mode") ||
+		strings.Contains(serialTail, "dracut-emergency") ||
+		strings.Contains(serialTail, "Cannot open shared object file") {
+		return fmt.Errorf("VM stuck in initramfs emergency shell (see serial log above)")
+	}
+
+	// Dracut-initqueue timeout — initramfs is waiting for a device that doesn't
+	// exist, typically caused by stale disk UUIDs embedded in initramfs (bug 15086).
+	// The serial log shows dracut-initqueue repeatedly trying to find the device.
+	if strings.Contains(serialTail, "dracut-initqueue") ||
+		strings.Contains(serialTail, "Timed out waiting for device") ||
+		strings.Contains(serialTail, "Could not boot") {
+		return fmt.Errorf("VM stuck in initramfs waiting for device — likely stale UUID in initramfs (bug 15086, see serial log above)")
+	}
+
+	// Kernel panic — the kernel itself crashed during boot.
+	if strings.Contains(serialTail, "Kernel panic") ||
+		strings.Contains(serialTail, "end Kernel panic") {
+		return fmt.Errorf("kernel panic during boot (see serial log above)")
+	}
+
+	// GRUB error — bootloader could not find the kernel or boot entry.
+	if strings.Contains(serialTail, "error: no such device") ||
+		strings.Contains(serialTail, "error: file") {
+		return fmt.Errorf("GRUB boot error (see serial log above)")
+	}
+
 	return nil
 }
 

--- a/tools/storm/utils/vm/qemu/qemu.go
+++ b/tools/storm/utils/vm/qemu/qemu.go
@@ -461,9 +461,24 @@ func analyzeSerialLog(serial string) error {
 
 	// Check for known boot failure patterns and return a specific error
 	// if one is found, so the failure category is clear in pipeline results.
+	// Ordered most-severe/specific first so that e.g. a kernel panic after
+	// dracut starts isn't misclassified as a stale-UUID issue.
+
+	// Kernel panic — the kernel itself crashed during boot.
+	if strings.Contains(serialTail, "Kernel panic") ||
+		strings.Contains(serialTail, "end Kernel panic") {
+		return fmt.Errorf("kernel panic during boot (see serial log above)")
+	}
 
 	if strings.Contains(serialTail, "tpm tpm0: Operation Timed out") {
 		return fmt.Errorf("tpm tpm0: Operation Timed out")
+	}
+
+	// GRUB error — bootloader could not find the kernel or boot entry.
+	if strings.Contains(serialTail, "error: no such device") ||
+		strings.Contains(serialTail, "error: file not found") ||
+		strings.Contains(serialTail, "error: file '/") {
+		return fmt.Errorf("GRUB boot error (see serial log above)")
 	}
 
 	// Dracut/initramfs emergency shell — VM booted but initramfs could not
@@ -477,23 +492,11 @@ func analyzeSerialLog(serial string) error {
 
 	// Dracut-initqueue timeout — initramfs is waiting for a device that doesn't
 	// exist, typically caused by stale disk UUIDs embedded in initramfs (bug 15086).
-	// The serial log shows dracut-initqueue repeatedly trying to find the device.
-	if strings.Contains(serialTail, "dracut-initqueue") ||
+	// Patterns are specific to failure messages, not the normal unit name.
+	if strings.Contains(serialTail, "dracut-initqueue[") && strings.Contains(serialTail, "Warning") ||
 		strings.Contains(serialTail, "Timed out waiting for device") ||
 		strings.Contains(serialTail, "Could not boot") {
 		return fmt.Errorf("VM stuck in initramfs waiting for device — likely stale UUID in initramfs (bug 15086, see serial log above)")
-	}
-
-	// Kernel panic — the kernel itself crashed during boot.
-	if strings.Contains(serialTail, "Kernel panic") ||
-		strings.Contains(serialTail, "end Kernel panic") {
-		return fmt.Errorf("kernel panic during boot (see serial log above)")
-	}
-
-	// GRUB error — bootloader could not find the kernel or boot entry.
-	if strings.Contains(serialTail, "error: no such device") ||
-		strings.Contains(serialTail, "error: file") {
-		return fmt.Errorf("GRUB boot error (see serial log above)")
 	}
 
 	return nil


### PR DESCRIPTION
## Problem

Bug 15086 describes a ~33% repro rate boot failure where initramfs hangs waiting for a device with a UUID from a previous installation. 8+ related pipeline bugs ("stuck in initramfs") span 7 months across ci, prerelease, and prism-cicd pipelines — affecting base, rebuild-raid, encrypted-partition, encrypted-swap, extensions, misc, and root-verity test types.

**Root cause:** `dracut --regenerate-all` runs in host-only mode and scans `/dev/disk/by-uuid/` to determine which devices to embed in initramfs. If stale partition UUIDs from a previous OS installation are still in the kernel's device table, dracut embeds them. On reboot, initramfs waits for devices that no longer exist.

The code path in `mkinitrd.rs` calls dracut without any device table refresh beforehand. Only `partx --update` is used for adopted partitions (`repart_mode.rs`), but nothing clears stale entries for clean installs or A/B updates.

## Fix

### Trident (mkinitrd.rs)
- Add `udevadm trigger` + `udevadm settle` before `dracut --regenerate-all`
- This forces the kernel to rescan devices and waits for udev to process all events
- Non-fatal: if udevadm fails (e.g., not available in chroot), dracut still runs

### Storm Diagnostics (test tooling)

Currently, when a VM gets stuck in initramfs, we have no way to confirm whether it's bug 15086 or something else. These changes add the diagnostic data needed:

**FetchLogs (logs.go):**
- Capture `blkid` output (shows current disk UUIDs)
- Capture `lsinitrd` output (shows what UUIDs dracut embedded)
- Capture dracut-specific journal entries

**Update loop (update.go):**
- Capture `blkid` before finalize/reboot (pre-reboot state for comparison)
- Scan serial log for dracut-initqueue patterns when WaitForLogin fails
- Log specific diagnostic messages identifying likely bug 15086 instances

**Serial log analysis (qemu.go):**
- Detect `dracut-initqueue` timeout, `Timed out waiting for device`, and `Could not boot` patterns
- Return specific error message referencing bug 15086

## Related Bugs

| Bug | Pipeline | Test Type | Title |
|-----|----------|-----------|-------|
| 15086 | (root cause) | clean install | Stale disk UUIDs in initramfs |
| 16448 | ci | rebuild-raid | stuck in initramfs |
| 16525 | ci | encrypted-partition | stuck in initramfs during install |
| 16478 | ci | extensions | stuck in initramfs |
| 16552 | ci | base | stuck in initramfs |
| 16710 | prerelease | base | stuck in initramfs |
| 16732 | ci | base | stuck in initramfs |
| 19595 | ci | base | stuck in initramfs (Apr 2026) |

## Testing

The trident fix should reduce or eliminate "stuck in initramfs" failures. The diagnostics will confirm whether remaining failures are UUID-related by comparing pre-reboot `blkid` with `lsinitrd` contents.
