### PR TITLE
fix: honor HTTPS_PROXY env var in OCI client for baremetal proxy support

### DIFF
--- a/crates/trident/src/io_utils/http/file.rs
+++ b/crates/trident/src/io_utils/http/file.rs
@@ -238,9 +238,7 @@ impl HttpFile {
         let http_proxy = env::var("HTTP_PROXY")
             .or_else(|_| env::var("http_proxy"))
             .ok();
-        let no_proxy = env::var("NO_PROXY")
-            .or_else(|_| env::var("no_proxy"))
-            .ok();
+        let no_proxy = env::var("NO_PROXY").or_else(|_| env::var("no_proxy")).ok();
 
         if https_proxy.is_some() || http_proxy.is_some() {
             debug!(

--- a/crates/trident/src/io_utils/http/file.rs
+++ b/crates/trident/src/io_utils/http/file.rs
@@ -234,17 +234,25 @@ impl HttpFile {
     fn create_oci_client() -> OciClient {
         let https_proxy = env::var("HTTPS_PROXY")
             .or_else(|_| env::var("https_proxy"))
-            .ok();
+            .ok()
+            .filter(|v| !v.trim().is_empty());
         let http_proxy = env::var("HTTP_PROXY")
             .or_else(|_| env::var("http_proxy"))
-            .ok();
-        let no_proxy = env::var("NO_PROXY").or_else(|_| env::var("no_proxy")).ok();
+            .ok()
+            .filter(|v| !v.trim().is_empty());
+        let no_proxy = env::var("NO_PROXY")
+            .or_else(|_| env::var("no_proxy"))
+            .ok()
+            .filter(|v| !v.trim().is_empty());
 
         if https_proxy.is_some() || http_proxy.is_some() {
+            let http_status = if http_proxy.is_some() {
+                "<set>"
+            } else {
+                "<unset>"
+            };
             debug!(
-                "Configuring OCI client with proxy (HTTPS_PROXY={}, HTTP_PROXY={})",
-                https_proxy.as_deref().unwrap_or("<unset>"),
-                http_proxy.as_deref().unwrap_or("<unset>"),
+                "Configuring OCI client with proxy (HTTPS_PROXY=<set>, HTTP_PROXY={http_status})"
             );
         }
 

--- a/crates/trident/src/io_utils/http/file.rs
+++ b/crates/trident/src/io_utils/http/file.rs
@@ -1,14 +1,17 @@
 use std::{
+    env,
     io::{Error as IoError, ErrorKind as IoErrorKind, Read, Result as IoResult, Seek},
     time::Duration,
 };
 
 #[cfg(feature = "dangerous-options")]
-use std::{env, io::BufReader};
+use std::io::BufReader;
 
 use anyhow::{ensure, Context, Error};
 use log::{debug, trace, warn};
-use oci_client::{secrets::RegistryAuth, Client as OciClient, Reference, RegistryOperation};
+use oci_client::{
+    client::ClientConfig, secrets::RegistryAuth, Client as OciClient, Reference, RegistryOperation,
+};
 use reqwest::{
     blocking::{Client, ClientBuilder},
     header::{ACCEPT_RANGES, AUTHORIZATION},
@@ -63,7 +66,7 @@ impl HttpFile {
             })?)
             .with_context(|| format!("Failed to parse URL '{url}'"))?;
 
-        let oci_client = OciClient::default();
+        let oci_client = Self::create_oci_client();
         let rt = Runtime::new().context("Failed to create Tokio runtime")?;
         let token = Self::retrieve_access_token(&img_ref, &rt, &oci_client)?;
         let digest = Self::retrieve_artifact_digest(&img_ref, &rt, &oci_client)?;
@@ -227,6 +230,35 @@ impl HttpFile {
         RegistryAuth::Anonymous
     }
 
+    /// Create an OCI client configured with proxy settings from the environment.
+    fn create_oci_client() -> OciClient {
+        let https_proxy = env::var("HTTPS_PROXY")
+            .or_else(|_| env::var("https_proxy"))
+            .ok();
+        let http_proxy = env::var("HTTP_PROXY")
+            .or_else(|_| env::var("http_proxy"))
+            .ok();
+        let no_proxy = env::var("NO_PROXY")
+            .or_else(|_| env::var("no_proxy"))
+            .ok();
+
+        if https_proxy.is_some() || http_proxy.is_some() {
+            debug!(
+                "Configuring OCI client with proxy (HTTPS_PROXY={}, HTTP_PROXY={})",
+                https_proxy.as_deref().unwrap_or("<unset>"),
+                http_proxy.as_deref().unwrap_or("<unset>"),
+            );
+        }
+
+        let config = ClientConfig {
+            https_proxy,
+            http_proxy,
+            no_proxy,
+            ..Default::default()
+        };
+        OciClient::new(config)
+    }
+
     /// Retrieve artifact digest, which is necessary to send HTTP request to container registry.
     fn retrieve_artifact_digest(
         img_ref: &Reference,
@@ -241,7 +273,8 @@ impl HttpFile {
                     format!("Failed to retrieve tag from OCI URL '{}'", img_ref.whole())
                 })?;
                 // Attempt to retrieve digest from manifest
-                let manifest = client.pull_image_manifest(img_ref, &RegistryAuth::Anonymous);
+                let auth = Self::get_docker_auth(img_ref);
+                let manifest = client.pull_image_manifest(img_ref, &auth);
                 let (oci_image_manifest, _) = runtime.block_on(manifest).with_context(||
                     format!(
                         "Repository '{}' does not exist in registry '{}' or tag '{tag}' not found in repository",
@@ -428,7 +461,7 @@ mod tests {
 
     #[test]
     fn test_retrieve_access_token() {
-        let client = OciClient::default();
+        let client = HttpFile::create_oci_client();
         let rt = Runtime::new().unwrap();
         let url = "oci://docker.io/library/hello-world:latest".to_string();
         let img_ref = url
@@ -440,7 +473,7 @@ mod tests {
 
     #[test]
     fn test_retrieve_artifact_digest() {
-        let client = OciClient::default();
+        let client = HttpFile::create_oci_client();
         let rt = Runtime::new().unwrap();
         // TODO(12732): Fix this test to use test COSI file instead of hello-world image
         let url = "oci://docker.io/library/hello-world@sha256:940c619fbd418f9b2b1b63e25d8861f9cc1b46e3fc8b018ccfe8b78f19b8cc4f".to_string();

--- a/crates/trident/src/io_utils/http/file.rs
+++ b/crates/trident/src/io_utils/http/file.rs
@@ -230,29 +230,34 @@ impl HttpFile {
         RegistryAuth::Anonymous
     }
 
+    /// Read a proxy environment variable, trying uppercase then lowercase,
+    /// and normalizing empty/whitespace-only values to None.
+    fn read_proxy_env(upper: &str, lower: &str) -> Option<String> {
+        env::var(upper)
+            .or_else(|_| env::var(lower))
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+    }
+
     /// Create an OCI client configured with proxy settings from the environment.
     fn create_oci_client() -> OciClient {
-        let https_proxy = env::var("HTTPS_PROXY")
-            .or_else(|_| env::var("https_proxy"))
-            .ok()
-            .filter(|v| !v.trim().is_empty());
-        let http_proxy = env::var("HTTP_PROXY")
-            .or_else(|_| env::var("http_proxy"))
-            .ok()
-            .filter(|v| !v.trim().is_empty());
-        let no_proxy = env::var("NO_PROXY")
-            .or_else(|_| env::var("no_proxy"))
-            .ok()
-            .filter(|v| !v.trim().is_empty());
+        let https_proxy = Self::read_proxy_env("HTTPS_PROXY", "https_proxy");
+        let http_proxy = Self::read_proxy_env("HTTP_PROXY", "http_proxy");
+        let no_proxy = Self::read_proxy_env("NO_PROXY", "no_proxy");
 
         if https_proxy.is_some() || http_proxy.is_some() {
-            let http_status = if http_proxy.is_some() {
-                "<set>"
-            } else {
-                "<unset>"
-            };
             debug!(
-                "Configuring OCI client with proxy (HTTPS_PROXY=<set>, HTTP_PROXY={http_status})"
+                "Configuring OCI client with proxy (HTTPS_PROXY={}, HTTP_PROXY={})",
+                if https_proxy.is_some() {
+                    "<set>"
+                } else {
+                    "<unset>"
+                },
+                if http_proxy.is_some() {
+                    "<set>"
+                } else {
+                    "<unset>"
+                },
             );
         }
 


### PR DESCRIPTION
## Problem

The OCI client used for pulling container images and artifacts was created with \OciClient::default()\, which does **not** read proxy environment variables (\HTTPS_PROXY\, \HTTP_PROXY\, \NO_PROXY\). This caused all OCI registry pulls to fail on baremetal machines that depend on a proxy for external network access.

### Symptoms
- DNS resolution failures for \maritimusdev.azurecr.io\ on baremetal test machines
- Error: \rror sending request ... dns error: failed to lookup address\
- Failures only on baremetal (which requires proxy), never on VMs (which have direct internet)
- Affected pipeline: \	rident-full-validation\ baremetal deployment testing stages

### Root Cause
The \oci-client\ crate (v0.15) requires explicit proxy configuration via \ClientConfig\ fields. Unlike \eqwest::ClientBuilder::new()\ (used elsewhere in this file for HTTP downloads), \OciClient::default()\ does **not** auto-detect proxy env vars.

Baremetal machines set \HTTPS_PROXY\ on the trident systemd service (via pipeline YAML), but the OCI client ignored it entirely.

### Additional Fix
The \etrieve_artifact_digest()\ function was hardcoding \RegistryAuth::Anonymous\ for manifest pulls, inconsistent with \get_docker_auth()\ used for token retrieval. This is now fixed to use the same auth logic.

## Changes
- Add \create_oci_client()\ helper that reads \HTTPS_PROXY\, \HTTP_PROXY\, and \NO_PROXY\ env vars (case-insensitive) and passes them to \ClientConfig\
- Fix \etrieve_artifact_digest()\ to use \get_docker_auth()\ instead of hardcoded \RegistryAuth::Anonymous\
- Update tests to use the new proxy-aware client constructor

## Testing
- \cargo check -p trident\ passes
- Verified \oci-client\ 0.15 \ClientConfig\ supports \https_proxy: Option<String>\
- Fix addresses failures observed in pipeline run [1113804](https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1113804)