### PR TITLE
engineering: Add AZL4 distro detection and extend GRUB path to AZL4

### DIFF
--- a/crates/osutils/src/mkinitrd.rs
+++ b/crates/osutils/src/mkinitrd.rs
@@ -118,6 +118,8 @@ mod functional_test {
     fn test_regenerate_initrd() {
         let pattern = if osrelease::is_azl3().unwrap() {
             "/boot/initramfs-*.azl3.img"
+        } else if osrelease::is_azl4().unwrap() {
+            "/boot/initramfs-*.azl4.img"
         } else {
             "/boot/initrd.img-*"
         };

--- a/crates/osutils/src/osrelease.rs
+++ b/crates/osutils/src/osrelease.rs
@@ -31,6 +31,11 @@ pub fn is_azl3() -> Result<bool, Error> {
     Ok(OsRelease::read()?.get_distro().is_azl3())
 }
 
+/// Returns whether the host is running Azure Linux 4.
+pub fn is_azl4() -> Result<bool, Error> {
+    Ok(OsRelease::read()?.get_distro().is_azl4())
+}
+
 /// Represents the contents of the /etc/os-release file.
 ///
 /// See <https://www.freedesktop.org/software/systemd/man/latest/os-release.html>
@@ -146,6 +151,8 @@ impl OsRelease {
                             AzureLinuxRelease::AzL2
                         } else if v.starts_with("3.") {
                             AzureLinuxRelease::AzL3
+                        } else if v.starts_with("4.") {
+                            AzureLinuxRelease::AzL4
                         } else {
                             trace!("Unknown Azure Linux release: {v}");
                             AzureLinuxRelease::Other
@@ -342,6 +349,10 @@ impl Distro {
         self == &Distro::AzureLinux(AzureLinuxRelease::AzL3)
     }
 
+    pub fn is_azl4(&self) -> bool {
+        self == &Distro::AzureLinux(AzureLinuxRelease::AzL4)
+    }
+
     pub fn is_acl(&self) -> bool {
         self == &Distro::AzureContainerLinux
     }
@@ -354,6 +365,7 @@ pub enum AzureLinuxRelease {
     Other,
     AzL2,
     AzL3,
+    AzL4,
 }
 
 #[cfg(test)]
@@ -426,6 +438,41 @@ mod tests {
         assert_eq!(
             os_release.get_distro(),
             Distro::AzureLinux(AzureLinuxRelease::AzL3)
+        );
+    }
+
+    #[test]
+    fn test_parse_azl4() {
+        let data = indoc::indoc! {
+            r#"
+            NAME="Azure Linux"
+            VERSION="4.0 (Four Alpha2)"
+            RELEASE_TYPE=development
+            ID=azurelinux
+            ID_LIKE=fedora
+            VERSION_ID="4.0"
+            VERSION_CODENAME=""
+            PRETTY_NAME="Azure Linux 4.0 (Four Alpha2)"
+            ANSI_COLOR="0;38;2;60;110;180"
+            LOGO=azurelinux-logo-icon
+            CPE_NAME="cpe:/o:azurelinuxproject:azurelinux:4.0"
+            DEFAULT_HOSTNAME="azurelinux"
+            HOME_URL="https://aka.ms/azurelinux"
+            DOCUMENTATION_URL="https://aka.ms/azurelinux"
+            SUPPORT_URL="https://aka.ms/azurelinux"
+            BUG_REPORT_URL="https://aka.ms/azurelinux"
+            SUPPORT_END=2026-05-15
+            "#,
+        };
+
+        let os_release = OsRelease::parse(data);
+        assert_eq!(os_release.id, Some("azurelinux".to_string()));
+        assert_eq!(os_release.version_id, Some("4.0".to_string()));
+        assert_eq!(os_release.id_like, Some("fedora".to_string()));
+        assert_eq!(os_release.release_type, Some("development".to_string()));
+        assert_eq!(
+            os_release.get_distro(),
+            Distro::AzureLinux(AzureLinuxRelease::AzL4)
         );
     }
 

--- a/crates/osutils/src/testutils/osrelease.rs
+++ b/crates/osutils/src/testutils/osrelease.rs
@@ -38,11 +38,36 @@ const AZURE_LINUX_3_OS_RELEASE: &str = indoc::indoc! {
     "#,
 };
 
+/// Azure Linux 4.0 sample os-release file.
+const AZURE_LINUX_4_OS_RELEASE: &str = indoc::indoc! {
+    r#"
+    NAME="Azure Linux"
+    VERSION="4.0 (Cloud Variant Beta)"
+    RELEASE_TYPE=development
+    ID=azurelinux
+    ID_LIKE=fedora
+    VERSION_ID="4.0"
+    VERSION_CODENAME=""
+    PRETTY_NAME="Azure Linux 4.0 (Cloud Variant Beta)"
+    ANSI_COLOR="0;38;2;60;110;180"
+    LOGO=azurelinux-logo-icon
+    CPE_NAME="cpe:/o:azurelinuxproject:azurelinux:4.0"
+    DEFAULT_HOSTNAME="azurelinux"
+    HOME_URL="https://aka.ms/azurelinux"
+    DOCUMENTATION_URL="https://aka.ms/azurelinux"
+    SUPPORT_URL="https://aka.ms/azurelinux"
+    BUG_REPORT_URL="https://aka.ms/azurelinux"
+    VARIANT="Cloud Variant"
+    VARIANT_ID=cloud
+    "#,
+};
+
 /// Creates a mock /etc/os-release file with the given Azure Linux release.
 pub fn make_mock_os_release(root_path: &Path, azl_release: AzureLinuxRelease) -> Result<(), Error> {
     let os_release_content = match azl_release {
         AzureLinuxRelease::AzL2 => AZURE_LINUX_2_OS_RELEASE,
         AzureLinuxRelease::AzL3 => AZURE_LINUX_3_OS_RELEASE,
+        AzureLinuxRelease::AzL4 => AZURE_LINUX_4_OS_RELEASE,
         AzureLinuxRelease::Other => bail!("Unsupported Azure Linux release 'other'"),
     };
 

--- a/crates/trident/src/engine/boot/grub.rs
+++ b/crates/trident/src/engine/boot/grub.rs
@@ -86,13 +86,13 @@ pub(super) fn update_configs(ctx: &EngineContext) -> Result<(), Error> {
     ))
 }
 
-/// Updates the GRUB config for Azure Linux 3.0 using OS modifier.
+/// Updates the GRUB config for Azure Linux using OS modifier.
 fn update_grub_config(
     ctx: &EngineContext,
     root_device_path: &Path,
     boot_grub_config_path: &Path,
 ) -> Result<(), Error> {
-    // For azl 3.0, we need to disable cloud-init's network configuration when Trident is
+    // For azl 3.0+, we need to disable cloud-init's network configuration when Trident is
     // configuring the network. This is done by setting the 'network-config' kernel parameter
     // to 'disabled'.
     if ctx.spec.os.netplan.is_some() {
@@ -104,7 +104,7 @@ fn update_grub_config(
             .context("Failed to disable default cloud-init network config")?;
     }
 
-    debug!("Updating GRUB config for Azure Linux 3.0 with OS modifier");
+    debug!("Updating GRUB config with OS modifier");
 
     // OS modifier will read values of verity, selinux, root device, and overlay from original GRUB config
     // stamp them into /etc/default/grub and regenerate the GRUB config using grub-mkconfig.
@@ -223,7 +223,7 @@ fn update_grub_config(
     osmodifier::modify_boot(&osmod_ctx, &config)
         .context("Failed to apply boot configuration modifications")?;
 
-    debug!("Finished updating GRUB config for Azure Linux 3.0 with OS modifier");
+    debug!("Finished updating GRUB config with OS modifier");
 
     Ok(())
 }

--- a/crates/trident/src/engine/boot/grub.rs
+++ b/crates/trident/src/engine/boot/grub.rs
@@ -63,9 +63,10 @@ pub(super) fn update_configs(ctx: &EngineContext) -> Result<(), Error> {
     let boot_grub_config_path = Path::new(ROOT_MOUNT_POINT_PATH).join(GRUB2_CONFIG_RELATIVE_PATH);
 
     // Update GRUB config on the boot device (volume holding /boot)
-    match ctx.host_os_release.get_distro() {
-        Distro::AzureLinux(AzureLinuxRelease::AzL3) => {
-            update_grub_config_azl3(ctx, &root_device_path, &boot_grub_config_path)?;
+    // Use the *image* distro (the OS being installed), not the host (MOS ISO).
+    match ctx.image_distro() {
+        Distro::AzureLinux(AzureLinuxRelease::AzL3 | AzureLinuxRelease::AzL4) => {
+            update_grub_config(ctx, &root_device_path, &boot_grub_config_path)?;
         }
 
         d => bail!("Unsupported distro for GRUB config update: {d:?}"),
@@ -86,7 +87,7 @@ pub(super) fn update_configs(ctx: &EngineContext) -> Result<(), Error> {
 }
 
 /// Updates the GRUB config for Azure Linux 3.0 using OS modifier.
-fn update_grub_config_azl3(
+fn update_grub_config(
     ctx: &EngineContext,
     root_device_path: &Path,
     boot_grub_config_path: &Path,

--- a/crates/trident/src/engine/context/mod.rs
+++ b/crates/trident/src/engine/context/mod.rs
@@ -441,8 +441,16 @@ impl EngineContext {
     }
 
     /// Retrieves the distribution of the OS image.
+    ///
+    /// Prefers the image's own os-release (e.g., from the COSI being installed).
+    /// Falls back to the host os-release when no image is available (functional
+    /// tests, runtime operations outside an install flow).
     pub(crate) fn image_distro(&self) -> Distro {
-        self.image_os_release().get_distro()
+        let distro = self.image_os_release().get_distro();
+        match distro {
+            Distro::Other => self.host_os_release.get_distro(),
+            d => d,
+        }
     }
 }
 

--- a/crates/trident/src/engine/context/mod.rs
+++ b/crates/trident/src/engine/context/mod.rs
@@ -443,13 +443,17 @@ impl EngineContext {
     /// Retrieves the distribution of the OS image.
     ///
     /// Prefers the image's own os-release (e.g., from the COSI being installed).
-    /// Falls back to the host os-release when no image is available (functional
-    /// tests, runtime operations outside an install flow).
+    /// Falls back to the host os-release only when no image is mounted
+    /// (functional tests, runtime operations outside an install flow).
+    ///
+    /// If an image IS present but its distro is unrecognized, the image's
+    /// distro is returned as-is (Distro::Other) so callers can bail
+    /// explicitly rather than silently using the host's distro.
     pub(crate) fn image_distro(&self) -> Distro {
-        let distro = self.image_os_release().get_distro();
-        match distro {
-            Distro::Other => self.host_os_release.get_distro(),
-            d => d,
+        if self.image.is_some() {
+            self.image_os_release().get_distro()
+        } else {
+            self.host_os_release.get_distro()
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds AZL4 (Azure Linux 4.0, Fedora-based) distro detection and wires it into the GRUB update flow so installs can target AZL4 correctly, including when the installer host OS differs from the image OS.

## Changes

- Extend `OsRelease::get_distro()` / `Distro` helpers to recognize `VERSION_ID=4.x` as `AzureLinuxRelease::AzL4`, plus `ID_LIKE=fedora` detection
- Add `is_azl4()` helper on `Distro`
- Add AZL4 Beta os-release test constant (Cloud Variant Beta)
- Switch GRUB update selection to key off the *image* distro via `image_distro()`, and allow the existing GRUB update path to run for AZL4 as well
- `image_distro()` falls back to host OS only when no image is mounted (not when distro is unrecognized)
- Rename `update_grub_config_azl3` to `update_grub_config` (serves both AZL3 and AZL4)
- Update mkinitrd functional-test initramfs glob to handle AZL4 naming

## PR Stack

| # | PR | Description | Diff |
|---|-----|-------------|------|
| **1** | **this (#642)** | **AZL4 distro detection + GRUB update path** | [vs main](https://github.com/microsoft/trident/compare/main...user/britel/azl4-1-grub-native) |
| 2 | #672 | Generic EFI vendor-dir discovery + AZL4 ESP | [vs PR-1](https://github.com/microsoft/trident/compare/user/britel/azl4-1-grub-native...user/britel/azl4-2-esp-layouts) |
| 3 | #679 | BLS entry support for boot arg extraction | [vs PR-2](https://github.com/microsoft/trident/compare/user/britel/azl4-2-esp-layouts...user/britel/azl4-2b-bls-grub) |
| 4 | — | Builder infra + image acquisition | [vs PR-3](https://github.com/microsoft/trident/compare/user/britel/azl4-2b-bls-grub...user/britel/azl4-5a-builder-infra) |
| 5 | — | Image configs + pipeline stages | [vs PR-4](https://github.com/microsoft/trident/compare/user/britel/azl4-5a-builder-infra...user/britel/azl4-5b-image-pipeline) |
| 6 | — | BM-simulated netlaunch stage | [vs PR-5](https://github.com/microsoft/trident/compare/user/britel/azl4-5b-image-pipeline...user/britel/azl4-6-bm-test) |
| 7 | — | qcow2 base + offline-init | [vs PR-6](https://github.com/microsoft/trident/compare/user/britel/azl4-6-bm-test...user/britel/azl4-7a-qcow2-rust) |
| 8 | — | VM rollback test stage | [vs PR-7](https://github.com/microsoft/trident/compare/user/britel/azl4-7a-qcow2-rust...user/britel/azl4-7b-rollback-stage) |