### PR TITLE
selinux: restore missing ioctl/lock and gpg_exec_t in optional policy blocks

### DIFF
--- a/packaging/selinux-policy-trident/trident.te
+++ b/packaging/selinux-policy-trident/trident.te
@@ -638,8 +638,8 @@ optional_policy(`
         type gpg_agent_exec_t;
         type gpg_secret_t;
     }
-    allow trident_t gpg_exec_t:file { ioctl read getattr lock map execute entrypoint open };
-    allow trident_t gpg_agent_exec_t:file { ioctl read getattr lock map execute entrypoint open };
+    allow trident_t gpg_exec_t:file { ioctl read getattr lock map execute execute_no_trans open };
+    allow trident_t gpg_agent_exec_t:file { ioctl read getattr lock map execute execute_no_trans open };
     allow trident_t gpg_secret_t:dir list_dir_perms;
     allow trident_t gpg_secret_t:file read_file_perms;
     allow trident_t gpg_secret_t:lnk_file read_lnk_file_perms;

--- a/packaging/selinux-policy-trident/trident.te
+++ b/packaging/selinux-policy-trident/trident.te
@@ -634,10 +634,12 @@ auth_read_lastlog(trident_t)
 auth_read_login_records(trident_t)
 optional_policy(`
     require {
+        type gpg_exec_t;
         type gpg_agent_exec_t;
         type gpg_secret_t;
     }
-    allow trident_t gpg_agent_exec_t:file { getattr open read execute entrypoint map };
+    allow trident_t gpg_exec_t:file { ioctl read getattr lock map execute entrypoint open };
+    allow trident_t gpg_agent_exec_t:file { ioctl read getattr lock map execute entrypoint open };
     allow trident_t gpg_secret_t:dir list_dir_perms;
     allow trident_t gpg_secret_t:file read_file_perms;
     allow trident_t gpg_secret_t:lnk_file read_lnk_file_perms;
@@ -660,7 +662,7 @@ optional_policy(`
         type chronyd_etc_t;
         type chronyd_keys_t;
     }
-    allow trident_t chronyd_exec_t:file { getattr open read execute execute_no_trans map };
+    allow trident_t chronyd_exec_t:file { ioctl read getattr lock map execute execute_no_trans open };
     allow trident_t chronyd_etc_t:dir list_dir_perms;
     allow trident_t chronyd_etc_t:file read_file_perms;
     allow trident_t chronyd_keys_t:file read_file_perms;
@@ -689,7 +691,7 @@ optional_policy(`
     require {
         type logrotate_exec_t;
     }
-    allow trident_t logrotate_exec_t:file { getattr open read execute execute_no_trans map };
+    allow trident_t logrotate_exec_t:file { ioctl read getattr lock map execute execute_no_trans open };
 ')
 ssh_domtrans(trident_t)
 ssh_domtrans_keygen(trident_t)
@@ -825,7 +827,7 @@ optional_policy(`
     allow trident_t rpm_var_lib_t:dir { manage_dir_perms relabelto };
     allow trident_t rpm_var_lib_t:file { manage_file_perms map relabelto };
     allow trident_t rpm_var_lib_t:lnk_file { read_lnk_file_perms };
-    allow trident_t rpm_exec_t:file { getattr open read execute execute_no_trans map };
+    allow trident_t rpm_exec_t:file { ioctl read getattr lock map execute execute_no_trans open };
     allow trident_t rpm_var_cache_t:dir list_dir_perms;
     allow trident_t rpm_var_cache_t:file read_file_perms;
     allow trident_t rpm_var_cache_t:lnk_file { read_lnk_file_perms };
@@ -879,7 +881,7 @@ optional_policy(`
     require {
         type sudo_exec_t;
     }
-    allow trident_t sudo_exec_t:file { getattr open read execute execute_no_trans map };
+    allow trident_t sudo_exec_t:file { ioctl read getattr lock map execute execute_no_trans open };
 ')
 corecmd_manage_bin_files(trident_t)
 corecmd_bin_entry_type(trident_t)
@@ -891,7 +893,7 @@ optional_policy(`
         type kadmind_exec_t;
         type krb5_conf_t;
     }
-    allow trident_t kadmind_exec_t:file { getattr open read execute execute_no_trans map };
+    allow trident_t kadmind_exec_t:file { ioctl read getattr lock map execute execute_no_trans open };
     allow trident_t krb5_conf_t:dir list_dir_perms;
     allow trident_t krb5_conf_t:file read_file_perms;
 ')


### PR DESCRIPTION
## Problem

PR #636 replaced refpolicy interface macros with hand-expanded allow rules inside `optional_policy` blocks so the policy compiles on ACL images that lack those modules. However, the manual expansions had two permission gaps:

### 1. `gpg_exec_t` dropped entirely
The original `gpg_entry_type(trident_t)` macro expanded to `domain_entry_file(trident_t, gpg_exec_t)`, granting trident access to the main gpg/gpg2 binary. The replacement only covered `gpg_agent_exec_t` — `gpg_exec_t` was neither required nor referenced.

On full Azure Linux where GPG is installed, trident loses all permissions on the gpg binary (needed by tdnf/rpm for package signature verification).

### 2. `ioctl` and `lock` systematically dropped from all exec replacements
Six exec macro replacements (chronyd_exec_t, logrotate_exec_t, rpm_exec_t, sudo_exec_t, kadmind_exec_t, gpg_agent_exec_t) all used `{ getattr open read execute execute_no_trans map }` but the original `can_exec` / `domain_entry_file` macros also grant `ioctl` and `lock`.

This creates a permission gap on full AZL that could cause AVC denials.

### 3. `entrypoint` used instead of `execute_no_trans` on gpg binaries
The pre-#636 policy used `gpg_entry_type(trident_t)` which grants `entrypoint` — meaning 'this binary is a valid entry point for transitioning INTO trident_t.' However, trident (and osmodifier, which trident calls) do not directly exec gpg. GPG is invoked indirectly by tdnf/rpm for package signature verification, running in `trident_t` via `execute_no_trans`. There is no `type_transition` rule for gpg → trident_t anywhere in the policy, so `entrypoint` was always a latent bug in the original policy. The correct permission is `execute_no_trans` (execute without domain transition), matching `can_exec` macro semantics.

Verified that all tools invoked by osmodifier (useradd, usermod, systemctl, openssl, sed, grub2-mkconfig, blkid, setfiles, semanage, chmod) are already covered by existing policy rules.

## Fix
- Add `gpg_exec_t` to the GPG optional block
- Use `execute_no_trans` (not `entrypoint`) on both `gpg_exec_t` and `gpg_agent_exec_t` to match actual runtime behavior
- Restore `ioctl` and `lock` on all six `_exec_t` allow rules to match upstream macro semantics

## Review
Changes validated by 9-agent deep review (3 roles × 3 models: GPT-5.5, Opus, Sonnet). Finding #2 (entrypoint semantics) was flagged by all 3 skeptic models and 2 of 3 architect models.

## Validation
* trideht pr-e2e: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1116164&view=results
* acl ab-update: https://dev.azure.com/mariner-org/ACL/_build/results?buildId=1116173