### PR TITLE
build: use imagecustomizer container for MOS ISO build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -803,24 +803,8 @@ starter-configuration:
 	@echo "\033[33mCreated \033[36m$(TRIDENT_CONFIG)\033[33m. Please review and modify as needed! :)"
 	@echo "\033[33mDon't forget to add your SSH public key to the Host Configuration!"
 
-MIC_PACKAGE_NAME ?= imagecustomizer
-MIC_PACKAGE_VERSION ?= *
-artifacts/imagecustomizer:
-	@mkdir -p artifacts
-	@az artifacts universal download \
-	    --organization "https://dev.azure.com/mariner-org/" \
-	    --project "36d030d6-1d99-4ebd-878b-09af1f4f722f" \
-	    --scope project \
-	    --feed "AzureLinuxArtifacts" \
-	    --name '$(MIC_PACKAGE_NAME)' \
-	    --version '$(MIC_PACKAGE_VERSION)' \
-	    --path artifacts/
-	@chmod +x artifacts/imagecustomizer
-	@touch artifacts/imagecustomizer
-
 bin/trident-mos.iso: \
 	artifacts/baremetal.vhdx \
-	artifacts/imagecustomizer \
 	packaging/systemd/trident-install.service \
 	tests/images/trident-mos/iso.yaml \
 	tests/images/trident-mos/files/* \
@@ -830,15 +814,17 @@ bin/trident-mos.iso: \
 	bin/rcp-agent
 	@echo "Rebuilding Trident MOS ISO: $@ from $< because of: $?"
 	@mkdir -p bin
-	BUILD_DIR=`mktemp -d` && \
-		trap 'sudo rm -rf $$BUILD_DIR' EXIT; \
-		sudo ./artifacts/imagecustomizer \
-			--log-level=debug \
-			--build-dir $$BUILD_DIR \
-			--image-file $< \
-			--output-image-file $@ \
-			--config-file tests/images/trident-mos/iso.yaml \
-			--output-image-format iso
+	docker run --rm \
+		--privileged \
+		-v ".:/repo:z" \
+		-v "/dev:/dev" \
+		${MIC_CONTAINER_IMAGE} \
+		--log-level=debug \
+		--build-dir /build \
+		--image-file /repo/$< \
+		--output-image-file /repo/$@ \
+		--config-file /repo/tests/images/trident-mos/iso.yaml \
+		--output-image-format iso
 
 .PHONY: recreate-verity-image
 recreate-verity-image: bin/trident-rpms.tar.gz

--- a/docs/Development/Testing/E2E-Tests.md
+++ b/docs/Development/Testing/E2E-Tests.md
@@ -164,20 +164,7 @@ mv artifacts/test-image/trident-usrverity-testimage_1.cosi artifacts/test-image/
 The images use the Image Customizer container from
 `mcr.microsoft.com/azurelinux/imagecustomizer:latest`.
 
-### 8. Extract Image Customizer
-
-The MOS ISO build uses the Image Customizer binary directly (not the
-container). Extract it from the container image:
-
-```bash
-mkdir -p artifacts
-id=$(docker create mcr.microsoft.com/azurelinux/imagecustomizer:latest)
-docker cp "$id:/usr/bin/imagecustomizer" artifacts/imagecustomizer
-docker rm "$id"
-chmod +x artifacts/imagecustomizer
-```
-
-### 9. Build the Installer ISO
+### 8. Build the Installer ISO
 
 The management OS ISO is used by `netlaunch` to boot the VM and run Trident:
 


### PR DESCRIPTION
## Summary

Replace the standalone `imagecustomizer` binary download with a `docker run` invocation of the Image Customizer container for the `bin/trident-mos.iso` Makefile target.

## Changes

### Makefile
- Remove `MIC_PACKAGE_NAME` and `MIC_PACKAGE_VERSION` variables (no longer needed)
- Remove `artifacts/imagecustomizer` download target
- Replace `sudo ./artifacts/imagecustomizer` invocation with `docker run --rm --privileged` using `$(MIC_CONTAINER_IMAGE)`
- Bind-mount the repo at `/repo` and use `/build` as the container-internal build directory
- Remove `artifacts/imagecustomizer` from the `clean` target

### docs/Development/Building/E2E-Tests.md
- Remove the "Extract Image Customizer" build step (no longer needed since the Makefile handles the container internally)
- Renumber subsequent steps

## Motivation

- Eliminates the `az` CLI dependency for local MOS ISO builds (the binary download required `az acr login`)
- Aligns with the existing pattern used by other Makefile targets that already use `$(MIC_CONTAINER_IMAGE)`
- Simplifies the developer workflow — `make bin/trident-mos.iso` just works with Docker

## Testing

- Built MOS ISO successfully on a Linux host using `make bin/trident-mos.iso`
- Container pull, privileged mount, and ISO generation all completed without errors (264MB ISO, ~94 seconds)

## Stacking

This PR is stacked on #652 (E2E doc rewrite).
