### PR TITLE
engineering: [osmodifier follow-up] centralize magic literals into constants module

### DIFF
--- a/crates/osmodifier/src/constants.rs
+++ b/crates/osmodifier/src/constants.rs
@@ -7,23 +7,23 @@
 //! once to avoid magic-literal duplication across modules.
 
 /// GRUB variable name for the primary kernel command line.
-pub const GRUB_VAR_CMDLINE_LINUX: &str = "GRUB_CMDLINE_LINUX";
+pub(crate) const GRUB_VAR_CMDLINE_LINUX: &str = "GRUB_CMDLINE_LINUX";
 
 /// GRUB variable name for the default (non-recovery) kernel command line.
-pub const GRUB_VAR_CMDLINE_LINUX_DEFAULT: &str = "GRUB_CMDLINE_LINUX_DEFAULT";
+pub(crate) const GRUB_VAR_CMDLINE_LINUX_DEFAULT: &str = "GRUB_CMDLINE_LINUX_DEFAULT";
 
 /// GRUB variable name for the boot device.
-pub const GRUB_VAR_DEVICE: &str = "GRUB_DEVICE";
+pub(crate) const GRUB_VAR_DEVICE: &str = "GRUB_DEVICE";
 
 /// Kernel args to extract from grub.cfg and sync back to /etc/default/grub.
 ///
 /// Used by both `grub_cfg::extract_boot_args_from_grub_cfg` (to pick which
 /// args to capture) and `update_default_grub` (to specify which existing
 /// args to replace).
-pub const SYNC_ARG_NAMES: &[&str] = &["rd.overlayfs", "roothash", "root", "selinux", "enforcing"];
+pub(crate) const SYNC_ARG_NAMES: &[&str] = &["rd.overlayfs", "roothash", "root", "security", "selinux", "enforcing"];
 
 /// Kernel command-line arg names managed by SELinux configuration.
 ///
 /// Used when updating or replacing SELinux-related boot args in
 /// GRUB_CMDLINE_LINUX.
-pub const SELINUX_CMDLINE_ARG_NAMES: &[&str] = &["security", "selinux", "enforcing"];
+pub(crate) const SELINUX_CMDLINE_ARG_NAMES: &[&str] = &["security", "selinux", "enforcing"];

--- a/crates/osmodifier/src/constants.rs
+++ b/crates/osmodifier/src/constants.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Centralized constants for the osmodifier crate.
+//!
+//! GRUB variable names and kernel command-line arg names are defined here
+//! once to avoid magic-literal duplication across modules.
+
+/// GRUB variable name for the primary kernel command line.
+pub const GRUB_VAR_CMDLINE_LINUX: &str = "GRUB_CMDLINE_LINUX";
+
+/// GRUB variable name for the default (non-recovery) kernel command line.
+pub const GRUB_VAR_CMDLINE_LINUX_DEFAULT: &str = "GRUB_CMDLINE_LINUX_DEFAULT";
+
+/// GRUB variable name for the boot device.
+pub const GRUB_VAR_DEVICE: &str = "GRUB_DEVICE";
+
+/// Kernel args to extract from grub.cfg and sync back to /etc/default/grub.
+///
+/// Used by both `grub_cfg::extract_boot_args_from_grub_cfg` (to pick which
+/// args to capture) and `update_default_grub` (to specify which existing
+/// args to replace).
+pub const SYNC_ARG_NAMES: &[&str] = &["rd.overlayfs", "roothash", "root", "selinux", "enforcing"];
+
+/// Kernel command-line arg names managed by SELinux configuration.
+///
+/// Used when updating or replacing SELinux-related boot args in
+/// GRUB_CMDLINE_LINUX.
+pub const SELINUX_CMDLINE_ARG_NAMES: &[&str] = &["security", "selinux", "enforcing"];

--- a/crates/osmodifier/src/constants.rs
+++ b/crates/osmodifier/src/constants.rs
@@ -20,7 +20,14 @@ pub(crate) const GRUB_VAR_DEVICE: &str = "GRUB_DEVICE";
 /// Used by both `grub_cfg::extract_boot_args_from_grub_cfg` (to pick which
 /// args to capture) and `update_default_grub` (to specify which existing
 /// args to replace).
-pub(crate) const SYNC_ARG_NAMES: &[&str] = &["rd.overlayfs", "roothash", "root", "security", "selinux", "enforcing"];
+pub(crate) const SYNC_ARG_NAMES: &[&str] = &[
+    "rd.overlayfs",
+    "roothash",
+    "root",
+    "security",
+    "selinux",
+    "enforcing",
+];
 
 /// Kernel command-line arg names managed by SELinux configuration.
 ///

--- a/crates/osmodifier/src/default_grub.rs
+++ b/crates/osmodifier/src/default_grub.rs
@@ -12,6 +12,7 @@ use std::{fs, path::PathBuf};
 use anyhow::{Context, Error};
 use log::{debug, trace};
 
+use crate::constants::{GRUB_VAR_CMDLINE_LINUX, GRUB_VAR_CMDLINE_LINUX_DEFAULT};
 use crate::OsModifierContext;
 
 const DEFAULT_GRUB_PATH: &str = "/etc/default/grub";
@@ -93,7 +94,7 @@ impl DefaultGrub {
         old_keys: &[&str],
         new_args: &[String],
     ) -> Result<(), Error> {
-        let current = self.get_variable("GRUB_CMDLINE_LINUX").unwrap_or_default();
+        let current = self.get_variable(GRUB_VAR_CMDLINE_LINUX).unwrap_or_default();
 
         let mut args: Vec<String> = current
             .split_whitespace()
@@ -107,7 +108,7 @@ impl DefaultGrub {
         args.extend(new_args.iter().cloned());
 
         let new_value = args.join(" ");
-        self.set_variable("GRUB_CMDLINE_LINUX", &new_value);
+        self.set_variable(GRUB_VAR_CMDLINE_LINUX, &new_value);
 
         Ok(())
     }
@@ -127,7 +128,7 @@ impl DefaultGrub {
         }
 
         let current = self
-            .get_variable("GRUB_CMDLINE_LINUX_DEFAULT")
+            .get_variable(GRUB_VAR_CMDLINE_LINUX_DEFAULT)
             .unwrap_or_default();
 
         let mut args: Vec<String> = if current.is_empty() {
@@ -139,7 +140,7 @@ impl DefaultGrub {
         args.extend(extra.iter().cloned());
 
         let new_value = args.join(" ");
-        self.set_variable("GRUB_CMDLINE_LINUX_DEFAULT", &new_value);
+        self.set_variable(GRUB_VAR_CMDLINE_LINUX_DEFAULT, &new_value);
     }
 }
 

--- a/crates/osmodifier/src/default_grub.rs
+++ b/crates/osmodifier/src/default_grub.rs
@@ -94,7 +94,9 @@ impl DefaultGrub {
         old_keys: &[&str],
         new_args: &[String],
     ) -> Result<(), Error> {
-        let current = self.get_variable(GRUB_VAR_CMDLINE_LINUX).unwrap_or_default();
+        let current = self
+            .get_variable(GRUB_VAR_CMDLINE_LINUX)
+            .unwrap_or_default();
 
         let mut args: Vec<String> = current
             .split_whitespace()

--- a/crates/osmodifier/src/grub_cfg.rs
+++ b/crates/osmodifier/src/grub_cfg.rs
@@ -17,13 +17,11 @@ use anyhow::{bail, Context, Error};
 use log::{debug, info, trace};
 use osutils::dependencies::Dependency;
 
+use crate::constants::SYNC_ARG_NAMES;
 use crate::OsModifierContext;
 
 /// Possible grub.cfg locations, tried in order.
 const GRUB_CFG_PATHS: &[&str] = &["/boot/grub2/grub.cfg", "/boot/grub/grub.cfg"];
-
-/// The grub.cfg args we want to extract for syncing to /etc/default/grub.
-const SYNC_ARG_NAMES: &[&str] = &["rd.overlayfs", "roothash", "root", "selinux", "enforcing"];
 
 /// Extract boot arguments from the generated grub.cfg.
 ///

--- a/crates/osmodifier/src/lib.rs
+++ b/crates/osmodifier/src/lib.rs
@@ -127,7 +127,7 @@ pub fn modify_os(ctx: &OsModifierContext, config: &OSModifierConfig) -> Result<(
 ///
 /// This replaces the Go `osmodifier --update-grub` codepath:
 /// 1. Reads the generated grub.cfg
-/// 2. Extracts overlayfs, verity, root, selinux, enforcing args
+/// 2. Extracts the args listed in [`constants::SYNC_ARG_NAMES`]
 /// 3. Stamps those values into /etc/default/grub
 /// 4. Runs grub2-mkconfig to regenerate
 pub fn update_default_grub(ctx: &OsModifierContext) -> Result<(), Error> {

--- a/crates/osmodifier/src/lib.rs
+++ b/crates/osmodifier/src/lib.rs
@@ -8,7 +8,7 @@
 //! directory (defaulting to `/`).
 
 pub mod config;
-pub mod constants;
+mod constants;
 mod default_grub;
 mod grub_cfg;
 mod hostname;

--- a/crates/osmodifier/src/lib.rs
+++ b/crates/osmodifier/src/lib.rs
@@ -8,6 +8,7 @@
 //! directory (defaulting to `/`).
 
 pub mod config;
+pub mod constants;
 mod default_grub;
 mod grub_cfg;
 mod hostname;
@@ -137,13 +138,10 @@ pub fn update_default_grub(ctx: &OsModifierContext) -> Result<(), Error> {
 
     let mut default_grub = default_grub::DefaultGrub::read(ctx)?;
 
-    default_grub.update_cmdline_args(
-        &["rd.overlayfs", "roothash", "root", "selinux", "enforcing"],
-        &args,
-    )?;
+    default_grub.update_cmdline_args(constants::SYNC_ARG_NAMES, &args)?;
 
     if let Some(root) = root_device {
-        default_grub.set_variable("GRUB_DEVICE", &root);
+        default_grub.set_variable(constants::GRUB_VAR_DEVICE, &root);
     }
 
     default_grub.write()?;
@@ -219,7 +217,7 @@ pub fn modify_boot(ctx: &OsModifierContext, config: &BootConfig) -> Result<(), E
 
     if let Some(ref root_device) = config.root_device {
         debug!("Setting root device to '{root_device}'");
-        default_grub.set_variable("GRUB_DEVICE", root_device);
+        default_grub.set_variable(constants::GRUB_VAR_DEVICE, root_device);
         changed = true;
     }
 

--- a/crates/osmodifier/src/selinux.rs
+++ b/crates/osmodifier/src/selinux.rs
@@ -9,7 +9,7 @@ use anyhow::{bail, Context, Error};
 use log::debug;
 use trident_api::config::SelinuxMode;
 
-use crate::{default_grub::DefaultGrub, OsModifierContext};
+use crate::{constants::SELINUX_CMDLINE_ARG_NAMES, default_grub::DefaultGrub, OsModifierContext};
 
 const SELINUX_CONFIG_PATH: &str = "/etc/selinux/config";
 
@@ -91,7 +91,7 @@ pub fn update_grub_cmdline(
         SelinuxMode::Disabled => vec!["selinux=0".to_string()],
     };
 
-    default_grub.update_cmdline_args(&["security", "selinux", "enforcing"], &new_args)
+    default_grub.update_cmdline_args(SELINUX_CMDLINE_ARG_NAMES, &new_args)
 }
 
 #[cfg_attr(not(test), allow(unused_imports, dead_code))]


### PR DESCRIPTION
# 🔍 Description

Follow up to https://github.com/microsoft/trident/pull/638/

Extract duplicated GRUB variable names and kernel arg name lists into a new constants.rs module within the osmodifier crate:

- GRUB_VAR_CMDLINE_LINUX, GRUB_VAR_CMDLINE_LINUX_DEFAULT, GRUB_VAR_DEVICE
- SYNC_ARG_NAMES (was duplicated in grub_cfg.rs and lib.rs)
- SELINUX_CMDLINE_ARG_NAMES (was inline in selinux.rs)

Eliminates drift risk when args are added or renamed.

