### PR TITLE
engineering: [osmodifier follow-up] write password_expires_days to shadow maxAge field

### DIFF
--- a/crates/osmodifier/src/users.rs
+++ b/crates/osmodifier/src/users.rs
@@ -362,6 +362,16 @@ fn set_password_expiry(ctx: &OsModifierContext, username: &str, days: u64) -> Re
                     }
                 }
 
+                // Validate that lastChange is numeric — password aging
+                // depends on it even though we no longer use it directly.
+                if new_fields[SHADOW_FIELD_LAST_CHANGE].parse::<i64>().is_err() {
+                    parse_err = Some(format!(
+                        "failed to parse lastChange field '{}' for user '{username}'",
+                        new_fields[SHADOW_FIELD_LAST_CHANGE]
+                    ));
+                    return line.to_string();
+                }
+
                 // Set maxAge (field 4) = number of days the password is valid.
                 // This is equivalent to `chage -M <days>`. The previous Go
                 // implementation incorrectly wrote to the account expiration

--- a/crates/osmodifier/src/users.rs
+++ b/crates/osmodifier/src/users.rs
@@ -17,7 +17,7 @@ use crate::{
 // Shadow file field indices (0-based, colon-delimited).
 const SHADOW_FIELD_PASSWORD: usize = 1;
 const SHADOW_FIELD_LAST_CHANGE: usize = 2;
-const SHADOW_FIELD_EXPIRATION: usize = 7;
+const SHADOW_FIELD_MAX_AGE: usize = 4;
 const SHADOW_TOTAL_FIELDS: usize = 9;
 
 // Passwd file field indices (0-based, colon-delimited).
@@ -350,7 +350,8 @@ fn set_password_expiry(ctx: &OsModifierContext, username: &str, days: u64) -> Re
                 found = true;
                 let mut new_fields: Vec<String> = fields.iter().map(|f| f.to_string()).collect();
 
-                // Ensure lastChange field is populated
+                // Ensure lastChange field is populated so password aging
+                // has a reference point for when the clock started.
                 if new_fields[SHADOW_FIELD_LAST_CHANGE].is_empty() {
                     match days_since_unix_epoch() {
                         Ok(d) => new_fields[SHADOW_FIELD_LAST_CHANGE] = d.to_string(),
@@ -360,22 +361,13 @@ fn set_password_expiry(ctx: &OsModifierContext, username: &str, days: u64) -> Re
                         }
                     }
                 }
-                let last_change: i64 = match new_fields[SHADOW_FIELD_LAST_CHANGE].parse() {
-                    Ok(v) => v,
-                    Err(_) => {
-                        parse_err = Some(format!(
-                            "failed to parse lastChange field '{}' for user '{username}'",
-                            new_fields[SHADOW_FIELD_LAST_CHANGE]
-                        ));
-                        return line.to_string();
-                    }
-                };
 
-                // Set account expiration date (field 7) = lastChange + days.
-                // Note: Go's Chage() comment says "chage -M" (max password age, field 4)
-                // but actually writes to the expiration field (field 7). We match Go's
-                // actual behavior, not its misleading comment. See installutils.go:643.
-                new_fields[SHADOW_FIELD_EXPIRATION] = (last_change + days as i64).to_string();
+                // Set maxAge (field 4) = number of days the password is valid.
+                // This is equivalent to `chage -M <days>`. The previous Go
+                // implementation incorrectly wrote to the account expiration
+                // field (field 7), which would disable the entire account
+                // rather than enforce password rotation.
+                new_fields[SHADOW_FIELD_MAX_AGE] = days.to_string();
                 new_fields.join(":")
             } else {
                 line.to_string()


### PR DESCRIPTION
# 🔍 Description

** This is a change in behavior from Go osmodifier behavior **

Follow up to https://github.com/microsoft/trident/pull/638/

The password_expires_days config is documented as setting when a password expires, but the implementation was writing to shadow field 7 (account expiration date), which disables the entire account. This matched a bug in the original Go implementation.

Fix by writing to shadow field 4 (maxAge) instead, which is the standard mechanism for password aging (equivalent to chage -M). The value written is now the raw day count rather than lastChange + days, since maxAge is a relative duration, not an absolute epoch date.

The lastChange field population is preserved because password aging requires a reference point for when the password was last set.

