### PR TITLE
docs: Fix partition type rendering in docs

### DIFF
--- a/crates/trident_api/src/config/host/storage/partitions.rs
+++ b/crates/trident_api/src/config/host/storage/partitions.rs
@@ -272,11 +272,15 @@ impl Display for PartitionType {
     /// Formats known partition types using systemd-repart names and unknown
     /// partition types as `unknown(<uuid>)` to preserve UUID visibility.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Self::Unknown(uuid) = self {
-            write!(f, "unknown({uuid})")
-        } else {
-            write!(f, "{}", self.to_sdrepart_part_type())
+        // On alternate format, show unknown partition types as `unknown(<uuid>)`.
+        if f.alternate() {
+            if let Self::Unknown(uuid) = self {
+                return write!(f, "unknown({uuid})");
+            }
         }
+
+        // On regular format, show the partition type as a simple string.
+        write!(f, "{}", self.to_sdrepart_part_type())
     }
 }
 

--- a/crates/trident_api/src/config/host/storage/partitions.rs
+++ b/crates/trident_api/src/config/host/storage/partitions.rs
@@ -269,8 +269,9 @@ impl From<PartitionType> for DiscoverablePartitionType {
 }
 
 impl Display for PartitionType {
-    /// Formats known partition types using systemd-repart names and unknown
-    /// partition types as `unknown(<uuid>)` to preserve UUID visibility.
+    /// Formats partition types using systemd-repart names for regular `{}`
+    /// output; unknown partition types print as `unknown`, or as
+    /// `unknown(<uuid>)` when using alternate `{:#}` formatting.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // On alternate format, show unknown partition types as `unknown(<uuid>)`.
         if f.alternate() {

--- a/crates/trident_api/src/config/host/storage/storage_graph/error.rs
+++ b/crates/trident_api/src/config/host/storage/storage_graph/error.rs
@@ -83,7 +83,7 @@ pub enum StorageGraphBuildError {
 
     #[error(
         "Referrer {} of kind '{kind}' references partition \
-            '{partition_id}' of invalid type '{partition_type}', acceptable \
+            '{partition_id}' of invalid type '{partition_type:#}', acceptable \
             types are: {valid_types}",
         pretty_node_id(.node_identifier)
     )]
@@ -97,7 +97,7 @@ pub enum StorageGraphBuildError {
 
     #[error(
         "Referrer {} of kind '{kind}' has a special reference of kind '{special_ref_kind}' which \
-            references partition '{partition_id}' of invalid type '{partition_type}', acceptable \
+            references partition '{partition_id}' of invalid type '{partition_type:#}', acceptable \
             types are: {valid_types}",
         pretty_node_id(.node_identifier)
     )]
@@ -175,9 +175,9 @@ pub enum StorageGraphBuildError {
     },
 
     #[error(
-        "Verity device '{node_id}' has a data device with partition type '{data_dev_partition_type}', \
-        which expects the hash device partition type to be '{expected_type}', but the type is \
-        '{hash_dev_partition_type}'."
+        "Verity device '{node_id}' has a data device with partition type '{data_dev_partition_type:#}', \
+        which expects the hash device partition type to be '{expected_type:#}', but the type is \
+        '{hash_dev_partition_type:#}'."
     )]
     InvalidVerityHashPartitionType {
         node_id: String,

--- a/docs/Reference/Host-Configuration/Storage-Rules.md
+++ b/docs/Reference/Host-Configuration/Storage-Rules.md
@@ -239,21 +239,21 @@ The following table lists the expected mount points for each partition type, as
 defined in the [Discoverable Partition Specification
 (DPS)](https://uapi-group.org/specifications/specs/discoverable_partitions_specification/):
 
-| Partition Type                                | Valid Mount Paths                |
-| --------------------------------------------- | -------------------------------- |
-| esp                                           | `/boot` or `/efi` or `/boot/efi` |
-| root                                          | `/`                              |
-| swap                                          | None                             |
-| root-verity                                   | None                             |
-| home                                          | `/home`                          |
-| var                                           | `/var`                           |
-| usr                                           | `/usr`                           |
-| usr-verity                                    | None                             |
-| tmp                                           | `/var/tmp`                       |
-| linux-generic                                 | Any path                         |
-| srv                                           | `/srv`                           |
-| xbootldr                                      | `/boot`                          |
-| unknown(00000000-0000-0000-0000-000000000000) | Any path                         |
+| Partition Type | Valid Mount Paths                |
+| -------------- | -------------------------------- |
+| esp            | `/boot` or `/efi` or `/boot/efi` |
+| root           | `/`                              |
+| swap           | None                             |
+| root-verity    | None                             |
+| home           | `/home`                          |
+| var            | `/var`                           |
+| usr            | `/usr`                           |
+| usr-verity     | None                             |
+| tmp            | `/var/tmp`                       |
+| linux-generic  | Any path                         |
+| srv            | `/srv`                           |
+| xbootldr       | `/boot`                          |
+| unknown        | Any path                         |
 
 ## Partition Type Matching Hash Partition
 


### PR DESCRIPTION
# 🔍 Description

Fixed `Display` impl for `PartitionType` to NOT output the unknown UUID by default.