### PR TITLE
fix: correct kebab-case serialization of acronym error codes

### DIFF
--- a/crates/trident_api/src/error.rs
+++ b/crates/trident_api/src/error.rs
@@ -31,6 +31,7 @@ pub enum ExecutionEnvironmentMisconfigurationError {
     CheckRootPrivileges,
 
     #[error("Failed to find OS Modifier binary at '{binary_path}' required by '{config}'")]
+    #[serde(rename = "find-os-modifier-binary")]
     FindOSModifierBinary { binary_path: String, config: String },
 
     #[error("Failed to find required binary '{binary}'")]
@@ -477,6 +478,7 @@ pub enum ServicingError {
     },
 
     #[error("Failed to perform file-based deployment of ESP images")]
+    #[serde(rename = "deploy-esp-images")]
     DeployESPImages,
 
     #[error("Failed to deploy images")]


### PR DESCRIPTION
## Problem

serde's `rename_all = "kebab-case"` splits consecutive uppercase letters into individual words, producing incorrect error codes in structured error output:

- `DeployESPImages` serializes as `deploy-e-s-p-images` (should be `deploy-esp-images`)
- `FindOSModifierBinary` serializes as `find-o-s-modifier-binary` (should be `find-os-modifier-binary`)

## Fix

Added explicit `#[serde(rename = "...")]` attributes to override the automatic conversion for these two enum variants.

## Testing

No functional change - only affects the serialized error code string in structured error output.
