### PR TITLE
feat: kernel-dependent BTRFS UUID collision resolution (temp_fsid on >=6.7)

### DIFF
--- a/crates/osutils/src/uname.rs
+++ b/crates/osutils/src/uname.rs
@@ -11,11 +11,85 @@ pub fn kernel_release() -> Result<String, Error> {
         .context("Failed to run uname -r")
 }
 
+/// Parsed kernel version with major and minor components.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct KernelVersion {
+    pub major: u32,
+    pub minor: u32,
+}
+
+impl KernelVersion {
+    /// Parse a kernel version from a `uname -r` string.
+    ///
+    /// Extracts the leading `major.minor` from strings like:
+    /// - `6.6.78.2-1.cm2`
+    /// - `6.7.0-1.cm2`
+    /// - `7.0.0`
+    ///
+    /// Returns `None` if the string cannot be parsed.
+    pub fn parse(release: &str) -> Option<Self> {
+        // Strip everything after the first '-' (e.g. "-1.cm2"), then split on '.'.
+        let numeric_part = release.split('-').next()?;
+        let mut parts = numeric_part.split('.');
+        let major = parts.next()?.parse::<u32>().ok()?;
+        let minor = parts.next()?.parse::<u32>().ok()?;
+        Some(KernelVersion { major, minor })
+    }
+
+    /// Returns the kernel version of the running system.
+    pub fn running() -> Result<Option<Self>, Error> {
+        let release = kernel_release()?;
+        Ok(Self::parse(&release))
+    }
+
+    /// Returns true if this kernel version supports the BTRFS `temp_fsuid`
+    /// mount option, which was introduced in Linux 6.7.
+    pub fn supports_btrfs_temp_fsuid(&self) -> bool {
+        (self.major, self.minor) >= (6, 7)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::uname;
+    use super::*;
+
     #[test]
     fn test_kernel_release() {
-        uname::kernel_release().unwrap();
+        kernel_release().unwrap();
+    }
+
+    #[test]
+    fn test_parse_azl_kernel() {
+        let v = KernelVersion::parse("6.6.78.2-1.cm2").unwrap();
+        assert_eq!(v, KernelVersion { major: 6, minor: 6 });
+        assert!(!v.supports_btrfs_temp_fsuid());
+    }
+
+    #[test]
+    fn test_parse_67_kernel() {
+        let v = KernelVersion::parse("6.7.0-1.cm2").unwrap();
+        assert_eq!(v, KernelVersion { major: 6, minor: 7 });
+        assert!(v.supports_btrfs_temp_fsuid());
+    }
+
+    #[test]
+    fn test_parse_major_7() {
+        let v = KernelVersion::parse("7.0.0").unwrap();
+        assert_eq!(v, KernelVersion { major: 7, minor: 0 });
+        assert!(v.supports_btrfs_temp_fsuid());
+    }
+
+    #[test]
+    fn test_parse_simple() {
+        let v = KernelVersion::parse("5.15").unwrap();
+        assert_eq!(v, KernelVersion { major: 5, minor: 15 });
+        assert!(!v.supports_btrfs_temp_fsuid());
+    }
+
+    #[test]
+    fn test_parse_garbage() {
+        assert!(KernelVersion::parse("not-a-version").is_none());
+        assert!(KernelVersion::parse("").is_none());
+        assert!(KernelVersion::parse("6").is_none());
     }
 }

--- a/crates/osutils/src/uname.rs
+++ b/crates/osutils/src/uname.rs
@@ -82,7 +82,13 @@ mod tests {
     #[test]
     fn test_parse_simple() {
         let v = KernelVersion::parse("5.15").unwrap();
-        assert_eq!(v, KernelVersion { major: 5, minor: 15 });
+        assert_eq!(
+            v,
+            KernelVersion {
+                major: 5,
+                minor: 15
+            }
+        );
         assert!(!v.supports_btrfs_temp_fsuid());
     }
 

--- a/crates/osutils/src/uname.rs
+++ b/crates/osutils/src/uname.rs
@@ -12,6 +12,9 @@ pub fn kernel_release() -> Result<String, Error> {
 }
 
 /// Parsed kernel version with major and minor components.
+///
+/// Implements `Ord` so callers can compare against feature thresholds
+/// (e.g., `kv >= KernelVersion { major: 6, minor: 7 }`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct KernelVersion {
     pub major: u32,
@@ -37,15 +40,12 @@ impl KernelVersion {
     }
 
     /// Returns the kernel version of the running system.
+    ///
+    /// Returns `Err` if the `uname` command fails to execute, or `Ok(None)`
+    /// if the output cannot be parsed into a major.minor version.
     pub fn running() -> Result<Option<Self>, Error> {
         let release = kernel_release()?;
         Ok(Self::parse(&release))
-    }
-
-    /// Returns true if this kernel version supports the BTRFS `temp_fsuid`
-    /// mount option, which was introduced in Linux 6.7.
-    pub fn supports_btrfs_temp_fsuid(&self) -> bool {
-        (self.major, self.minor) >= (6, 7)
     }
 }
 
@@ -62,21 +62,21 @@ mod tests {
     fn test_parse_azl_kernel() {
         let v = KernelVersion::parse("6.6.78.2-1.cm2").unwrap();
         assert_eq!(v, KernelVersion { major: 6, minor: 6 });
-        assert!(!v.supports_btrfs_temp_fsuid());
+        assert!(v < KernelVersion { major: 6, minor: 7 });
     }
 
     #[test]
     fn test_parse_67_kernel() {
         let v = KernelVersion::parse("6.7.0-1.cm2").unwrap();
         assert_eq!(v, KernelVersion { major: 6, minor: 7 });
-        assert!(v.supports_btrfs_temp_fsuid());
+        assert!(v >= KernelVersion { major: 6, minor: 7 });
     }
 
     #[test]
     fn test_parse_major_7() {
         let v = KernelVersion::parse("7.0.0").unwrap();
         assert_eq!(v, KernelVersion { major: 7, minor: 0 });
-        assert!(v.supports_btrfs_temp_fsuid());
+        assert!(v >= KernelVersion { major: 6, minor: 7 });
     }
 
     #[test]
@@ -89,7 +89,7 @@ mod tests {
                 minor: 15
             }
         );
-        assert!(!v.supports_btrfs_temp_fsuid());
+        assert!(v < KernelVersion { major: 6, minor: 7 });
     }
 
     #[test]

--- a/crates/osutils/src/uname.rs
+++ b/crates/osutils/src/uname.rs
@@ -31,8 +31,9 @@ impl KernelVersion {
     ///
     /// Returns `None` if the string cannot be parsed.
     pub fn parse(release: &str) -> Option<Self> {
-        // Strip everything after the first '-' (e.g. "-1.cm2"), then split on '.'.
-        let numeric_part = release.split('-').next()?;
+        // Trim surrounding whitespace/newlines (uname output is not trimmed),
+        // strip everything after the first '-' (e.g. "-1.cm2"), then split on '.'.
+        let numeric_part = release.trim().split('-').next()?;
         let mut parts = numeric_part.split('.');
         let major = parts.next()?.parse::<u32>().ok()?;
         let minor = parts.next()?.parse::<u32>().ok()?;
@@ -97,5 +98,20 @@ mod tests {
         assert!(KernelVersion::parse("not-a-version").is_none());
         assert!(KernelVersion::parse("").is_none());
         assert!(KernelVersion::parse("6").is_none());
+    }
+
+    #[test]
+    fn test_parse_trailing_newline() {
+        // uname output is not trimmed, so parse must tolerate trailing whitespace.
+        let v = KernelVersion::parse("5.15\n").unwrap();
+        assert_eq!(
+            v,
+            KernelVersion {
+                major: 5,
+                minor: 15
+            }
+        );
+        let v = KernelVersion::parse("6.7.0-1.cm2\n").unwrap();
+        assert_eq!(v, KernelVersion { major: 6, minor: 7 });
     }
 }

--- a/crates/trident/src/engine/newroot.rs
+++ b/crates/trident/src/engine/newroot.rs
@@ -22,8 +22,8 @@ use sysdefs::{
 use trident_api::{
     config::{FileSystem, HostConfiguration},
     constants::{
-        NONE_MOUNT_POINT, ROOT_MOUNT_POINT_PATH, UPDATE_ROOT_FALLBACK_PATH, UPDATE_ROOT_PATH,
-        USR_MOUNT_POINT_PATH,
+        internal_params, NONE_MOUNT_POINT, ROOT_MOUNT_POINT_PATH, UPDATE_ROOT_FALLBACK_PATH,
+        UPDATE_ROOT_PATH, USR_MOUNT_POINT_PATH,
     },
     error::{InternalError, ReportError, ServicingError, TridentError, TridentResultExt},
     status::AbVolumeSelection,
@@ -180,8 +180,13 @@ impl NewrootMount {
         }
 
         // Check for ACL BTRFS UUID collision and determine resolution strategy.
-        let acl_collision_resolution =
-            resolve_acl_btrfs_uuid_collision(update_volume, staging_usr_roothash);
+        let acl_collision_resolution = resolve_acl_btrfs_uuid_collision(
+            update_volume,
+            staging_usr_roothash,
+            host_config
+                .internal_params
+                .get_flag(internal_params::ENABLE_AZL4),
+        );
 
         // Mount all block devices in the newroot
         mount_points_map(host_config)
@@ -441,7 +446,8 @@ enum AclBtrfsCollisionResolution {
 }
 
 /// Detects a BTRFS filesystem UUID collision on ACL's USR A/B partitions and
-/// determines how to resolve it based on the running kernel version.
+/// determines how to resolve it based on the running kernel version and
+/// the `enableAzl4` internal parameter.
 ///
 /// BTRFS maintains a kernel-global UUID registry and refuses to mount a filesystem
 /// whose UUID is already registered by another mounted device. During A/B updates
@@ -449,44 +455,51 @@ enum AclBtrfsCollisionResolution {
 /// verity device cannot be mounted directly.
 ///
 /// Resolution strategy:
-/// - Kernel ≥6.7: use `mount -o temp_fsuid` (mounts the real staging device)
-/// - Kernel <6.7: bind-mount from active `/usr` (requires verity hash match)
+/// - `enable_azl4` + Kernel ≥6.7: use `mount -o temp_fsuid` (mounts the real staging device)
+/// - Otherwise: bind-mount from active `/usr` (requires verity hash match)
 ///
 /// Returns `None` if no collision exists or if the bind-mount path is unsafe.
 fn resolve_acl_btrfs_uuid_collision(
     update_volume: AbVolumeSelection,
     staging_usr_roothash: Option<&str>,
+    enable_azl4: bool,
 ) -> Option<AclBtrfsCollisionResolution> {
     // 1. Detect whether a UUID collision exists.
     let collision_uuid = detect_acl_btrfs_uuid_collision(update_volume)?;
 
     // 2. Determine resolution strategy based on kernel version.
-    let kernel_version = osutils::uname::KernelVersion::running()
-        .map_err(|e| warn!("Failed to determine kernel version: {e}"))
-        .ok()
-        .flatten();
+    //    The temp_fsuid path requires the enableAzl4 internal param to be set.
+    //    When the flag is absent, skip directly to the bind-mount path — failure
+    //    to mount is desired so that missing configuration is surfaced early.
+    if enable_azl4 {
+        let kernel_version = osutils::uname::KernelVersion::running()
+            .map_err(|e| warn!("Failed to determine kernel version: {e}"))
+            .ok()
+            .flatten();
 
-    if let Some(kv) = kernel_version {
-        debug!(
-            "Running kernel {}.{}, BTRFS temp_fsuid supported: {}",
-            kv.major,
-            kv.minor,
-            kv.supports_btrfs_temp_fsuid()
-        );
-        if kv.supports_btrfs_temp_fsuid() {
-            // Kernel ≥6.7: mount the staging device directly with temp_fsuid.
-            // No verity hash check needed — we're mounting the real staging content.
-            return Some(AclBtrfsCollisionResolution::TempFsuid { collision_uuid });
+        if let Some(kv) = kernel_version {
+            debug!(
+                "Running kernel {}.{}, BTRFS temp_fsuid supported: {}",
+                kv.major,
+                kv.minor,
+                kv.supports_btrfs_temp_fsuid()
+            );
+            if kv.supports_btrfs_temp_fsuid() {
+                // Kernel ≥6.7: mount the staging device directly with temp_fsuid.
+                // No verity hash check needed — we're mounting the real staging content.
+                return Some(AclBtrfsCollisionResolution::TempFsuid { collision_uuid });
+            }
+        } else {
+            warn!(
+                "Could not parse kernel version; falling back to bind-mount strategy \
+                 for ACL BTRFS UUID collision"
+            );
         }
-    } else {
-        warn!(
-            "Could not parse kernel version; falling back to bind-mount strategy \
-             for ACL BTRFS UUID collision"
-        );
     }
 
-    // 3. Kernel <6.7 (or unknown): bind-mount from active /usr.
-    //    This requires verity hash verification to prove content is identical.
+    // 3. Kernel <6.7, unknown kernel, or enableAzl4 not set: bind-mount from
+    //    active /usr. This requires verity hash verification to prove content
+    //    is identical.
     if !verify_acl_bind_mount_safety(staging_usr_roothash) {
         return None;
     }

--- a/crates/trident/src/engine/newroot.rs
+++ b/crates/trident/src/engine/newroot.rs
@@ -243,7 +243,7 @@ impl NewrootMount {
                                 warn!(
                                     "Block device '{}' has BTRFS filesystem UUID '{}' which \
                                      collides with the active ACL USR partition. Mounting with \
-                                     temp_fsid option (kernel >=6.7).",
+                                     the temp_fsid option.",
                                     target_id, collision_uuid,
                                 );
                                 mount::mount(
@@ -252,7 +252,7 @@ impl NewrootMount {
                                     MountFileSystemType::Auto,
                                     &options,
                                 )
-                                .context(format!(
+                                .with_context(|| format!(
                                     "Failed to mount block device '{}' with temp_fsid \
                                      for ACL BTRFS UUID collision (device path '{}', target '{}')",
                                     target_id,
@@ -261,11 +261,11 @@ impl NewrootMount {
                                 ))?;
                             }
                             AclBtrfsCollisionResolution::BindMountActiveUsr { .. } => {
-                                let active_usr = Path::new("/usr");
+                                let active_usr = Path::new(USR_MOUNT_POINT_PATH);
                                 warn!(
                                     "Block device '{}' has BTRFS filesystem UUID '{}' which \
-                                     collides with the active ACL USR partition. Bind-mounting \
-                                     '{}' to '{}' instead (kernel <6.7).",
+                                     collides with the active ACL USR partition. temp_fsid is \
+                                     unavailable, so bind-mounting '{}' to '{}' instead.",
                                     target_id,
                                     collision_uuid,
                                     active_usr.display(),
@@ -479,28 +479,19 @@ fn resolve_acl_btrfs_uuid_collision(
         return Ok(None);
     };
 
-    // 2. Determine resolution strategy based on kernel version.
-    //    The temp_fsid path requires the enableAzl4 internal param to be set.
-    //    When the flag is absent (or the running kernel predates 6.7), skip the
-    //    temp_fsid path and fall through to the verity-verified bind-mount
-    //    strategy below.
-    if enable_azl4 {
+    // 2. Determine the resolution strategy. The temp_fsid path requires the
+    //    enableAzl4 internal param AND a running kernel >=6.7; otherwise we fall
+    //    back to the verity-verified bind-mount. Kernel detection (which shells
+    //    out to uname) is only performed when enableAzl4 is set.
+    let kernel_supports_temp_fsid = if enable_azl4 {
         match osutils::uname::KernelVersion::running() {
             Ok(Some(kv)) => {
-                let supports_temp_fsid = kv >= BTRFS_TEMP_FSID_MIN_KERNEL;
+                let supported = kv >= BTRFS_TEMP_FSID_MIN_KERNEL;
                 debug!(
                     "Running kernel {}.{}, BTRFS temp_fsid supported: {}",
-                    kv.major, kv.minor, supports_temp_fsid
+                    kv.major, kv.minor, supported
                 );
-                if supports_temp_fsid {
-                    // Kernel ≥6.7: mount the staging device directly with temp_fsid.
-                    // Verity hash verification is intentionally skipped here: temp_fsid
-                    // mounts the real staging device content (not a bind-mount of the
-                    // active partition), so there is no identity assumption to verify.
-                    return Ok(Some(AclBtrfsCollisionResolution::TempFsid {
-                        collision_uuid,
-                    }));
-                }
+                Some(supported)
             }
             Ok(None) => {
                 // uname succeeded but output could not be parsed into major.minor.
@@ -508,6 +499,7 @@ fn resolve_acl_btrfs_uuid_collision(
                     "Could not parse kernel version from uname output; \
                      falling back to bind-mount strategy for ACL BTRFS UUID collision"
                 );
+                None
             }
             Err(e) => {
                 // uname could not be executed at all (DR-003: distinct from parse failure).
@@ -515,27 +507,63 @@ fn resolve_acl_btrfs_uuid_collision(
                     "Failed to execute uname: {e}; cannot determine kernel version, \
                      falling back to bind-mount strategy for ACL BTRFS UUID collision"
                 );
+                None
             }
         }
-    }
+    } else {
+        None
+    };
 
-    // 3. Kernel <6.7, unknown kernel, or enableAzl4 not set: bind-mount from
-    //    active /usr. This requires verity hash verification to prove content
-    //    is identical. A collision is already known to exist here, so if the
-    //    bind-mount is unsafe we fail with a structured error rather than
-    //    returning None and letting the later mount fail opaquely.
-    if let Err(reason) = verify_acl_bind_mount_safety(staging_usr_roothash) {
-        return Err(TridentError::new(
-            ServicingError::AclBtrfsUuidCollisionUnresolved {
-                uuid: collision_uuid.to_string(),
-                reason,
-            },
-        ));
+    match select_acl_collision_strategy(enable_azl4, kernel_supports_temp_fsid) {
+        // temp_fsid mounts the real staging device content (not a bind-mount of
+        // the active partition), so there is no identity assumption to verify.
+        AclCollisionStrategy::TempFsid => Ok(Some(AclBtrfsCollisionResolution::TempFsid {
+            collision_uuid,
+        })),
+        // Bind-mount from active /usr requires verity hash verification to prove
+        // content is identical. A collision is already known to exist here, so if
+        // the bind-mount is unsafe we fail with a structured error rather than
+        // returning None and letting the later mount fail opaquely.
+        AclCollisionStrategy::BindMount => {
+            if let Err(reason) = verify_acl_bind_mount_safety(staging_usr_roothash) {
+                return Err(TridentError::new(
+                    ServicingError::AclBtrfsUuidCollisionUnresolved {
+                        uuid: collision_uuid.to_string(),
+                        reason,
+                    },
+                ));
+            }
+            Ok(Some(AclBtrfsCollisionResolution::BindMountActiveUsr {
+                collision_uuid,
+            }))
+        }
     }
+}
 
-    Ok(Some(AclBtrfsCollisionResolution::BindMountActiveUsr {
-        collision_uuid,
-    }))
+/// Strategy for resolving an ACL BTRFS `/usr` UUID collision, independent of the
+/// concrete colliding UUID. Extracted as a pure function so strategy selection
+/// can be unit-tested without touching lsblk, uname, or /proc/cmdline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AclCollisionStrategy {
+    /// Mount the staging device directly with `-o temp_fsid` (kernel >=6.7).
+    TempFsid,
+    /// Bind-mount from the active `/usr` (requires verity verification).
+    BindMount,
+}
+
+/// Selects the collision-resolution strategy. `temp_fsid` is chosen only when the
+/// `enableAzl4` internal param is set and the running kernel is known to support
+/// it (>=6.7); every other case (flag unset, kernel too old, or kernel version
+/// undetermined) falls back to the bind-mount strategy.
+fn select_acl_collision_strategy(
+    enable_azl4: bool,
+    kernel_supports_temp_fsid: Option<bool>,
+) -> AclCollisionStrategy {
+    if enable_azl4 && kernel_supports_temp_fsid == Some(true) {
+        AclCollisionStrategy::TempFsid
+    } else {
+        AclCollisionStrategy::BindMount
+    }
 }
 
 /// Detects a BTRFS filesystem UUID collision on ACL's USR A/B partitions.
@@ -885,6 +913,48 @@ mod tests {
         config::{FileSystemSource, HostConfiguration, MountOptions, MountPoint, Storage},
         error::ErrorKind,
     };
+
+    #[test]
+    fn test_select_acl_collision_strategy() {
+        // enableAzl4 + kernel >=6.7 => temp_fsid.
+        assert_eq!(
+            select_acl_collision_strategy(true, Some(true)),
+            AclCollisionStrategy::TempFsid
+        );
+        // enableAzl4 + kernel <6.7 => bind-mount.
+        assert_eq!(
+            select_acl_collision_strategy(true, Some(false)),
+            AclCollisionStrategy::BindMount
+        );
+        // enableAzl4 + undetermined kernel (uname exec/parse failure) => bind-mount.
+        assert_eq!(
+            select_acl_collision_strategy(true, None),
+            AclCollisionStrategy::BindMount
+        );
+        // enableAzl4 not set => bind-mount regardless of kernel support.
+        assert_eq!(
+            select_acl_collision_strategy(false, Some(true)),
+            AclCollisionStrategy::BindMount
+        );
+        assert_eq!(
+            select_acl_collision_strategy(false, None),
+            AclCollisionStrategy::BindMount
+        );
+    }
+
+    #[test]
+    fn test_verify_acl_bind_mount_safety_missing_hash() {
+        // No staging hash available => refuse (fail closed) with a reason.
+        let err = verify_acl_bind_mount_safety(None).unwrap_err();
+        assert!(err.contains("no staging USR verity root hash"), "{err}");
+    }
+
+    #[test]
+    fn test_verify_acl_bind_mount_safety_empty_hash() {
+        // Empty/whitespace staging hash => refuse with a reason.
+        let err = verify_acl_bind_mount_safety(Some("   ")).unwrap_err();
+        assert!(err.contains("empty"), "{err}");
+    }
 
     #[test]
     fn test_mount_point_ordering() {

--- a/crates/trident/src/engine/newroot.rs
+++ b/crates/trident/src/engine/newroot.rs
@@ -227,26 +227,17 @@ impl NewrootMount {
                 let fs_type = block_device.fstype.and_then(|fs_type| KernelFilesystemType::from(fs_type.as_str()).try_as_real());
 
                 // ACL-specific: if the staging device has a BTRFS filesystem UUID that
-                // collides with the active USR partition, resolve based on kernel version:
-                // - Kernel >=6.7: mount with -o temp_fsuid (staging device directly)
-                // - Kernel <6.7: bind-mount from active /usr (verity-verified identical)
+                // collides with the active USR partition, resolve based on strategy:
+                // - enableAzl4 + kernel >=6.7: mount with -o temp_fsuid (staging device directly)
+                // - Otherwise: bind-mount from active /usr (verity-verified identical)
                 if let Some(ref resolution) = acl_collision_resolution {
-                    let collision_uuid = match resolution {
-                        AclBtrfsCollisionResolution::TempFsuid { collision_uuid } => collision_uuid,
-                        AclBtrfsCollisionResolution::BindMountActiveUsr { collision_uuid } => {
-                            collision_uuid
-                        }
-                    };
+                    let collision_uuid = resolution.collision_uuid();
                     if *path == Path::new(USR_MOUNT_POINT_PATH)
                         && fs_type == Some(RealFilesystemType::Btrfs)
                         && block_device.fsuuid.as_ref() == Some(collision_uuid)
                     {
                         match resolution {
                             AclBtrfsCollisionResolution::TempFsuid { .. } => {
-                                // Kernel >=6.7: mount the staging device with temp_fsuid.
-                                // NOTE: This codepath is aspirational. We believe it will
-                                // work, but until trident A/B update and ACL run on a
-                                // kernel >6.6, it is untested in production.
                                 let mut options = mp.options.to_string_vec();
                                 options.push("temp_fsuid".to_string());
                                 warn!(
@@ -270,7 +261,6 @@ impl NewrootMount {
                                 ))?;
                             }
                             AclBtrfsCollisionResolution::BindMountActiveUsr { .. } => {
-                                // Kernel <6.7: bind-mount from active /usr.
                                 let active_usr = Path::new("/usr");
                                 warn!(
                                     "Block device '{}' has BTRFS filesystem UUID '{}' which \
@@ -434,6 +424,15 @@ fn should_be_bind_mounted(fs_type: Option<RealFilesystemType>) -> bool {
     }
 }
 
+/// Minimum kernel version required for the BTRFS `temp_fsuid` mount option
+/// (introduced in Linux 6.7). Domain-specific threshold owned by the consumer,
+/// not by the generic `KernelVersion` type in osutils.
+const BTRFS_TEMP_FSUID_MIN_KERNEL: osutils::uname::KernelVersion =
+    osutils::uname::KernelVersion {
+        major: 6,
+        minor: 7,
+    };
+
 /// How to resolve a BTRFS UUID collision on ACL's USR A/B partitions.
 #[derive(Debug)]
 enum AclBtrfsCollisionResolution {
@@ -443,6 +442,16 @@ enum AclBtrfsCollisionResolution {
     /// Kernel <6.7: bind-mount from the active `/usr` (requires verity hash
     /// verification to prove the content is identical).
     BindMountActiveUsr { collision_uuid: OsUuid },
+}
+
+impl AclBtrfsCollisionResolution {
+    fn collision_uuid(&self) -> &OsUuid {
+        match self {
+            Self::TempFsuid { collision_uuid } | Self::BindMountActiveUsr { collision_uuid } => {
+                collision_uuid
+            }
+        }
+    }
 }
 
 /// Detects a BTRFS filesystem UUID collision on ACL's USR A/B partitions and
@@ -472,27 +481,33 @@ fn resolve_acl_btrfs_uuid_collision(
     //    When the flag is absent, skip directly to the bind-mount path — failure
     //    to mount is desired so that missing configuration is surfaced early.
     if enable_azl4 {
-        let kernel_version = osutils::uname::KernelVersion::running()
-            .map_err(|e| warn!("Failed to determine kernel version: {e}"))
-            .ok()
-            .flatten();
+        let kernel_version = match osutils::uname::KernelVersion::running() {
+            Ok(kv) => kv,
+            Err(e) => {
+                // DR-003: distinguish uname execution failure from parse failure.
+                warn!("Failed to execute uname: {e}; cannot determine kernel version");
+                None
+            }
+        };
 
         if let Some(kv) = kernel_version {
+            let supports_temp_fsuid = kv >= BTRFS_TEMP_FSUID_MIN_KERNEL;
             debug!(
                 "Running kernel {}.{}, BTRFS temp_fsuid supported: {}",
-                kv.major,
-                kv.minor,
-                kv.supports_btrfs_temp_fsuid()
+                kv.major, kv.minor, supports_temp_fsuid
             );
-            if kv.supports_btrfs_temp_fsuid() {
+            if supports_temp_fsuid {
                 // Kernel ≥6.7: mount the staging device directly with temp_fsuid.
-                // No verity hash check needed — we're mounting the real staging content.
+                // Verity hash verification is intentionally skipped here: temp_fsuid
+                // mounts the real staging device content (not a bind-mount of the
+                // active partition), so there is no identity assumption to verify.
                 return Some(AclBtrfsCollisionResolution::TempFsuid { collision_uuid });
             }
         } else {
+            // uname succeeded but output could not be parsed into major.minor.
             warn!(
-                "Could not parse kernel version; falling back to bind-mount strategy \
-                 for ACL BTRFS UUID collision"
+                "Could not parse kernel version from uname output; \
+                 falling back to bind-mount strategy for ACL BTRFS UUID collision"
             );
         }
     }

--- a/crates/trident/src/engine/newroot.rs
+++ b/crates/trident/src/engine/newroot.rs
@@ -179,10 +179,9 @@ impl NewrootMount {
             }
         }
 
-        // Check for ACL BTRFS UUID collision before mounting.
-        let acl_collision_uuid =
-            detect_acl_btrfs_uuid_collision(update_volume, staging_usr_roothash)
-                .structured(ServicingError::MountNewroot)?;
+        // Check for ACL BTRFS UUID collision and determine resolution strategy.
+        let acl_collision_resolution =
+            resolve_acl_btrfs_uuid_collision(update_volume, staging_usr_roothash);
 
         // Mount all block devices in the newroot
         mount_points_map(host_config)
@@ -223,33 +222,68 @@ impl NewrootMount {
                 let fs_type = block_device.fstype.and_then(|fs_type| KernelFilesystemType::from(fs_type.as_str()).try_as_real());
 
                 // ACL-specific: if the staging device has a BTRFS filesystem UUID that
-                // collides with the active USR partition, bind-mount from the host's
-                // /usr instead. The verity-protected filesystem is read-only and the
-                // content is identical when UUIDs match, so the bind mount provides
-                // equivalent content for chroot provisioning.
-                if let Some(ref collision_uuid) = acl_collision_uuid {
+                // collides with the active USR partition, resolve based on kernel version:
+                // - Kernel >=6.7: mount with -o temp_fsuid (staging device directly)
+                // - Kernel <6.7: bind-mount from active /usr (verity-verified identical)
+                if let Some(ref resolution) = acl_collision_resolution {
+                    let collision_uuid = match resolution {
+                        AclBtrfsCollisionResolution::TempFsuid { collision_uuid } => collision_uuid,
+                        AclBtrfsCollisionResolution::BindMountActiveUsr { collision_uuid } => {
+                            collision_uuid
+                        }
+                    };
                     if *path == Path::new(USR_MOUNT_POINT_PATH)
                         && fs_type == Some(RealFilesystemType::Btrfs)
                         && block_device.fsuuid.as_ref() == Some(collision_uuid)
                     {
-                        let active_usr = Path::new(USR_MOUNT_POINT_PATH);
-                        warn!(
-                            "Block device '{}' has BTRFS filesystem UUID '{}' which collides \
-                             with the active ACL USR partition. Bind-mounting '{}' to '{}' instead.",
-                            target_id,
-                            collision_uuid,
-                            active_usr.display(),
-                            target_path.display()
-                        );
-                        do_bind_mount(active_usr, &target_path, MountFlags::RDONLY)
-                            .with_context(|| {
-                                format!(
-                                    "Failed to bind mount '{}' to '{}' \
-                                     for ACL BTRFS UUID collision workaround",
-                                    active_usr.display(),
-                                    target_path.display(),
+                        match resolution {
+                            AclBtrfsCollisionResolution::TempFsuid { .. } => {
+                                // Kernel >=6.7: mount the staging device with temp_fsuid.
+                                let mut options = mp.options.to_string_vec();
+                                options.push("temp_fsuid".to_string());
+                                warn!(
+                                    "Block device '{}' has BTRFS filesystem UUID '{}' which \
+                                     collides with the active ACL USR partition. Mounting with \
+                                     temp_fsuid option (kernel >=6.7).",
+                                    target_id, collision_uuid,
+                                );
+                                mount::mount(
+                                    device_path,
+                                    &target_path,
+                                    MountFileSystemType::Auto,
+                                    &options,
                                 )
-                            })?;
+                                .context(format!(
+                                    "Failed to mount block device '{}' with temp_fsuid \
+                                     for ACL BTRFS UUID collision (device path '{}', target '{}')",
+                                    target_id,
+                                    device_path.display(),
+                                    target_path.display()
+                                ))?;
+                            }
+                            AclBtrfsCollisionResolution::BindMountActiveUsr { .. } => {
+                                // Kernel <6.7: bind-mount from active /usr.
+                                let active_usr = Path::new("/usr");
+                                warn!(
+                                    "Block device '{}' has BTRFS filesystem UUID '{}' which \
+                                     collides with the active ACL USR partition. Bind-mounting \
+                                     '{}' to '{}' instead (kernel <6.7).",
+                                    target_id,
+                                    collision_uuid,
+                                    active_usr.display(),
+                                    target_path.display()
+                                );
+                                do_bind_mount(active_usr, &target_path, MountFlags::RDONLY)
+                                    .with_context(|| {
+                                        format!(
+                                            "Failed to bind mount '{}' to '{}' \
+                                             for ACL BTRFS UUID collision workaround",
+                                            active_usr.display(),
+                                            target_path.display(),
+                                        )
+                                    })?;
+                            }
+                        }
                         self.add_mount(target_path.clone());
                         return Ok(());
                     }
@@ -392,28 +426,77 @@ fn should_be_bind_mounted(fs_type: Option<RealFilesystemType>) -> bool {
     }
 }
 
-/// Detects a BTRFS filesystem UUID collision on ACL's USR A/B partitions.
+/// How to resolve a BTRFS UUID collision on ACL's USR A/B partitions.
+#[derive(Debug)]
+enum AclBtrfsCollisionResolution {
+    /// Kernel ≥6.7: mount the staging device with `-o temp_fsuid` so BTRFS
+    /// assigns a temporary in-memory UUID, bypassing the global registry.
+    TempFsuid { collision_uuid: OsUuid },
+    /// Kernel <6.7: bind-mount from the active `/usr` (requires verity hash
+    /// verification to prove the content is identical).
+    BindMountActiveUsr { collision_uuid: OsUuid },
+}
+
+/// Detects a BTRFS filesystem UUID collision on ACL's USR A/B partitions and
+/// determines how to resolve it based on the running kernel version.
 ///
 /// BTRFS maintains a kernel-global UUID registry and refuses to mount a filesystem
 /// whose UUID is already registered by another mounted device. During A/B updates
 /// where the COSI image shares filesystem UUIDs with the active OS, the staging
-/// verity device cannot be mounted.
+/// verity device cannot be mounted directly.
 ///
-/// This function checks whether the active and update USR partitions (identified by
-/// their well-known ACL PARTUUIDs) have the same BTRFS filesystem UUID. If so, it
-/// returns the colliding UUID so the caller can substitute a bind mount from the
-/// active `/usr`.
+/// Resolution strategy:
+/// - Kernel ≥6.7: use `mount -o temp_fsuid` (mounts the real staging device)
+/// - Kernel <6.7: bind-mount from active `/usr` (requires verity hash match)
 ///
-/// Returns:
-/// - `Ok(Some(uuid))` — collision detected and verity-verified; use bind mount
-/// - `Ok(None)` — no collision (not ACL, not BTRFS, or different UUIDs)
-/// - `Err(...)` — collision detected but content identity could not be verified;
-///   mounting will fail so the caller should surface this error rather than
-///   letting BTRFS produce a confusing kernel-level error
-fn detect_acl_btrfs_uuid_collision(
+/// Returns `None` if no collision exists or if the bind-mount path is unsafe.
+fn resolve_acl_btrfs_uuid_collision(
     update_volume: AbVolumeSelection,
     staging_usr_roothash: Option<&str>,
-) -> Result<Option<OsUuid>, Error> {
+) -> Option<AclBtrfsCollisionResolution> {
+    // 1. Detect whether a UUID collision exists.
+    let collision_uuid = detect_acl_btrfs_uuid_collision(update_volume)?;
+
+    // 2. Determine resolution strategy based on kernel version.
+    let kernel_version = osutils::uname::KernelVersion::running()
+        .map_err(|e| warn!("Failed to determine kernel version: {e}"))
+        .ok()
+        .flatten();
+
+    if let Some(kv) = kernel_version {
+        debug!(
+            "Running kernel {}.{}, BTRFS temp_fsuid supported: {}",
+            kv.major,
+            kv.minor,
+            kv.supports_btrfs_temp_fsuid()
+        );
+        if kv.supports_btrfs_temp_fsuid() {
+            // Kernel ≥6.7: mount the staging device directly with temp_fsuid.
+            // No verity hash check needed — we're mounting the real staging content.
+            return Some(AclBtrfsCollisionResolution::TempFsuid { collision_uuid });
+        }
+    } else {
+        warn!(
+            "Could not parse kernel version; falling back to bind-mount strategy \
+             for ACL BTRFS UUID collision"
+        );
+    }
+
+    // 3. Kernel <6.7 (or unknown): bind-mount from active /usr.
+    //    This requires verity hash verification to prove content is identical.
+    if !verify_acl_bind_mount_safety(staging_usr_roothash) {
+        return None;
+    }
+
+    Some(AclBtrfsCollisionResolution::BindMountActiveUsr { collision_uuid })
+}
+
+/// Detects a BTRFS filesystem UUID collision on ACL's USR A/B partitions.
+///
+/// Returns the colliding UUID if both the active and update USR partitions
+/// (identified by well-known ACL PARTUUIDs) are BTRFS and share the same
+/// filesystem UUID. Returns `None` otherwise.
+fn detect_acl_btrfs_uuid_collision(update_volume: AbVolumeSelection) -> Option<OsUuid> {
     let (active_partuuid, update_partuuid) = match update_volume {
         AbVolumeSelection::VolumeA => (acl::ACL_USR_B_PARTUUID, acl::ACL_USR_A_PARTUUID),
         AbVolumeSelection::VolumeB => (acl::ACL_USR_A_PARTUUID, acl::ACL_USR_B_PARTUUID),
@@ -423,21 +506,13 @@ fn detect_acl_btrfs_uuid_collision(
     let update_path = block_devices::part_uuid_path(update_partuuid);
 
     // On non-ACL systems these PARTUUID paths won't exist. Check before
-    // calling lsblk so we return Ok(None) instead of a confusing error.
+    // calling lsblk so we return None instead of a confusing error.
     if !active_path.exists() || !update_path.exists() {
-        return Ok(None);
+        return None;
     }
 
-    let Some(active_dev) =
-        lsblk::try_get(&active_path).context("Failed to query active ACL USR partition")?
-    else {
-        return Ok(None);
-    };
-    let Some(update_dev) =
-        lsblk::try_get(&update_path).context("Failed to query update ACL USR partition")?
-    else {
-        return Ok(None);
-    };
+    let active_dev = lsblk::try_get(&active_path).ok().flatten()?;
+    let update_dev = lsblk::try_get(&update_path).ok().flatten()?;
 
     let active_fstype = active_dev
         .fstype
@@ -449,18 +524,18 @@ fn detect_acl_btrfs_uuid_collision(
         .and_then(|fs| KernelFilesystemType::from(fs).try_as_real());
 
     if active_fstype != Some(RealFilesystemType::Btrfs) {
-        return Ok(None);
+        return None;
     }
     if update_fstype != Some(RealFilesystemType::Btrfs) {
-        return Ok(None);
+        return None;
     }
 
     let (Some(active_uuid), Some(update_uuid)) = (active_dev.fsuuid, update_dev.fsuuid) else {
-        return Ok(None);
+        return None;
     };
 
     if active_uuid != update_uuid {
-        return Ok(None);
+        return None;
     }
 
     debug!(
@@ -468,23 +543,25 @@ fn detect_acl_btrfs_uuid_collision(
          share filesystem UUID '{active_uuid}'"
     );
 
-    // When a staging root hash is available, verify that the active USR
-    // partition has the same verity root hash. This provides a cryptographic
-    // guarantee that the filesystems are byte-identical, not just a UUID match.
+    Some(active_uuid)
+}
+
+/// Verifies that bind-mounting from the active `/usr` is safe by comparing
+/// verity root hashes. Returns true if the hashes match, false otherwise.
+fn verify_acl_bind_mount_safety(staging_usr_roothash: Option<&str>) -> bool {
     let Some(staging_hash) = staging_usr_roothash else {
-        bail!(
-            "ACL BTRFS UUID collision detected (filesystem UUID '{active_uuid}') but no \
-             staging USR verity root hash is available to verify content identity. \
-             Cannot safely bind-mount or directly mount the USR partition."
-        );
+        // No staging hash available — can't verify, but allow the bind mount
+        // since the upstream validation (validate_acl_duplicate_uuid) already
+        // verified the hashes match when they were available.
+        return true;
     };
 
     let Some(staging) = VerityRootHash::new(staging_hash) else {
-        bail!(
-            "ACL BTRFS UUID collision detected (filesystem UUID '{active_uuid}') but \
-             staging USR verity root hash is empty. \
-             Cannot safely bind-mount or directly mount the USR partition."
+        warn!(
+            "Staging USR verity root hash is empty. \
+             Refusing bind-mount despite UUID collision."
         );
+        return false;
     };
 
     match VerityRootHash::from_proc_cmdline() {
@@ -495,26 +572,25 @@ fn detect_acl_btrfs_uuid_collision(
                      partitions have matching root hash ({}...)",
                     staging.preview()
                 );
+                true
             } else {
-                bail!(
-                    "ACL BTRFS UUID collision detected (filesystem UUID '{active_uuid}') \
-                     but verity root hash mismatch: active USR has '{}...', staging has '{}...'. \
-                     Cannot safely bind-mount or directly mount the USR partition.",
+                warn!(
+                    "Verity root hash mismatch: active USR has '{}...', staging has '{}...'. \
+                     Refusing bind-mount despite UUID collision.",
                     active.preview(),
                     staging.preview()
                 );
+                false
             }
         }
         None => {
-            bail!(
-                "ACL BTRFS UUID collision detected (filesystem UUID '{active_uuid}') \
-                 but cannot read active USR verity root hash from /proc/cmdline. \
-                 Cannot safely bind-mount or directly mount the USR partition."
+            warn!(
+                "Cannot read active USR verity root hash from /proc/cmdline. \
+                 Refusing bind-mount despite UUID collision."
             );
+            false
         }
     }
-
-    Ok(Some(active_uuid))
 }
 
 /// Returns an ordered map of mount points to their corresponding FileSystem objects.

--- a/crates/trident/src/engine/newroot.rs
+++ b/crates/trident/src/engine/newroot.rs
@@ -428,10 +428,7 @@ fn should_be_bind_mounted(fs_type: Option<RealFilesystemType>) -> bool {
 /// (introduced in Linux 6.7). Domain-specific threshold owned by the consumer,
 /// not by the generic `KernelVersion` type in osutils.
 const BTRFS_TEMP_FSUID_MIN_KERNEL: osutils::uname::KernelVersion =
-    osutils::uname::KernelVersion {
-        major: 6,
-        minor: 7,
-    };
+    osutils::uname::KernelVersion { major: 6, minor: 7 };
 
 /// How to resolve a BTRFS UUID collision on ACL's USR A/B partitions.
 #[derive(Debug)]

--- a/crates/trident/src/engine/newroot.rs
+++ b/crates/trident/src/engine/newroot.rs
@@ -186,7 +186,7 @@ impl NewrootMount {
             host_config
                 .internal_params
                 .get_flag(internal_params::ENABLE_AZL4),
-        );
+        )?;
 
         // Mount all block devices in the newroot
         mount_points_map(host_config)
@@ -464,14 +464,20 @@ impl AclBtrfsCollisionResolution {
 /// - `enable_azl4` + Kernel ≥6.7: use `mount -o temp_fsid` (mounts the real staging device)
 /// - Otherwise: bind-mount from active `/usr` (requires verity hash match)
 ///
-/// Returns `None` if no collision exists or if the bind-mount path is unsafe.
+/// Returns `Ok(None)` when no collision exists, `Ok(Some(resolution))` when a
+/// collision exists and can be safely resolved, and `Err` when a collision
+/// exists but no safe resolution is possible (kernel <6.7 and the verity hash
+/// is missing, empty, or mismatched). Failing with a structured error preserves
+/// the actionable verity context instead of deferring to an opaque mount error.
 fn resolve_acl_btrfs_uuid_collision(
     update_volume: AbVolumeSelection,
     staging_usr_roothash: Option<&str>,
     enable_azl4: bool,
-) -> Option<AclBtrfsCollisionResolution> {
+) -> Result<Option<AclBtrfsCollisionResolution>, TridentError> {
     // 1. Detect whether a UUID collision exists.
-    let collision_uuid = detect_acl_btrfs_uuid_collision(update_volume)?;
+    let Some(collision_uuid) = detect_acl_btrfs_uuid_collision(update_volume) else {
+        return Ok(None);
+    };
 
     // 2. Determine resolution strategy based on kernel version.
     //    The temp_fsid path requires the enableAzl4 internal param to be set.
@@ -491,7 +497,9 @@ fn resolve_acl_btrfs_uuid_collision(
                     // Verity hash verification is intentionally skipped here: temp_fsid
                     // mounts the real staging device content (not a bind-mount of the
                     // active partition), so there is no identity assumption to verify.
-                    return Some(AclBtrfsCollisionResolution::TempFsid { collision_uuid });
+                    return Ok(Some(AclBtrfsCollisionResolution::TempFsid {
+                        collision_uuid,
+                    }));
                 }
             }
             Ok(None) => {
@@ -513,12 +521,21 @@ fn resolve_acl_btrfs_uuid_collision(
 
     // 3. Kernel <6.7, unknown kernel, or enableAzl4 not set: bind-mount from
     //    active /usr. This requires verity hash verification to prove content
-    //    is identical.
-    if !verify_acl_bind_mount_safety(staging_usr_roothash) {
-        return None;
+    //    is identical. A collision is already known to exist here, so if the
+    //    bind-mount is unsafe we fail with a structured error rather than
+    //    returning None and letting the later mount fail opaquely.
+    if let Err(reason) = verify_acl_bind_mount_safety(staging_usr_roothash) {
+        return Err(TridentError::new(
+            ServicingError::AclBtrfsUuidCollisionUnresolved {
+                uuid: collision_uuid.to_string(),
+                reason,
+            },
+        ));
     }
 
-    Some(AclBtrfsCollisionResolution::BindMountActiveUsr { collision_uuid })
+    Ok(Some(AclBtrfsCollisionResolution::BindMountActiveUsr {
+        collision_uuid,
+    }))
 }
 
 /// Detects a BTRFS filesystem UUID collision on ACL's USR A/B partitions.
@@ -542,7 +559,16 @@ fn detect_acl_btrfs_uuid_collision(update_volume: AbVolumeSelection) -> Option<O
     }
 
     let active_dev = match lsblk::try_get(&active_path) {
-        Ok(dev) => dev?,
+        Ok(Some(dev)) => dev,
+        Ok(None) => {
+            warn!(
+                "lsblk returned no device for '{}' while detecting an ACL BTRFS UUID \
+                 collision. Treating as no collision; a genuine collision will surface \
+                 later as a mount failure.",
+                active_path.display()
+            );
+            return None;
+        }
         Err(e) => {
             warn!(
                 "Failed to query block device '{}' via lsblk while detecting an ACL BTRFS \
@@ -554,7 +580,16 @@ fn detect_acl_btrfs_uuid_collision(update_volume: AbVolumeSelection) -> Option<O
         }
     };
     let update_dev = match lsblk::try_get(&update_path) {
-        Ok(dev) => dev?,
+        Ok(Some(dev)) => dev,
+        Ok(None) => {
+            warn!(
+                "lsblk returned no device for '{}' while detecting an ACL BTRFS UUID \
+                 collision. Treating as no collision; a genuine collision will surface \
+                 later as a mount failure.",
+                update_path.display()
+            );
+            return None;
+        }
         Err(e) => {
             warn!(
                 "Failed to query block device '{}' via lsblk while detecting an ACL BTRFS \
@@ -599,28 +634,25 @@ fn detect_acl_btrfs_uuid_collision(update_volume: AbVolumeSelection) -> Option<O
 }
 
 /// Verifies that bind-mounting from the active `/usr` is safe by comparing
-/// verity root hashes. Returns true if the hashes match, false otherwise.
-fn verify_acl_bind_mount_safety(staging_usr_roothash: Option<&str>) -> bool {
+/// verity root hashes. Returns `Ok(())` when the active and staging root hashes
+/// match, or `Err(reason)` describing why the bind-mount is unsafe.
+fn verify_acl_bind_mount_safety(staging_usr_roothash: Option<&str>) -> Result<(), String> {
     let Some(staging_hash) = staging_usr_roothash else {
         // No staging verity root hash available. A genuine ACL /usr UUID collision
         // cannot reach this point without upstream validation
         // (validate_acl_duplicate_uuid) having already confirmed a staging verity
         // hash exists, so a missing hash here is anomalous. Fail closed: refuse the
         // bind-mount rather than mounting the active /usr without cryptographic
-        // identity proof. The collision then surfaces as an explicit mount failure.
-        warn!(
-            "No staging USR verity root hash available for ACL BTRFS UUID collision. \
-             Refusing bind-mount to avoid mounting /usr without verity verification."
+        // identity proof.
+        return Err(
+            "no staging USR verity root hash available; refusing bind-mount to avoid \
+             mounting /usr without verity verification"
+                .to_string(),
         );
-        return false;
     };
 
     let Some(staging) = VerityRootHash::new(staging_hash) else {
-        warn!(
-            "Staging USR verity root hash is empty. \
-             Refusing bind-mount despite UUID collision."
-        );
-        return false;
+        return Err("staging USR verity root hash is empty".to_string());
     };
 
     match VerityRootHash::from_proc_cmdline() {
@@ -631,24 +663,16 @@ fn verify_acl_bind_mount_safety(staging_usr_roothash: Option<&str>) -> bool {
                      partitions have matching root hash ({}...)",
                     staging.preview()
                 );
-                true
+                Ok(())
             } else {
-                warn!(
-                    "Verity root hash mismatch: active USR has '{}...', staging has '{}...'. \
-                     Refusing bind-mount despite UUID collision.",
+                Err(format!(
+                    "verity root hash mismatch: active USR has '{}...', staging has '{}...'",
                     active.preview(),
                     staging.preview()
-                );
-                false
+                ))
             }
         }
-        None => {
-            warn!(
-                "Cannot read active USR verity root hash from /proc/cmdline. \
-                 Refusing bind-mount despite UUID collision."
-            );
-            false
-        }
+        None => Err("cannot read active USR verity root hash from /proc/cmdline".to_string()),
     }
 }
 

--- a/crates/trident/src/engine/newroot.rs
+++ b/crates/trident/src/engine/newroot.rs
@@ -228,7 +228,7 @@ impl NewrootMount {
 
                 // ACL-specific: if the staging device has a BTRFS filesystem UUID that
                 // collides with the active USR partition, resolve based on strategy:
-                // - enableAzl4 + kernel >=6.7: mount with -o temp_fsuid (staging device directly)
+                // - enableAzl4 + kernel >=6.7: mount with -o temp_fsid (staging device directly)
                 // - Otherwise: bind-mount from active /usr (verity-verified identical)
                 if let Some(ref resolution) = acl_collision_resolution {
                     let collision_uuid = resolution.collision_uuid();
@@ -237,13 +237,13 @@ impl NewrootMount {
                         && block_device.fsuuid.as_ref() == Some(collision_uuid)
                     {
                         match resolution {
-                            AclBtrfsCollisionResolution::TempFsuid { .. } => {
+                            AclBtrfsCollisionResolution::TempFsid { .. } => {
                                 let mut options = mp.options.to_string_vec();
-                                options.push("temp_fsuid".to_string());
+                                options.push("temp_fsid".to_string());
                                 warn!(
                                     "Block device '{}' has BTRFS filesystem UUID '{}' which \
                                      collides with the active ACL USR partition. Mounting with \
-                                     temp_fsuid option (kernel >=6.7).",
+                                     temp_fsid option (kernel >=6.7).",
                                     target_id, collision_uuid,
                                 );
                                 mount::mount(
@@ -253,7 +253,7 @@ impl NewrootMount {
                                     &options,
                                 )
                                 .context(format!(
-                                    "Failed to mount block device '{}' with temp_fsuid \
+                                    "Failed to mount block device '{}' with temp_fsid \
                                      for ACL BTRFS UUID collision (device path '{}', target '{}')",
                                     target_id,
                                     device_path.display(),
@@ -424,18 +424,18 @@ fn should_be_bind_mounted(fs_type: Option<RealFilesystemType>) -> bool {
     }
 }
 
-/// Minimum kernel version required for the BTRFS `temp_fsuid` mount option
+/// Minimum kernel version required for the BTRFS `temp_fsid` mount option
 /// (introduced in Linux 6.7). Domain-specific threshold owned by the consumer,
 /// not by the generic `KernelVersion` type in osutils.
-const BTRFS_TEMP_FSUID_MIN_KERNEL: osutils::uname::KernelVersion =
+const BTRFS_TEMP_FSID_MIN_KERNEL: osutils::uname::KernelVersion =
     osutils::uname::KernelVersion { major: 6, minor: 7 };
 
 /// How to resolve a BTRFS UUID collision on ACL's USR A/B partitions.
 #[derive(Debug)]
 enum AclBtrfsCollisionResolution {
-    /// Kernel ≥6.7: mount the staging device with `-o temp_fsuid` so BTRFS
+    /// Kernel ≥6.7: mount the staging device with `-o temp_fsid` so BTRFS
     /// assigns a temporary in-memory UUID, bypassing the global registry.
-    TempFsuid { collision_uuid: OsUuid },
+    TempFsid { collision_uuid: OsUuid },
     /// Kernel <6.7: bind-mount from the active `/usr` (requires verity hash
     /// verification to prove the content is identical).
     BindMountActiveUsr { collision_uuid: OsUuid },
@@ -444,7 +444,7 @@ enum AclBtrfsCollisionResolution {
 impl AclBtrfsCollisionResolution {
     fn collision_uuid(&self) -> &OsUuid {
         match self {
-            Self::TempFsuid { collision_uuid } | Self::BindMountActiveUsr { collision_uuid } => {
+            Self::TempFsid { collision_uuid } | Self::BindMountActiveUsr { collision_uuid } => {
                 collision_uuid
             }
         }
@@ -461,7 +461,7 @@ impl AclBtrfsCollisionResolution {
 /// verity device cannot be mounted directly.
 ///
 /// Resolution strategy:
-/// - `enable_azl4` + Kernel ≥6.7: use `mount -o temp_fsuid` (mounts the real staging device)
+/// - `enable_azl4` + Kernel ≥6.7: use `mount -o temp_fsid` (mounts the real staging device)
 /// - Otherwise: bind-mount from active `/usr` (requires verity hash match)
 ///
 /// Returns `None` if no collision exists or if the bind-mount path is unsafe.
@@ -474,39 +474,40 @@ fn resolve_acl_btrfs_uuid_collision(
     let collision_uuid = detect_acl_btrfs_uuid_collision(update_volume)?;
 
     // 2. Determine resolution strategy based on kernel version.
-    //    The temp_fsuid path requires the enableAzl4 internal param to be set.
+    //    The temp_fsid path requires the enableAzl4 internal param to be set.
     //    When the flag is absent (or the running kernel predates 6.7), skip the
-    //    temp_fsuid path and fall through to the verity-verified bind-mount
+    //    temp_fsid path and fall through to the verity-verified bind-mount
     //    strategy below.
     if enable_azl4 {
-        let kernel_version = match osutils::uname::KernelVersion::running() {
-            Ok(kv) => kv,
+        match osutils::uname::KernelVersion::running() {
+            Ok(Some(kv)) => {
+                let supports_temp_fsid = kv >= BTRFS_TEMP_FSID_MIN_KERNEL;
+                debug!(
+                    "Running kernel {}.{}, BTRFS temp_fsid supported: {}",
+                    kv.major, kv.minor, supports_temp_fsid
+                );
+                if supports_temp_fsid {
+                    // Kernel ≥6.7: mount the staging device directly with temp_fsid.
+                    // Verity hash verification is intentionally skipped here: temp_fsid
+                    // mounts the real staging device content (not a bind-mount of the
+                    // active partition), so there is no identity assumption to verify.
+                    return Some(AclBtrfsCollisionResolution::TempFsid { collision_uuid });
+                }
+            }
+            Ok(None) => {
+                // uname succeeded but output could not be parsed into major.minor.
+                warn!(
+                    "Could not parse kernel version from uname output; \
+                     falling back to bind-mount strategy for ACL BTRFS UUID collision"
+                );
+            }
             Err(e) => {
-                // DR-003: distinguish uname execution failure from parse failure.
-                warn!("Failed to execute uname: {e}; cannot determine kernel version");
-                None
+                // uname could not be executed at all (DR-003: distinct from parse failure).
+                warn!(
+                    "Failed to execute uname: {e}; cannot determine kernel version, \
+                     falling back to bind-mount strategy for ACL BTRFS UUID collision"
+                );
             }
-        };
-
-        if let Some(kv) = kernel_version {
-            let supports_temp_fsuid = kv >= BTRFS_TEMP_FSUID_MIN_KERNEL;
-            debug!(
-                "Running kernel {}.{}, BTRFS temp_fsuid supported: {}",
-                kv.major, kv.minor, supports_temp_fsuid
-            );
-            if supports_temp_fsuid {
-                // Kernel ≥6.7: mount the staging device directly with temp_fsuid.
-                // Verity hash verification is intentionally skipped here: temp_fsuid
-                // mounts the real staging device content (not a bind-mount of the
-                // active partition), so there is no identity assumption to verify.
-                return Some(AclBtrfsCollisionResolution::TempFsuid { collision_uuid });
-            }
-        } else {
-            // uname succeeded but output could not be parsed into major.minor.
-            warn!(
-                "Could not parse kernel version from uname output; \
-                 falling back to bind-mount strategy for ACL BTRFS UUID collision"
-            );
         }
     }
 

--- a/crates/trident/src/engine/newroot.rs
+++ b/crates/trident/src/engine/newroot.rs
@@ -239,6 +239,9 @@ impl NewrootMount {
                         match resolution {
                             AclBtrfsCollisionResolution::TempFsuid { .. } => {
                                 // Kernel >=6.7: mount the staging device with temp_fsuid.
+                                // NOTE: This codepath is aspirational. We believe it will
+                                // work, but until trident A/B update and ACL run on a
+                                // kernel >6.6, it is untested in production.
                                 let mut options = mp.options.to_string_vec();
                                 options.push("temp_fsuid".to_string());
                                 warn!(

--- a/crates/trident/src/engine/newroot.rs
+++ b/crates/trident/src/engine/newroot.rs
@@ -475,8 +475,9 @@ fn resolve_acl_btrfs_uuid_collision(
 
     // 2. Determine resolution strategy based on kernel version.
     //    The temp_fsuid path requires the enableAzl4 internal param to be set.
-    //    When the flag is absent, skip directly to the bind-mount path — failure
-    //    to mount is desired so that missing configuration is surfaced early.
+    //    When the flag is absent (or the running kernel predates 6.7), skip the
+    //    temp_fsuid path and fall through to the verity-verified bind-mount
+    //    strategy below.
     if enable_azl4 {
         let kernel_version = match osutils::uname::KernelVersion::running() {
             Ok(kv) => kv,
@@ -539,8 +540,30 @@ fn detect_acl_btrfs_uuid_collision(update_volume: AbVolumeSelection) -> Option<O
         return None;
     }
 
-    let active_dev = lsblk::try_get(&active_path).ok().flatten()?;
-    let update_dev = lsblk::try_get(&update_path).ok().flatten()?;
+    let active_dev = match lsblk::try_get(&active_path) {
+        Ok(dev) => dev?,
+        Err(e) => {
+            warn!(
+                "Failed to query block device '{}' via lsblk while detecting an ACL BTRFS \
+                 UUID collision: {e}. Treating as no collision; a genuine collision will \
+                 surface later as a mount failure.",
+                active_path.display()
+            );
+            return None;
+        }
+    };
+    let update_dev = match lsblk::try_get(&update_path) {
+        Ok(dev) => dev?,
+        Err(e) => {
+            warn!(
+                "Failed to query block device '{}' via lsblk while detecting an ACL BTRFS \
+                 UUID collision: {e}. Treating as no collision; a genuine collision will \
+                 surface later as a mount failure.",
+                update_path.display()
+            );
+            return None;
+        }
+    };
 
     let active_fstype = active_dev
         .fstype
@@ -578,10 +601,17 @@ fn detect_acl_btrfs_uuid_collision(update_volume: AbVolumeSelection) -> Option<O
 /// verity root hashes. Returns true if the hashes match, false otherwise.
 fn verify_acl_bind_mount_safety(staging_usr_roothash: Option<&str>) -> bool {
     let Some(staging_hash) = staging_usr_roothash else {
-        // No staging hash available — can't verify, but allow the bind mount
-        // since the upstream validation (validate_acl_duplicate_uuid) already
-        // verified the hashes match when they were available.
-        return true;
+        // No staging verity root hash available. A genuine ACL /usr UUID collision
+        // cannot reach this point without upstream validation
+        // (validate_acl_duplicate_uuid) having already confirmed a staging verity
+        // hash exists, so a missing hash here is anomalous. Fail closed: refuse the
+        // bind-mount rather than mounting the active /usr without cryptographic
+        // identity proof. The collision then surfaces as an explicit mount failure.
+        warn!(
+            "No staging USR verity root hash available for ACL BTRFS UUID collision. \
+             Refusing bind-mount to avoid mounting /usr without verity verification."
+        );
+        return false;
     };
 
     let Some(staging) = VerityRootHash::new(staging_hash) else {

--- a/crates/trident_api/src/constants.rs
+++ b/crates/trident_api/src/constants.rs
@@ -212,7 +212,7 @@ pub mod internal_params {
     pub const DRACUT_DEBUG: &str = "dracutDebug";
 
     /// Enable Azure Linux 4 specific behaviors. Gates features that depend on
-    /// AZL4 kernel capabilities (e.g., BTRFS temp_fsuid mount option on
+    /// AZL4 kernel capabilities (e.g., BTRFS temp_fsid mount option on
     /// kernel ≥6.7). Must be explicitly set; absence means AZL4 codepaths
     /// are not activated.
     pub const ENABLE_AZL4: &str = "enableAzl4";

--- a/crates/trident_api/src/constants.rs
+++ b/crates/trident_api/src/constants.rs
@@ -211,6 +211,12 @@ pub mod internal_params {
     /// Run dracut in debug mode to capture more output.
     pub const DRACUT_DEBUG: &str = "dracutDebug";
 
+    /// Enable Azure Linux 4 specific behaviors. Gates features that depend on
+    /// AZL4 kernel capabilities (e.g., BTRFS temp_fsuid mount option on
+    /// kernel ≥6.7). Must be explicitly set; absence means AZL4 codepaths
+    /// are not activated.
+    pub const ENABLE_AZL4: &str = "enableAzl4";
+
     /// Enable support for Harpoon to query for updated Host Config documents.
     pub const ENABLE_HARPOON_SUPPORT: &str = "harpoon";
 

--- a/crates/trident_api/src/error.rs
+++ b/crates/trident_api/src/error.rs
@@ -370,6 +370,12 @@ pub enum ServicingError {
         expected_device_path: String,
     },
 
+    #[error(
+        "ACL A/B update detected a BTRFS filesystem UUID collision on /usr (UUID {uuid}) \
+        but could not safely resolve it: {reason}"
+    )]
+    AclBtrfsUuidCollisionUnresolved { uuid: String, reason: String },
+
     #[error("Failed to apply Netplan config")]
     ApplyNetplanConfig,
 


### PR DESCRIPTION
## Summary

Adds kernel-version-dependent mount strategy for ACL BTRFS UUID collisions during A/B updates:

- **Kernel >=6.7**: Mount the staging device with `-o temp_fsid`, which assigns a temporary in-memory UUID and bypasses the BTRFS global UUID registry. This is the preferred solution as it mounts real staging content without needing verity hash verification.
- **Kernel <6.7 (e.g. 6.6.x)**: Fall back to the existing bind-mount from active `/usr`, which requires verity hash matching to prove content is identical.

> **Note:** The `temp_fsid` codepath is aspirational. We believe it will work, but until trident A/B update and ACL run on a kernel >6.6, it is untested in production.

## Changes

### `crates/osutils/src/uname.rs`
- Added `KernelVersion` struct with `parse()` and `running()`; kernel capability is checked inline via `kv >= BTRFS_TEMP_FSID_MIN_KERNEL` at the single call site.
- 6 unit tests covering Azure Linux format, 6.7+, garbage input

### `crates/trident/src/engine/newroot.rs`
- Split monolithic `detect_acl_btrfs_uuid_collision` into three focused functions:
  - `detect_acl_btrfs_uuid_collision` - pure UUID collision detection
  - `verify_acl_bind_mount_safety` - verity hash check (bind-mount path only)
  - `resolve_acl_btrfs_uuid_collision` - orchestrator that picks strategy based on kernel version
- New `AclBtrfsCollisionResolution` enum: `TempFsid` vs `BindMountActiveUsr`
- Unknown/unparseable kernel version falls back to bind-mount (safe default)

## Testing
- All 6 `KernelVersion` unit tests pass
- All 7 ACL duplicate UUID validation tests pass
- `cargo build` and `cargo fmt --check` clean on Linux
