### PR TITLE
tests: [workaround] containerd 2.2 SELinux mmap denial for container images

### DIFF
--- a/tests/images/trident-container-installer/base/baseimg.yaml
+++ b/tests/images/trident-container-installer/base/baseimg.yaml
@@ -40,6 +40,7 @@ os:
       - mdadm
       - moby-engine
       - openssh-server
+      - selinux-policy
       - squashfs-tools
       - tar
       - vim
@@ -53,6 +54,8 @@ os:
       destination: /root/.profile
     - source: files/trident-container.service
       destination: /usr/lib/systemd/system/trident-container.service
+    - source: files/containerd-mmap-fix.cil
+      destination: /usr/share/selinux/packages/containerd-mmap-fix.cil
 
   services:
     enable:
@@ -62,6 +65,7 @@ os:
 scripts:
   postCustomization:
     - path: scripts/post-install.sh
+    - path: scripts/load-containerd-selinux-fix.sh
 
 iso:
   additionalFiles:
@@ -71,7 +75,6 @@ iso:
       destination: /trident-override.conf
   kernelCommandLine:
     extraCommandLine:
-      - enforcing=0
       - console=tty0
       - console=ttyS0
       - rd.luks=0

--- a/tests/images/trident-container-installer/base/baseimg.yaml
+++ b/tests/images/trident-container-installer/base/baseimg.yaml
@@ -75,6 +75,7 @@ iso:
       destination: /trident-override.conf
   kernelCommandLine:
     extraCommandLine:
+      - enforcing=0
       - console=tty0
       - console=ttyS0
       - rd.luks=0

--- a/tests/images/trident-container-installer/base/files/containerd-mmap-fix.cil
+++ b/tests/images/trident-container-installer/base/files/containerd-mmap-fix.cil
@@ -1,0 +1,7 @@
+; Fix for containerd 2.2+ MountManager plugin SELinux denial.
+; containerd 2.2 introduces a MountManager that opens a bbolt DB under
+; /run/containerd/ using mmap(). The base refpolicy (RELEASE_2_20240226)
+; grants manage_file_perms on container_runtime_t:file but that set does
+; not include 'map'. Upstream fixed this in commit 7876e51510 (May 2024).
+; This module backports the missing permission.
+(allow container_engine_system_domain container_runtime_t (file (map)))

--- a/tests/images/trident-container-installer/base/scripts/load-containerd-selinux-fix.sh
+++ b/tests/images/trident-container-installer/base/scripts/load-containerd-selinux-fix.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Load SELinux policy module that grants the 'map' permission on
+# container_runtime_t:file for container engines.  This fixes containerd
+# 2.2+ MountManager bbolt mmap() denials under enforcing mode.
+semodule -i /usr/share/selinux/packages/containerd-mmap-fix.cil

--- a/tests/images/trident-container-testimage/base/baseimg.yaml
+++ b/tests/images/trident-container-testimage/base/baseimg.yaml
@@ -66,12 +66,15 @@ os:
 
       - docker-cli
       - moby-engine
+      - selinux-policy
       - squashfs-tools
       - tar
 
   additionalFiles:
   - source: files/trident-container.service
     destination: /usr/lib/systemd/system/trident-container.service
+  - source: files/containerd-mmap-fix.cil
+    destination: /usr/share/selinux/packages/containerd-mmap-fix.cil
 
   services:
     enable:
@@ -81,3 +84,4 @@ os:
 scripts:
   postCustomization:
   - path: scripts/post-install.sh
+  - path: scripts/load-containerd-selinux-fix.sh

--- a/tests/images/trident-container-testimage/base/files/containerd-mmap-fix.cil
+++ b/tests/images/trident-container-testimage/base/files/containerd-mmap-fix.cil
@@ -1,0 +1,7 @@
+; Fix for containerd 2.2+ MountManager plugin SELinux denial.
+; containerd 2.2 introduces a MountManager that opens a bbolt DB under
+; /run/containerd/ using mmap(). The base refpolicy (RELEASE_2_20240226)
+; grants manage_file_perms on container_runtime_t:file but that set does
+; not include 'map'. Upstream fixed this in commit 7876e51510 (May 2024).
+; This module backports the missing permission.
+(allow container_engine_system_domain container_runtime_t (file (map)))

--- a/tests/images/trident-container-testimage/base/files/trident-container.service
+++ b/tests/images/trident-container-testimage/base/files/trident-container.service
@@ -6,8 +6,6 @@ After=network.target network-online.target systemd-udev-settle.service docker.se
 [Service]
 Type=oneshot
 ExecStartPre=/bin/bash -c "set -e; if ! docker image ls | grep -q 'trident/trident'; then docker load --input /var/lib/trident/trident-container.tar.gz; fi"
-# TODO: Remove line to enable SELinux, when bug #9508 is fixed.
-ExecStartPre=/bin/bash -c "sudo setenforce 0" 
 ExecStart=docker run --name trident_container --pull=never --rm --privileged -v /etc/trident:/etc/trident -v /var/lib/trident:/var/lib/trident -v /var/log:/var/log -v /:/host -v /dev:/dev -v /run:/run -v /sys:/sys --pid host --ipc host trident/trident:latest commit --verbosity DEBUG
 StandardOutput=journal+console
 StandardError=journal+console

--- a/tests/images/trident-container-testimage/base/files/trident-container.service
+++ b/tests/images/trident-container-testimage/base/files/trident-container.service
@@ -6,6 +6,8 @@ After=network.target network-online.target systemd-udev-settle.service docker.se
 [Service]
 Type=oneshot
 ExecStartPre=/bin/bash -c "set -e; if ! docker image ls | grep -q 'trident/trident'; then docker load --input /var/lib/trident/trident-container.tar.gz; fi"
+# TODO: Remove line to enable SELinux, when bug #9508 is fixed.
+ExecStartPre=/bin/bash -c "sudo setenforce 0" 
 ExecStart=docker run --name trident_container --pull=never --rm --privileged -v /etc/trident:/etc/trident -v /var/lib/trident:/var/lib/trident -v /var/log:/var/log -v /:/host -v /dev:/dev -v /run:/run -v /sys:/sys --pid host --ipc host trident/trident:latest commit --verbosity DEBUG
 StandardOutput=journal+console
 StandardError=journal+console

--- a/tests/images/trident-container-testimage/base/scripts/load-containerd-selinux-fix.sh
+++ b/tests/images/trident-container-testimage/base/scripts/load-containerd-selinux-fix.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Load SELinux policy module that grants the 'map' permission on
+# container_runtime_t:file for container engines.  This fixes containerd
+# 2.2+ MountManager bbolt mmap() denials under enforcing mode.
+semodule -i /usr/share/selinux/packages/containerd-mmap-fix.cil


### PR DESCRIPTION
## Summary

containerd 2.2+ introduces a MountManager plugin that `mmap()`s a bbolt DB under `/run/containerd/`. The AZL 3.0 SELinux policy (refpolicy `RELEASE_2_20240226`) grants `manage_file_perms` on `container_runtime_t:file` which does **not** include the `map` permission, causing a cascade failure that surfaces as:

\\\
docker: Error response from daemon: failed to create task for container:
unknown service containerd.services.tasks.v1.Tasks: not implemented
\\\

Upstream refpolicy fixed this in commit [\7876e51510\](https://github.com/SELinuxProject/refpolicy/commit/7876e51510) (May 2024), but AZL's pinned version predates it.

## Validation

https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1134778

## AZL bug

https://microsoft.visualstudio.com/OS/_workitems/edit/62602180

## Changes

- Add a CIL policy module (`containerd-mmap-fix.cil`) that grants the missing `map` permission on `container_runtime_t:file` for `container_engine_system_domain`
- Add `selinux-policy` package to both container images
- Load the CIL module during image build via a `postCustomization` script
- Applied to both `trident-container-installer` and `trident-container-testimage`

> **Note:** Existing workarounds (`enforcing=0` kernel param on installer, `setenforce 0` in testimage service) are intentionally kept in place. They should be removed in a follow-up PR after this fix is validated.

## Related

- Upstream fix: https://github.com/SELinuxProject/refpolicy/commit/7876e51510
- Pipeline bugs: #20870, #20884, #20879, #20905
