### PR TITLE
bug: version-pin all intra-package RPM dependencies

### DIFF
--- a/packaging/rpm/trident.spec
+++ b/packaging/rpm/trident.spec
@@ -56,7 +56,7 @@ Requires:       openssl
 Requires:       shadow-utils
 Requires:       systemd >= 255
 Requires:       systemd-udev
-Requires:       (%{name}-selinux if selinux-policy-%{selinuxtype})
+Requires:       (%{name}-selinux = %{version}-%{release} if selinux-policy-%{selinuxtype})
 
 # Optional dependencies for various optional features
 
@@ -100,7 +100,7 @@ and its dependencies for managing the lifecycle of Azure Linux hosts.
 
 %package provisioning
 Summary:        Trident files for the provisioning OS
-Requires:       %{name}
+Requires:       %{name} = %{version}-%{release}
 
 %description provisioning
 Trident files for the provisioning OS
@@ -121,7 +121,7 @@ Trident files for the provisioning OS
 
 %package service
 Summary:        Trident files for SystemD update and commit services
-Requires:       %{name}
+Requires:       %{name} = %{version}-%{release}
 Conflicts:      %{name}-install-service
 
 %description service
@@ -143,7 +143,7 @@ Trident files for SystemD commit services
 
 %package install-service
 Summary:        Trident files for SystemD install service
-Requires:       %{name}
+Requires:       %{name} = %{version}-%{release}
 Conflicts:      %{name}-service
 
 %description install-service
@@ -199,7 +199,7 @@ fi
 
 %package static-pcrlock-files
 Summary:        Statically defined .pcrlock files
-Requires:       %{name}
+Requires:       %{name} = %{version}-%{release}
 
 %description static-pcrlock-files
 Statically defined .pcrlock files for PCR-based encryption. This is a workaround needed because AZL
@@ -213,7 +213,7 @@ be removed once the fix is merged in AZL 4.0.
 
 %package acl-agent
 Summary:        Trident ACL Agent
-Requires:       %{name}
+Requires:       %{name} = %{version}-%{release}
 
 %description acl-agent
 The Trident ACL Agent triggers updates of ACL images.


### PR DESCRIPTION
## Problem

Trident pipelines install `trident-service` from a local dev RPM repo alongside the public Azure Linux repo. All trident subpackages used unversioned `Requires: %{name}`, allowing tdnf to satisfy dependencies from any repo. Combined with a createrepo_c issue where noarch RPMs (trident-selinux) are not indexed in the local repo, this caused version skew:

- `trident-service` 0.24.0 (dev, local) ✅
- `trident` 0.22.0 (released, public) ❌
- `trident-selinux` 0.22.0 (released, public) ❌

When PR #659 added `atomic_write_file()` using 
`ename()` syscall for modprobe configs, the dev SELinux policy (0.24.0) was updated with the necessary `ename` permission on `modules_conf_t`. But the released policy (0.22.0) lacks this permission, causing:

```
Atomic rename failed for '/etc/modprobe.d/modules-disabled.conf': Permission denied (os error 13)
```

## Fix

Pin all intra-package `Requires` to exact `%{version}-%{release}`:

- `trident-service`, `install-service`, `provisioning`, `static-pcrlock-files`, `acl-agent`: `Requires: %{name} = %{version}-%{release}`
- `trident` (main): `Requires: (%{name}-selinux = %{version}-%{release} if selinux-policy-targeted)`

This forces tdnf to find the exact matching version — which only exists in the local dev repo — preventing silent version skew.

## Verification

- **Run [1136368](https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1136368)**: All trident packages resolve from local repo (0.24.0), both \Testing misc\ clones pass ✅
- **Run [1136303](https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1136303)** (old spec, no version-pin): trident and trident-selinux resolve from public repo (0.22.0)

## Impact on distro builds

For Azure Linux distro builds (`rpm_ver` undefined), all packages come from the same SRPM build, so version-release always matches. The pinning is a no-op for distro builds but critical for dev/CI scenarios.

Fixes Bug [#21696](https://dev.azure.com/mariner-org/polar/_workitems/edit/21696)