### PR TITLE
packaging: build acl-agent package only for repo builds

### DIFF
--- a/packaging/rpm/trident.spec
+++ b/packaging/rpm/trident.spec
@@ -211,6 +211,7 @@ be removed once the fix is merged in AZL 4.0.
 
 # ------------------------------------------------------------------------------
 
+%if %{defined rpm_ver}
 %package acl-agent
 Summary:        Trident ACL Agent
 Requires:       %{name}
@@ -220,6 +221,7 @@ The Trident ACL Agent triggers updates of ACL images.
 
 %files acl-agent
 %{_bindir}/%{name}-acl-agent
+%endif
 
 # ------------------------------------------------------------------------------
 
@@ -251,7 +253,11 @@ export TRIDENT_VERSION="%{version}-%{release}"
 # Use %{trident_version} for Trident repo build
 export TRIDENT_VERSION="%{trident_version}"
 %endif
+%if %{defined rpm_ver}
 cargo build --release -p trident -p trident-acl-agent
+%else
+cargo build --release -p trident
+%endif
 
 mkdir selinux
 cp -p packaging/selinux-policy-trident/trident.fc selinux/
@@ -281,7 +287,9 @@ cargo test --all --no-fail-fast -- --skip test_run_systemd_check --skip test_pre
 
 %install
 install -D -m 755 target/release/%{name} %{buildroot}/%{_bindir}/%{name}
+%if %{defined rpm_ver}
 install -D -m 755 target/release/%{name}-acl-agent %{buildroot}/%{_bindir}/%{name}-acl-agent
+%endif
 
 # Copy Trident SELinux policy module to /usr/share/selinux/packages
 install -D -m 0644 %{name}.pp.bz2 %{buildroot}%{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2


### PR DESCRIPTION
The `trident-acl-agent` binary and RPM sub-package are not ready for azurelinux distro builds. This change gates three spots in `trident.spec` behind `%{defined rpm_ver}`:

1. **Package definition** — the `%package acl-agent`, `%description`, and `%files` sections
2. **Cargo build** — only includes `-p trident-acl-agent` for repo builds
3. **Binary install** — only installs `trident-acl-agent` to `%{_bindir}` for repo builds

Distro builds (`rpm_ver` undefined) will no longer build or package the acl-agent.