### PR TITLE
engineering: enable azl4 RPM builds (DISTRO-parameterized Docker/Makefile/pipelines)

### DIFF
--- a/.pipelines/templates/stages/build_docker_image/trident-container.yml
+++ b/.pipelines/templates/stages/build_docker_image/trident-container.yml
@@ -3,6 +3,13 @@ parameters:
     type: string
     default: ""
 
+  - name: distro
+    type: string
+    default: "azl3"
+    values:
+      - azl3
+      - azl4
+
 stages:
   - stage: BuildTridentContainerImage
     displayName: Build Docker Image
@@ -37,8 +44,17 @@ stages:
             inputs:
               buildType: current
               artifactName: "trident-binaries"
-              patterns: "**/*.rpm"
+              patterns: "**/*${{ parameters.distro }}*.rpm"
               targetPath: "$(TRIDENT_SOURCE_DIR)/bin/RPMS/x86_64"
+
+          - script: |
+              set -eux
+              # azl4 RPMs are published under an azl4/ subdirectory in the artifact;
+              # flatten any nested RPMs so Dockerfile.runtime's bin/RPMS/x86_64 glob finds them.
+              find bin/RPMS/x86_64 -mindepth 2 -name '*.rpm' -type f -exec mv -t bin/RPMS/x86_64 {} +
+              find bin/RPMS/x86_64 -name '*.rpm' -type f
+            displayName: Flatten nested RPMs
+            workingDirectory: $(TRIDENT_SOURCE_DIR)
 
           - template: ../common_tasks/preview-container.yml
             parameters:
@@ -48,8 +64,18 @@ stages:
           - script: |
               set -euxo pipefail
 
+              AZL_IMAGE="$(DISTRO=${{ parameters.distro }} make azl-version-vars | grep AZL_IMAGE | cut -d '=' -f2)"
+              RPM_PACKAGES="$(DISTRO=${{ parameters.distro }} make azl-version-vars | grep RPM_PACKAGES | cut -d '=' -f2)"
+
               mkdir -p $(ob_outputDirectory)
-              DOCKER_BUILDKIT=1 docker build -f packaging/docker/Dockerfile.runtime --progress plain -t trident/trident:latest .
+              DOCKER_BUILDKIT=1 docker build -f \
+                  packaging/docker/Dockerfile.runtime \
+                  --progress plain \
+                  -t trident/trident:latest \
+                  . \
+                  --build-arg AZL_IMAGE="$AZL_IMAGE" \
+                  --build-arg RPM_PACKAGES="$RPM_PACKAGES"
+
               docker save trident/trident:latest | gzip > $(ob_outputDirectory)/trident-container.tar.gz
             workingDirectory: $(TRIDENT_SOURCE_DIR)
             displayName: Build Docker image

--- a/.pipelines/templates/stages/build_image/build-image-template.yml
+++ b/.pipelines/templates/stages/build_image/build-image-template.yml
@@ -139,10 +139,15 @@ steps:
         rm $(Build.ArtifactStagingDirectory)/rpms/rpms.tar.gz
       fi
 
+      DISTRO=azl3
+      if [[ "${{ parameters.azureLinuxVersion }}" == "4.0-preview" ]]; then
+        DISTRO=azl4
+      fi
+
       # Move Trident RPMs to bin/RPMS/ (builder expects bin/RPMS/*.rpm)
       if [ -d "$(Build.ArtifactStagingDirectory)/trident" ]; then
         mkdir -p bin/RPMS
-        find "$(Build.ArtifactStagingDirectory)/trident" -name '*.rpm' -exec mv {} bin/RPMS/ \;
+        find "$(Build.ArtifactStagingDirectory)/trident" -name "*${DISTRO}*.rpm" -exec mv {} bin/RPMS/ \;
         rm -rf "$(Build.ArtifactStagingDirectory)/trident"
       fi
     displayName: "Prepare and move requirements"

--- a/.pipelines/templates/stages/common_tasks/download-universal-artifact.yml
+++ b/.pipelines/templates/stages/common_tasks/download-universal-artifact.yml
@@ -76,14 +76,16 @@ steps:
   - ${{ if startswith(parameters.packageName, 'rpms') }}:
       - script: |
           set -eux
-          # For amd64, get ride of *.aarch64.rpm
+
+          # For amd64, get rid of *.aarch64.rpm
           OTHER_ARCH_SUFFIX="aarch64.rpm"
           if [ "${{ parameters.targetArchitecture }}" = "arm64" ]; then
-            # For arm64, get ride of *.x86_64.rpm
+            # For arm64, get rid of *.x86_64.rpm
             OTHER_ARCH_SUFFIX="x86_64.rpm"
           fi
           # Use find to delete all RPM files that match the other architecture suffix
           find ${{ parameters.downloadLocation }} -name "*.${OTHER_ARCH_SUFFIX}" -type f -delete
+
           # List remaining RPM files to help pipeline debugging
           echo "List remaining RPM files:"
           find ${{ parameters.downloadLocation }} -name "*.rpm" -type f

--- a/.pipelines/templates/stages/download_staged/download-staged.yml
+++ b/.pipelines/templates/stages/download_staged/download-staged.yml
@@ -32,7 +32,7 @@ parameters:
     values:
       - amd64
       - arm64
-
+  
 stages:
   - stage: GetTridentBinaries_${{ replace(parameters.packageName, '-', '_') }}_${{ parameters.targetArchitecture }}
     displayName: Download staged ${{ parameters.packageName }} (${{ parameters.targetArchitecture }}) for ${{ parameters.stageType }}
@@ -86,6 +86,10 @@ stages:
               displayName: Install native dependencies to extract Trident binary
               retryCountOnTaskFailure: 3
 
-            - script: ./scripts/extract-binary.sh $(ob_outputDirectory) $(ob_outputDirectory) ${{ parameters.targetArchitecture }}
+            - script: ./scripts/extract-binary.sh $(ob_outputDirectory) $(ob_outputDirectory) ${{ parameters.targetArchitecture }} azl3
+              displayName: Extract Trident binary
+              workingDirectory: $(TRIDENT_SOURCE_DIR)
+
+            - script: ./scripts/extract-binary.sh $(ob_outputDirectory) $(ob_outputDirectory)/azl4 ${{ parameters.targetArchitecture }} azl4
               displayName: Extract Trident binary
               workingDirectory: $(TRIDENT_SOURCE_DIR)

--- a/.pipelines/templates/stages/trident_images/trident-testimg-template.yml
+++ b/.pipelines/templates/stages/trident_images/trident-testimg-template.yml
@@ -251,12 +251,17 @@ steps:
         rm $(Build.ArtifactStagingDirectory)/rpms/rpms.tar.gz
       fi
 
+      DISTRO=azl3
+      if [[ "${{ parameters.baseimgAzureLinuxVersion }}" == "4.0-preview" ]]; then
+        DISTRO=azl4
+      fi
+
       find $(Build.ArtifactStagingDirectory)
       if [ -d "$(Build.ArtifactStagingDirectory)/trident" ]; then
         rpm_dir='${{ parameters.tridentSourceDirectory }}/bin/RPMS'
         mkdir -p $rpm_dir
-        cp -r $(Build.ArtifactStagingDirectory)/trident/* $rpm_dir/ || echo 'no rpms to copy'
-        rm -rf $(Build.ArtifactStagingDirectory)/trident
+        find "$(Build.ArtifactStagingDirectory)/trident" -name "*${DISTRO}*.rpm" -exec mv {} $rpm_dir/ \;
+        rm -rf "$(Build.ArtifactStagingDirectory)/trident"
       fi
 
     workingDirectory: ${{ parameters.tridentSourceDirectory }}

--- a/.pipelines/templates/stages/trident_rpms/build-source.yml
+++ b/.pipelines/templates/stages/trident_rpms/build-source.yml
@@ -65,7 +65,7 @@ stages:
                   tridentRepoDirectory: $(TRIDENT_SOURCE_DIR)
 
           - job: BuildTrident_${{ parameters.targetArchitecture }}
-            displayName: Build Trident 3.0 ${{ parameters.targetArchitecture }} RPMs
+            displayName: Build Trident AzureLinux ${{ parameters.targetArchitecture }} RPMs
             pool:
               type: linux
 
@@ -94,10 +94,16 @@ stages:
                   targetArchitecture: ${{ parameters.targetArchitecture }}
                   tridentRepoDirectory: $(TRIDENT_SOURCE_DIR)
                   artifactDirectory: "$(ob_outputDirectory)"
+              - template: release.yml
+                parameters:
+                  targetArchitecture: ${{ parameters.targetArchitecture }}
+                  tridentRepoDirectory: $(TRIDENT_SOURCE_DIR)
+                  artifactDirectory: "$(ob_outputDirectory)/azl4"
+                  distro: azl4
 
       - ${{ elseif eq( parameters.targetArchitecture, 'arm64' ) }}:
           - job: BuildTrident_${{ parameters.targetArchitecture }}
-            displayName: Build Trident 3.0 ${{ parameters.targetArchitecture }} RPMs
+            displayName: Build Trident AzureLinux ${{ parameters.targetArchitecture }} RPMs
             pool:
               type: linux
               name: azl3-hci-ARM64-1es-pool-westcentralus
@@ -131,3 +137,9 @@ stages:
                   targetArchitecture: ${{ parameters.targetArchitecture }}
                   tridentRepoDirectory: $(TRIDENT_SOURCE_DIR)
                   artifactDirectory: "$(ob_outputDirectory)"
+              - template: release.yml
+                parameters:
+                  targetArchitecture: ${{ parameters.targetArchitecture }}
+                  tridentRepoDirectory: $(TRIDENT_SOURCE_DIR)
+                  artifactDirectory: "$(ob_outputDirectory)/azl4"
+                  distro: azl4

--- a/.pipelines/templates/stages/trident_rpms/release.yml
+++ b/.pipelines/templates/stages/trident_rpms/release.yml
@@ -6,6 +6,13 @@ parameters:
       - arm64
       - amd64
 
+  - name: distro
+    type: string
+    default: "azl3"
+    values:
+      - azl3
+      - azl4
+
   - name: tridentRepoDirectory
     type: string
 
@@ -57,11 +64,22 @@ steps:
       rm -rf "$outdir"
       mkdir -p "$outdir"
 
+      AZL_IMAGE="$(DISTRO=${{ parameters.distro }} make azl-version-vars | grep AZL_IMAGE | cut -d '=' -f2)"
+      DISTRO_PACKAGES="$(DISTRO=${{ parameters.distro }} make azl-version-vars | grep DISTRO_PACKAGES | cut -d '=' -f2)"
+      RPM_PACKAGES="$(DISTRO=${{ parameters.distro }} make azl-version-vars | grep RPM_PACKAGES | cut -d '=' -f2)"
+      RPM_DEST="$(DISTRO=${{ parameters.distro }} make azl-version-vars | grep RPM_DEST | cut -d '=' -f2)"
+      RUST_PACKAGE="$(DISTRO=${{ parameters.distro }} make azl-version-vars | grep RUST_PACKAGE | cut -d '=' -f2)"
+
       docker build -f ${{ parameters.tridentRepoDirectory }}/packaging/docker/Dockerfile.full -t trident/trident-build:latest \
         --secret id=registry_token,env=CARGO_REGISTRIES_BMP_PUBLICPACKAGES_TOKEN \
         --build-arg TRIDENT_VERSION="$full_version" \
         --build-arg RPM_VER="$version"\
-        --build-arg RPM_REL="$prerelease"\
+        --build-arg RPM_REL="$prerelease.${{ parameters.distro }}"\
+        --build-arg AZL_IMAGE="$AZL_IMAGE"\
+        --build-arg DISTRO_PACKAGES="$DISTRO_PACKAGES" \
+        --build-arg RPM_PACKAGES="$RPM_PACKAGES" \
+        --build-arg RUST_PACKAGE="$RUST_PACKAGE" \
+        --build-arg RPM_DEST="$RPM_DEST" \
         --target artifact \
         --output type=local,dest="$outdir" \
         .
@@ -73,6 +91,6 @@ steps:
     workingDirectory: ${{ parameters.tridentRepoDirectory }}
     displayName: Build RPMs
 
-  - script: ./scripts/extract-binary.sh ${{ parameters.artifactDirectory }} ${{ parameters.artifactDirectory }} ${{ parameters.targetArchitecture }}
+  - script: ./scripts/extract-binary.sh ${{ parameters.artifactDirectory }} ${{ parameters.artifactDirectory }} ${{ parameters.targetArchitecture }} ${{ parameters.distro }}
     workingDirectory: ${{ parameters.tridentRepoDirectory }}
     displayName: Extract Trident binary

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,6 @@ OVERRIDE_RUST_FEED ?= true
 
 SERVER_PORT ?= 8133
 
-# Azl3 builder docker image name
-AZL3_BUILDER_IMAGE := azl3/trident-builder:latest
-
 .PHONY: all
 all: format check test build-api-docs bin/trident-rpms.tar.gz docker-build build-functional-test coverage validate-configs
 
@@ -69,13 +66,44 @@ check-sh:
 	fi
 	@echo "NOTICE: Created local .cargo/config file."
 
+DISTRO ?= azl3
+
+.PHONY: azl-version-vars
+azl-version-vars:
+ifeq ($(DISTRO),azl3)
+	$(eval BUILDER_IMAGE := azl3/trident-builder:latest)
+	$(eval AZL_IMAGE := mcr.microsoft.com/azurelinux/base/core:3.0)
+	$(eval DISTRO_PACKAGES := build-essential)
+	$(eval RPM_PACKAGES := )
+	$(eval RPM_DEST := /usr/src/azl)
+	$(eval RUST_PACKAGE := rust-1.86.0)
+	@echo "Using Azure Linux 3 for build and runtime images."
+else ifeq ($(DISTRO),azl4)
+	$(eval BUILDER_IMAGE := azl4/trident-builder:latest)
+	$(eval AZL_IMAGE := mcr.microsoft.com/azurelinux-beta/base/core:4.0)
+	$(eval DISTRO_PACKAGES := make automake gcc gcc-c++ kernel-devel cargo)
+	$(eval RPM_PACKAGES := systemd)
+	$(eval RPM_DEST := /root/rpmbuild)
+	$(eval RUST_PACKAGE := rust)
+	@echo "Using Azure Linux 4 for build and runtime images."
+else
+	$(error "Invalid DISTRO specified: $(DISTRO). Must be 'azl3' or 'azl4'.")
+endif
+	@echo "DISTRO=$(DISTRO)"
+	@echo "BUILDER_IMAGE=$(BUILDER_IMAGE)"
+	@echo "AZL_IMAGE=$(AZL_IMAGE)"
+	@echo "DISTRO_PACKAGES=$(DISTRO_PACKAGES)"
+	@echo "RPM_PACKAGES=$(RPM_PACKAGES)"
+	@echo "RPM_DEST=$(RPM_DEST)"
+	@echo "RUST_PACKAGE=$(RUST_PACKAGE)"
+
 .PHONY: version-vars
-version-vars:
+version-vars: azl-version-vars
 	$(eval SIMULATED_BUILD_ID := 99)
 	$(eval TRIDENT_BUILD_DATE := $(shell date +%Y%m%d))
 	$(eval TRIDENT_CARGO_VERSION := $(shell python3 ./scripts/get-version.py))
 	$(eval GIT_COMMIT := v$(shell git rev-parse --short HEAD)$(shell git diff --quiet || echo '.dirty'))
-	$(eval TRIDENT_PREVIEW_VERSION := "dev.$(TRIDENT_BUILD_DATE)$(SIMULATED_BUILD_ID).$(GIT_COMMIT)")
+	$(eval TRIDENT_PREVIEW_VERSION := "dev.$(TRIDENT_BUILD_DATE)$(SIMULATED_BUILD_ID).$(GIT_COMMIT).$(DISTRO)")
 	$(eval LOCAL_BUILD_TRIDENT_VERSION := "$(TRIDENT_CARGO_VERSION)-$(TRIDENT_PREVIEW_VERSION)")
 	@echo "TRIDENT_CARGO_VERSION=$(TRIDENT_CARGO_VERSION)"
 	@echo "TRIDENT_PREVIEW_VERSION=$(TRIDENT_PREVIEW_VERSION)"
@@ -144,33 +172,47 @@ target/release/trident target/release/trident-acl-agent: .cargo/config | version
 
 ARTIFACTS_DIR="artifacts"
 
-.PHONY: azl3-builder-image clean-azl3-builder-image build-azl3
-azl3-builder-image:
-	@echo "Checking for local image $(AZL3_BUILDER_IMAGE)..."
-	@if docker image inspect $(AZL3_BUILDER_IMAGE) >/dev/null 2>&1 ; then \
-		echo "Image $(AZL3_BUILDER_IMAGE) found locally." ; \
+.PHONY: builder-image clean-builder-image
+builder-image: azl-version-vars
+	@echo "Checking for local image $(BUILDER_IMAGE)..."
+	@if docker image inspect $(BUILDER_IMAGE) >/dev/null 2>&1 ; then \
+		echo "Image $(BUILDER_IMAGE) found locally." ; \
 	else \
-		echo "Image $(AZL3_BUILDER_IMAGE) not found locally. Building..." ; \
-		docker build -t $(AZL3_BUILDER_IMAGE) -f packaging/docker/Dockerfile.azl3-builder . ; \
+		echo "Image $(BUILDER_IMAGE) not found locally. Building..." ; \
+		docker build -t $(BUILDER_IMAGE) \
+		   -f packaging/docker/Dockerfile.azl-builder \
+		   . \
+		   --build-arg AZL_IMAGE="$(AZL_IMAGE)" \
+		   --build-arg DISTRO_PACKAGES="$(DISTRO_PACKAGES)" \
+		   --build-arg RPM_PACKAGES="$(RPM_PACKAGES)" ; \
 	fi
 
-clean-azl3-builder-image:
-	@echo "Removing local image $(AZL3_BUILDER_IMAGE)..."
-	@docker rmi $(AZL3_BUILDER_IMAGE) || echo "Image $(AZL3_BUILDER_IMAGE) not found locally."
+clean-builder-image: azl-version-vars
+	@echo "Removing local image $(BUILDER_IMAGE)..."
+	@docker rmi $(BUILDER_IMAGE) || echo "Image $(BUILDER_IMAGE) not found locally."
 
-target/azl3/release/trident target/azl3/release/trident-acl-agent: version-vars | azl3-builder-image
+target/$(DISTRO)/release/trident target/$(DISTRO)/release/trident-acl-agent: azl-version-vars version-vars builder-image
 	@mkdir -p bin/
-	@mkdir -p target/azl3/
-	@echo "Building Trident for Azure Linux 3 using Docker image $(AZL3_BUILDER_IMAGE)..."
+	@mkdir -p target/$(DISTRO)/
+	@echo "Building Trident for Azure Linux ($(DISTRO)) using Docker image $(BUILDER_IMAGE)..."
 	@docker run --rm \
 		-e TRIDENT_VERSION="$(LOCAL_BUILD_TRIDENT_VERSION)" \
-		-v $(PWD):/work -w /work $(AZL3_BUILDER_IMAGE) \
-		cargo build --color always --target-dir target/azl3 --release --features dangerous-options,grpc-preview -p trident -p trident-acl-agent
+		-v $(PWD):/work -w /work $(BUILDER_IMAGE) \
+		cargo build \
+		    --color always \
+			--target-dir target/$(DISTRO) \
+			--release \
+			--features dangerous-options,grpc-preview \
+			-p trident \
+			-p trident-acl-agent
 
 # This will do a proper build on azl3, exactly as the pipelines would, with the custom registry and all.
-bin/trident-rpms-azl3.tar.gz: packaging/docker/Dockerfile.full packaging/systemd/*.service packaging/rpm/trident.spec packaging/selinux-policy-trident/* version-vars
+bin/trident-rpms-%.tar.gz: packaging/docker/Dockerfile.full packaging/systemd/*.service packaging/rpm/trident.spec packaging/selinux-policy-trident/* version-vars azl-version-vars
+	@case "$@" in \
+		*$(DISTRO).tar.gz) ;; \
+		*) echo "Invalid target '$@' for DISTRO '$(DISTRO)'. Expected target ending in '$(DISTRO).tar.gz'."; exit 1 ;; \
+	esac
 	$(eval CARGO_REGISTRIES_BMP_PUBLICPACKAGES_TOKEN := $(shell az account get-access-token --query "join(' ', ['Bearer', accessToken])" --output tsv))
-
 	@mkdir -p bin/
 	@tmpdir=$$(mktemp -d) && \
 		export CARGO_REGISTRIES_BMP_PUBLICPACKAGES_TOKEN="$(CARGO_REGISTRIES_BMP_PUBLICPACKAGES_TOKEN)" &&\
@@ -180,6 +222,11 @@ bin/trident-rpms-azl3.tar.gz: packaging/docker/Dockerfile.full packaging/systemd
 			--build-arg TRIDENT_VERSION="$(LOCAL_BUILD_TRIDENT_VERSION)" \
 			--build-arg RPM_VER="$(TRIDENT_CARGO_VERSION)" \
 			--build-arg RPM_REL="$(TRIDENT_PREVIEW_VERSION)" \
+			--build-arg AZL_IMAGE="$(AZL_IMAGE)" \
+			--build-arg DISTRO_PACKAGES="$(DISTRO_PACKAGES)" \
+			--build-arg RPM_PACKAGES="$(RPM_PACKAGES)" \
+			--build-arg RUST_PACKAGE="$(RUST_PACKAGE)" \
+			--build-arg RPM_DEST="$(RPM_DEST)" \
 			--target artifact \
 			--output type=local,dest=$$tmpdir \
 			-f packaging/docker/Dockerfile.full \
@@ -190,19 +237,26 @@ bin/trident-rpms-azl3.tar.gz: packaging/docker/Dockerfile.full packaging/systemd
 	@tar xf $@ -C bin/
 
 # This one does a fast trick-build where we build locally and inject the binary into the container to add it to the RPM.
-bin/trident-rpms.tar.gz: packaging/docker/Dockerfile.azl3 packaging/systemd/*.service packaging/rpm/trident.spec target/release/trident target/release/trident-acl-agent packaging/selinux-policy-trident/*
+# For the fast RPM build, azl3 (the default) uses the native host build for
+# backward compatibility; other distros use the in-container distro build.
+TRIDENT_RPM_BIN_DIR := $(if $(filter azl3,$(DISTRO)),target/release,target/$(DISTRO)/release)
+
+bin/trident-rpms.tar.gz: azl-version-vars packaging/docker/Dockerfile.azl packaging/systemd/*.service packaging/rpm/trident.spec $(TRIDENT_RPM_BIN_DIR)/trident $(TRIDENT_RPM_BIN_DIR)/trident-acl-agent packaging/selinux-policy-trident/*
 	@mkdir -p bin/
-	@if [ ! -f bin/trident ] || ! cmp -s target/release/trident bin/trident; then \
-		cp target/release/trident bin/trident; \
+	@if [ ! -f bin/trident ] || ! cmp -s $(TRIDENT_RPM_BIN_DIR)/trident bin/trident; then \
+		cp $(TRIDENT_RPM_BIN_DIR)/trident bin/trident; \
 	fi
-	@if [ ! -f bin/trident-acl-agent ] || ! cmp -s target/release/trident-acl-agent bin/trident-acl-agent; then \
-		cp target/release/trident-acl-agent bin/trident-acl-agent; \
+	@if [ ! -f bin/trident-acl-agent ] || ! cmp -s $(TRIDENT_RPM_BIN_DIR)/trident-acl-agent bin/trident-acl-agent; then \
+		cp $(TRIDENT_RPM_BIN_DIR)/trident-acl-agent bin/trident-acl-agent; \
 	fi
 	@docker build -t trident/trident-build:latest \
 		--build-arg TRIDENT_VERSION="$(LOCAL_BUILD_TRIDENT_VERSION)" \
 		--build-arg RPM_VER="$(TRIDENT_CARGO_VERSION)" \
 		--build-arg RPM_REL="$(TRIDENT_PREVIEW_VERSION)" \
-		-f packaging/docker/Dockerfile.azl3 \
+		--build-arg AZL_IMAGE="$(AZL_IMAGE)" \
+		--build-arg RPM_DEST="$(RPM_DEST)" \
+		--build-arg RPM_PACKAGES="$(RPM_PACKAGES)" \
+		-f packaging/docker/Dockerfile.azl \
 		.
 	@id=$$(docker create trident/trident-build:latest) && \
 	    docker cp -q $$id:/work/trident-rpms.tar.gz $@ || \
@@ -213,7 +267,7 @@ bin/trident-rpms.tar.gz: packaging/docker/Dockerfile.azl3 packaging/systemd/*.se
 STEAMBOAT_RPMS_DIR ?= ../steamboat/build/uki/out/RPMS
 
 .PHONY: copy-rpms-to-steamboat
-copy-rpms-to-steamboat: bin/trident-rpms-azl3.tar.gz
+copy-rpms-to-steamboat: azl-version-vars bin/trident-rpms-$(DISTRO).tar.gz
 	@echo "Cleaning up old Trident RPMs in Steamboat..."
 	@rm -f $(STEAMBOAT_RPMS_DIR)/trident-*
 	@echo "Copying Trident RPMs to Steamboat..."
@@ -224,7 +278,7 @@ copy-rpms-to-steamboat: bin/trident-rpms-azl3.tar.gz
 
 # Does a full build of Trident RPMs and publishes them to the TridentDev feed in Azure DevOps.
 .PHONY: publish-dev-rpms
-publish-dev-rpms: bin/trident-rpms-azl3.tar.gz
+publish-dev-rpms: azl-version-vars bin/trident-rpms-$(DISTRO).tar.gz
 	@echo "Publishing Trident dev RPMs to TridentDev/rpms-dev:$(LOCAL_BUILD_TRIDENT_VERSION)"
 	$(eval STAGING_DIR := $(shell mktemp -d))
 	@find bin/RPMS/ -type f -name '*.rpm' -exec cp {} $(STAGING_DIR)/ \;
@@ -242,8 +296,13 @@ publish-dev-rpms: bin/trident-rpms-azl3.tar.gz
 
 # Grabs bin/trident-rpms.tar.gz from the local build directory and builds a Docker image with it.
 .PHONY: docker-build
-docker-build: packaging/docker/Dockerfile.runtime bin/trident-rpms.tar.gz
-	@docker build --quiet -f packaging/docker/Dockerfile.runtime -t trident/trident:latest .
+docker-build: azl-version-vars packaging/docker/Dockerfile.runtime bin/trident-rpms.tar.gz
+	@docker build --quiet \
+	    -f packaging/docker/Dockerfile.runtime \
+		-t trident/trident:latest \
+		. \
+		--build-arg AZL_IMAGE="$(AZL_IMAGE)" \
+		--build-arg RPM_PACKAGES="$(RPM_PACKAGES)"
 
 artifacts/test-image/trident-container.tar.gz: docker-build
 	@mkdir -p artifacts/test-image
@@ -545,8 +604,8 @@ IS_UBUNTU_24_OR_NEWER := $(shell \
 	. $(OS_RELEASE_FILE) 2>/dev/null && \
 	[ "$$ID" = "ubuntu" ] && [ "$${VERSION_ID%%.*}" -ge 24 ] && echo yes)
 
-RUN_NETLAUNCH_TRIDENT_BIN ?= $(if $(filter yes,$(IS_UBUNTU_24_OR_NEWER)),target/azl3/release/trident,target/release/trident)
-RUN_NETLAUNCH_LAUNCHER_BIN ?= $(if $(filter yes,$(IS_UBUNTU_24_OR_NEWER)),target/azl3/release/trident-acl-agent,target/release/trident-acl-agent)
+RUN_NETLAUNCH_TRIDENT_BIN ?= $(if $(filter yes,$(IS_UBUNTU_24_OR_NEWER)),target/$(DISTRO)/release/trident,target/release/trident)
+RUN_NETLAUNCH_LAUNCHER_BIN ?= $(if $(filter yes,$(IS_UBUNTU_24_OR_NEWER)),target/$(DISTRO)/release/trident-acl-agent,target/release/trident-acl-agent)
 
 .PHONY: run-netlaunch run-netlaunch-stream
 run-netlaunch: $(NETLAUNCH_CONFIG) $(TRIDENT_CONFIG) $(NETLAUNCH_ISO) bin/netlaunch validate $(RUN_NETLAUNCH_TRIDENT_BIN) $(RUN_NETLAUNCH_LAUNCHER_BIN)

--- a/packaging/docker/Dockerfile.azl
+++ b/packaging/docker/Dockerfile.azl
@@ -1,8 +1,20 @@
 ### This file is primarily used to build Trident RPMs for local testing.
 
-FROM mcr.microsoft.com/azurelinux/base/core:3.0
+ARG AZL_IMAGE=mcr.microsoft.com/azurelinux/base/core:3.0
+FROM ${AZL_IMAGE}
 
-RUN tdnf install -y rpmdevtools openssl-devel clang-devel protobuf-devel rust sed selinux-policy-devel
+ARG DISTRO_PACKAGES=build-essential
+ARG RPM_PACKAGES=
+
+RUN tdnf install -y \
+    rpmdevtools \
+    openssl-devel \
+    clang-devel \
+    protobuf-devel \
+    rust \
+    sed \
+    selinux-policy-devel \
+    ${DISTRO_PACKAGES}
 
 WORKDIR /work
 
@@ -15,6 +27,8 @@ ARG TRIDENT_VERSION=dev-build
 ARG RPM_VER=0.1.0
 ARG RPM_REL=1
 
+ARG RPM_DEST=/usr/src/azl
+
 RUN \
     sed -i "s/^Version:.*/Version:        $RPM_VER/" trident.spec && \
     sed -i "s/^Release:.*/Release:        $RPM_REL/" trident.spec && \
@@ -23,4 +37,4 @@ RUN \
     --define="trident_version $TRIDENT_VERSION" \
     --define="rpm_ver $RPM_VER" \
     --define="rpm_rel $RPM_REL" && \
-    tar -czvf trident-rpms.tar.gz -C /usr/src/azl ./RPMS
+    tar -czvf trident-rpms.tar.gz -C $RPM_DEST ./RPMS

--- a/packaging/docker/Dockerfile.azl-builder
+++ b/packaging/docker/Dockerfile.azl-builder
@@ -1,7 +1,11 @@
 # Simple container image with all build tools required to build Trident RPMs for Azure Linux 3.
-FROM mcr.microsoft.com/azurelinux/base/core:3.0
+ARG AZL_IMAGE=mcr.microsoft.com/azurelinux/base/core:3.0
+FROM ${AZL_IMAGE}
 
-RUN tdnf install -y build-essential openssl-devel clang-devel protobuf-devel rust sed selinux-policy-devel ca-certificates
+ARG DISTRO_PACKAGES=build-essential
+ARG RPM_PACKAGES=
+
+RUN tdnf install -y ${DISTRO_PACKAGES} openssl-devel clang-devel protobuf-devel rust sed selinux-policy-devel ca-certificates
 RUN tdnf clean all
 
 # Pre-fetch cargo dependencies to leverage Docker layer caching.

--- a/packaging/docker/Dockerfile.full
+++ b/packaging/docker/Dockerfile.full
@@ -1,8 +1,24 @@
 ### This file is used in pipelines to build Trident RPMs.
 
-FROM mcr.microsoft.com/azurelinux/base/core:3.0 AS build
+ARG AZL_IMAGE=mcr.microsoft.com/azurelinux/base/core:3.0
+FROM ${AZL_IMAGE} as build
 
-RUN tdnf install -y rpmdevtools openssl-devel clang-devel protobuf-devel rust-1.86.0 sed ca-certificates perl build-essential selinux-policy-devel
+ARG DISTRO_PACKAGES=build-essential
+ARG RPM_PACKAGES=
+ARG RUST_PACKAGE=rust-1.86.0
+
+RUN tdnf install -y \
+    rpmdevtools \
+    openssl-devel \
+    clang-devel \
+    protobuf-devel \
+    ${RUST_PACKAGE} \
+    sed \
+    ca-certificates \
+    perl \
+    selinux-policy-devel \
+    ${DISTRO_PACKAGES} \
+    ${RPM_PACKAGES}
 
 WORKDIR /work
 
@@ -19,6 +35,8 @@ ARG TRIDENT_VERSION=dev-build
 ARG RPM_VER=0.1.0
 ARG RPM_REL=1
 
+ARG RPM_DEST=/usr/src/azl
+
 # This entry needs to exist in the config.toml file to allow cargo to use the
 # token from the environment variable.
 ARG CARGO_REGISTRIES_FROM_ENV=false
@@ -34,7 +52,7 @@ RUN --mount=type=secret,id=registry_token \
     --define="trident_version $TRIDENT_VERSION" \
     --define="rpm_ver $RPM_VER" \
     --define="rpm_rel $RPM_REL" && \
-    tar -czvf trident-rpms.tar.gz -C /usr/src/azl ./RPMS
+    tar -czvf trident-rpms.tar.gz -C $RPM_DEST ./RPMS
 
 FROM scratch AS artifact
 COPY --from=build /work/trident-rpms.tar.gz /trident-rpms.tar.gz

--- a/packaging/docker/Dockerfile.full.public
+++ b/packaging/docker/Dockerfile.full.public
@@ -1,8 +1,13 @@
 ### This file is used in pipelines to build Trident RPMs.
 
-FROM mcr.microsoft.com/azurelinux/base/core:3.0
+ARG AZL_IMAGE=mcr.microsoft.com/azurelinux/base/core:3.0
+FROM ${AZL_IMAGE}
 
-RUN tdnf install -y rpmdevtools openssl-devel clang-devel protobuf-devel rust sed ca-certificates perl build-essential selinux-policy-devel
+ARG DISTRO_PACKAGES=build-essential
+ARG RPM_PACKAGES=
+ARG RUST_PACKAGE=rust-1.86.0
+
+RUN tdnf install -y rpmdevtools openssl-devel clang-devel protobuf-devel ${RUST_PACKAGE} sed ca-certificates perl ${DISTRO_PACKAGES} ${RPM_PACKAGES} selinux-policy-devel
 
 WORKDIR /work
 
@@ -19,10 +24,12 @@ ARG TRIDENT_VERSION=dev-build
 ARG RPM_VER=0.1.0
 ARG RPM_REL=1
 
+ARG RPM_DEST=/usr/src/azl
+
 RUN sed -i "s/^Version:.*/Version:        $RPM_VER/" trident.spec && \
     sed -i "s/^Release:.*/Release:        $RPM_REL/" trident.spec && \
     rpmbuild -bb --build-in-place trident.spec \
     --define="trident_version $TRIDENT_VERSION" \
     --define="rpm_ver $RPM_VER" \
     --define="rpm_rel $RPM_REL" && \
-    tar -czvf trident-rpms.tar.gz -C /usr/src/azl ./RPMS
+    tar -czvf trident-rpms.tar.gz -C $RPM_DEST ./RPMS

--- a/packaging/docker/Dockerfile.runtime
+++ b/packaging/docker/Dockerfile.runtime
@@ -1,6 +1,9 @@
 ### This file is used to build a container image with Trident inside.
 
-FROM mcr.microsoft.com/azurelinux/base/core:3.0
+ARG AZL_IMAGE=mcr.microsoft.com/azurelinux/base/core:3.0
+FROM ${AZL_IMAGE}
+
+ARG RPM_PACKAGES=
 
 RUN tdnf -y install \
     # Explicitly required by Trident specfile
@@ -18,14 +21,15 @@ RUN tdnf -y install \
     cryptsetup \
     veritysetup \
     ntfs-3g \
-    ntfsprogs
+    ntfsprogs \
+    ${RPM_PACKAGES}
 
 RUN \
     --mount=type=bind,source=./bin/RPMS,target=/trident \
     tdnf install -y \
-        /trident/x86_64/trident-0*.rpm && \
+    /trident/x86_64/trident-0*.rpm && \
     tdnf install -y \
-        /trident/x86_64/trident-static-pcrlock-files-0*.rpm && \
+    /trident/x86_64/trident-static-pcrlock-files-0*.rpm && \
     tdnf clean all
 
 ENV DOCKER_ENVIRONMENT=true

--- a/packaging/selinux-policy-trident/trident.te
+++ b/packaging/selinux-policy-trident/trident.te
@@ -2,6 +2,35 @@ policy_module(trident, 1.0.0)
 
 ########################################
 #
+# Platform compatibility (AZL3 refpolicy vs AZL4 Fedora policy)
+#
+# AZL3 uses refpolicy 2.20240226: types named *_runtime_t, interfaces named *_runtime_*
+# AZL4 uses Fedora selinux-policy 43.4: types named *_var_run_t, interfaces named *_pid_*
+#
+# We use a sentinel interface (raid_manage_mdadm_runtime_files) that exists only in
+# refpolicy to detect the platform at m4 preprocessing time, then define type-name
+# macros accordingly. Interface calls use per-call ifdef.
+#
+ifdef(`raid_manage_mdadm_runtime_files',`
+    define(`INIT_RUNTIME_T',`init_runtime_t')
+    define(`LVM_RUNTIME_T',`lvm_runtime_t')
+    define(`SYSLOGD_RUNTIME_T',`syslogd_runtime_t')
+    define(`SYSTEMD_NETWORKD_RUNTIME_T',`systemd_networkd_runtime_t')
+    define(`MDADM_RUNTIME_T',`mdadm_runtime_t')
+    define(`MOUNT_RUNTIME_T',`mount_runtime_t')
+    define(`UDEV_RUNTIME_T',`udev_runtime_t')
+',`
+    define(`INIT_RUNTIME_T',`init_var_run_t')
+    define(`LVM_RUNTIME_T',`lvm_var_run_t')
+    define(`SYSLOGD_RUNTIME_T',`syslogd_var_run_t')
+    define(`SYSTEMD_NETWORKD_RUNTIME_T',`systemd_networkd_var_run_t')
+    define(`MDADM_RUNTIME_T',`mdadm_var_run_t')
+    define(`MOUNT_RUNTIME_T',`mount_var_run_t')
+    define(`UDEV_RUNTIME_T',`udev_var_run_t')
+')
+
+########################################
+#
 # Declarations
 #
 
@@ -63,7 +92,7 @@ require {
         type http_port_t;
         type init_t;
         type init_exec_t;
-        type init_runtime_t;
+        type INIT_RUNTIME_T;
         type init_var_lib_t;
         type initctl_t;
         type iptables_unit_t;
@@ -76,7 +105,7 @@ require {
         type locale_t;
         type lost_found_t;
         type lvm_metadata_t;
-        type lvm_runtime_t;
+        type LVM_RUNTIME_T;
         type lvm_t;
         type lvm_unit_t;
         type mail_spool_t;
@@ -118,7 +147,7 @@ require {
         type sysfs_t;
         type syslog_conf_t;
         type syslogd_exec_t;
-        type syslogd_runtime_t;
+        type SYSLOGD_RUNTIME_T;
         type syslogd_unit_t;
         type systemd_analyze_exec_t;
         type systemd_backlight_exec_t;
@@ -145,7 +174,9 @@ require {
         type systemd_networkd_t;
         type systemd_networkd_unit_t;
         type systemd_networkd_exec_t;
-        type systemd_networkd_runtime_t;
+        type SYSTEMD_NETWORKD_RUNTIME_T;
+        type MOUNT_RUNTIME_T;
+        type UDEV_RUNTIME_T;
         type systemd_notify_exec_t;
         type systemd_passwd_agent_exec_t;
         type systemd_pcrphase_t;
@@ -180,6 +211,32 @@ require {
         type user_devpts_t;
         type usr_t;
         type var_run_t;
+
+
+        # Types previously implicit via interface gen_require; declared
+        # explicitly for cross-distro compatibility (AZL3 + AZL4).
+        type auditd_log_t;
+        type devlog_t;
+        type faillog_t;
+        type fixed_disk_device_t;
+        type initrc_t;
+        type lastlog_t;
+        type pstore_t;
+        type selinux_config_t;
+        type semanage_read_lock_t;
+        type semanage_store_t;
+        type semanage_trans_lock_t;
+        type setfiles_exec_t;
+        type system_dbusd_var_lib_t;
+        type system_map_t;
+        type tpm_device_t;
+        type udev_rules_t;
+        type var_lib_t;
+        type var_lock_t;
+        type var_log_t;
+        type var_spool_t;
+        type var_t;
+        type wtmp_t;
 
         # Define object classes that SELinux can protect
         class dir { add_name create getattr open read remove_name search write };
@@ -345,10 +402,10 @@ allow trident_t init_t:system { reboot reload start status };
 allow trident_t init_t:key search;
 allow trident_t init_t:unix_stream_socket connectto;
 allow trident_t initctl_t:fifo_file getattr;
-allow trident_t init_runtime_t:dir { add_name remove_name write };
-allow trident_t init_runtime_t:file { create getattr open setattr read rename unlink write };
-allow trident_t init_runtime_t:lnk_file { create unlink };
-allow trident_t init_runtime_t:service { start status };
+allow trident_t INIT_RUNTIME_T:dir { add_name remove_name write };
+allow trident_t INIT_RUNTIME_T:file { create getattr open setattr read rename unlink write };
+allow trident_t INIT_RUNTIME_T:lnk_file { create unlink };
+allow trident_t INIT_RUNTIME_T:service { start status };
 allow trident_t init_var_lib_t:dir { add_name getattr open read relabelto remove_name search write };
 allow trident_t init_var_lib_t:file { create getattr open read rename setattr unlink write };
 allow trident_t iptables_unit_t:file getattr;
@@ -387,7 +444,7 @@ optional_policy(`
 ')
 allow trident_t lost_found_t:dir { getattr open read relabelto };
 allow trident_t lvm_metadata_t:dir { getattr open read };
-allow trident_t lvm_runtime_t:dir { add_name open read remove_name search write };
+allow trident_t LVM_RUNTIME_T:dir { add_name open read remove_name search write };
 allow trident_t lvm_unit_t:file getattr;
 allow trident_t mail_spool_t:dir { list_dir_perms relabelto };
 allow trident_t memory_pressure_t:file { read open getattr setattr };
@@ -469,9 +526,15 @@ allow trident_t sysctl_vm_t:dir search;
 allow trident_t sysfs_t:filesystem { mount unmount };
 allow trident_t syslog_conf_t:file { getattr open read relabelto setattr unlink };
 allow trident_t syslogd_exec_t:file { execute getattr map open read relabelto setattr unlink write };
-allow trident_t syslogd_runtime_t:dir search;
+allow trident_t SYSLOGD_RUNTIME_T:dir search;
 allow trident_t syslogd_unit_t:file { getattr open read relabelto setattr unlink };
-allow trident_t system_cron_spool_t:dir relabelto;
+# AZL4: system_cron_spool_t does not exist
+optional_policy(`
+    require {
+        type system_cron_spool_t;
+    }
+    allow trident_t system_cron_spool_t:dir relabelto;
+')
 allow trident_t system_dbusd_var_lib_t:dir relabelto;
 allow trident_t system_dbusd_var_lib_t:lnk_file relabelto;
 allow trident_t system_map_t:file relabelto;
@@ -492,8 +555,14 @@ allow trident_t systemd_homework_exec_t:file getattr;
 allow trident_t systemd_hostnamed_exec_t:file { execute getattr };
 allow trident_t systemd_hw_exec_t:file getattr;
 allow trident_t systemd_hwdb_t:file { getattr open read relabelto setattr unlink };
-allow trident_t systemd_journal_t:file { relabelfrom_file_perms map open read relabelto };
-allow trident_t systemd_journal_t:dir relabelto;
+# AZL4: systemd_journal_t does not exist (journal handled differently)
+optional_policy(`
+    require {
+        type systemd_journal_t;
+    }
+    allow trident_t systemd_journal_t:file { relabelfrom_file_perms map open read relabelto };
+    allow trident_t systemd_journal_t:dir relabelto;
+')
 allow trident_t systemd_journalctl_exec_t:file { execute getattr map open read relabelto setattr unlink write };
 allow trident_t systemd_locale_exec_t:file getattr;
 allow trident_t systemd_logind_exec_t:file getattr;
@@ -501,8 +570,8 @@ allow trident_t systemd_machine_id_setup_exec_t:file getattr;
 allow trident_t systemd_modules_load_exec_t:file { execute getattr map open read relabelto setattr unlink write };
 allow trident_t systemd_networkd_unit_t:service { start status };
 allow trident_t systemd_networkd_exec_t:file { execute getattr };
-allow trident_t systemd_networkd_runtime_t:dir { add_name getattr open read remove_name search write };
-allow trident_t systemd_networkd_runtime_t:file { create getattr open read rename setattr unlink write };
+allow trident_t SYSTEMD_NETWORKD_RUNTIME_T:dir { add_name getattr open read remove_name search write };
+allow trident_t SYSTEMD_NETWORKD_RUNTIME_T:file { create getattr open read rename setattr unlink write };
 allow trident_t systemd_notify_exec_t:file getattr;
 allow trident_t systemd_passwd_agent_exec_t:file { execute getattr map open read relabelto setattr unlink write };
 allow trident_t systemd_pcrphase_exec_t:file { execute execute_no_trans getattr map open read };
@@ -533,9 +602,9 @@ allow trident_t tmp_t:lnk_file { create getattr read rename unlink };
 allow trident_t tmpfs_t:file { append create execute getattr ioctl link lock map mounton open read relabelto rename setattr unlink write };
 allow trident_t tmpfs_t:filesystem { getattr mount unmount };
 allow trident_t udev_exec_t:file { execute execute_no_trans getattr map open read relabelto setattr unlink write };
-allow trident_t udev_runtime_t:dir { add_name create read remove_name watch write };
-allow trident_t udev_runtime_t:file { create rename setattr unlink write };
-allow trident_t udev_runtime_t:sock_file write;
+allow trident_t UDEV_RUNTIME_T:dir { add_name create read remove_name watch write };
+allow trident_t UDEV_RUNTIME_T:file { create rename setattr unlink write };
+allow trident_t UDEV_RUNTIME_T:sock_file write;
 allow trident_t unlabeled_t:chr_file { create getattr link rename unlink };
 allow trident_t unlabeled_t:dir { create add_name getattr setattr open read remove_name search write mounton relabelfrom ioctl rename reparent rmdir };
 allow trident_t unlabeled_t:file { create getattr lock open read setattr unlink write ioctl relabelfrom append execute execute_no_trans link map relabelto rename };
@@ -615,19 +684,28 @@ optional_policy(`
         type trident_t;
         type mdadm_exec_t;
         type mdadm_unit_t;
-        type mdadm_runtime_t;
+        type MDADM_RUNTIME_T;
     }
     allow trident_t mdadm_exec_t:file { open read getattr map relabelto setattr unlink write execute execute_no_trans };
     allow trident_t mdadm_unit_t:file { getattr open read relabelto setattr unlink };
-    allow trident_t mdadm_runtime_t:dir { add_name remove_name search write };
-    raid_manage_mdadm_runtime_files(trident_t)
+    allow trident_t MDADM_RUNTIME_T:dir { add_name remove_name search write };
+    ifdef(`raid_manage_mdadm_runtime_files',`
+        raid_manage_mdadm_runtime_files(trident_t)
+    ',`
+        raid_manage_mdadm_pid(trident_t)
+    ')
 ')
 
 #============= interfaces ==============
 ###########################################
 # Authentication and User Management
 ###########################################
-auth_create_faillog_files(trident_t)
+# AZL3: auth_create_faillog_files / AZL4: auth_manage_faillog
+ifdef(`auth_create_faillog_files',`
+    auth_create_faillog_files(trident_t)
+',`
+    auth_manage_faillog(trident_t)
+')
 auth_exec_pam(trident_t)
 auth_login_entry_type(trident_t)
 auth_read_lastlog(trident_t)
@@ -648,8 +726,16 @@ su_exec(trident_t)
 usermanage_check_exec_passwd(trident_t)
 userdom_list_user_home_dirs(trident_t)
 userdom_read_user_home_content_files(trident_t)
-userdom_search_user_runtime_root(trident_t)
-userdom_relabel_generic_user_home_files(trident_t)
+# AZL3: userdom_search_user_runtime_root / AZL4: removed (covered by var_run_t allow rules)
+ifdef(`userdom_search_user_runtime_root',`
+    userdom_search_user_runtime_root(trident_t)
+')
+# AZL3: userdom_relabel_generic_user_home_files / AZL4: userdom_relabel_user_home_files
+ifdef(`userdom_relabel_generic_user_home_files',`
+    userdom_relabel_generic_user_home_files(trident_t)
+',`
+    userdom_relabel_user_home_files(trident_t)
+')
 userdom_relabelto_user_home_dirs(trident_t)
 
 ###########################################
@@ -675,13 +761,31 @@ optional_policy(`
     create_files_pattern(trident_t, cgroup_t, cgroup_t)
 ')
 cron_exec(trident_t)
-cron_exec_crontab(trident_t)
-cron_read_system_spool(trident_t)
-dbus_exec(trident_t)
+# AZL3: cron_exec_crontab / AZL4: removed (covered by cron_exec)
+ifdef(`cron_exec_crontab',`
+    cron_exec_crontab(trident_t)
+')
+# AZL3: cron_read_system_spool / AZL4: cron_manage_system_spool (superset)
+ifdef(`cron_read_system_spool',`
+    cron_read_system_spool(trident_t)
+',`
+    cron_manage_system_spool(trident_t)
+')
+# AZL3: dbus_exec / AZL4: dbus_exec_dbusd
+ifdef(`dbus_exec',`
+    dbus_exec(trident_t)
+',`
+    dbus_exec_dbusd(trident_t)
+')
 dbus_manage_lib_files(trident_t)
 dbus_read_config(trident_t)
 dbus_read_lib_files(trident_t)
-dbus_list_system_bus_runtime(trident_t)
+# AZL3: dbus_list_system_bus_runtime / AZL4: removed, use dbus_read_pid_files
+ifdef(`dbus_list_system_bus_runtime',`
+    dbus_list_system_bus_runtime(trident_t)
+',`
+    dbus_read_pid_files(trident_t)
+')
 dbus_system_bus_client(trident_t)
 domain_read_all_domains_state(trident_t)
 hostname_exec(trident_t)
@@ -696,11 +800,27 @@ optional_policy(`
 ssh_domtrans(trident_t)
 ssh_domtrans_keygen(trident_t)
 ssh_manage_home_files(trident_t)
-systemd_list_journal_dirs(trident_t)
-systemd_read_networkd_units(trident_t)
-systemd_read_user_runtime_units_files(trident_t)
+# AZL3: systemd_list_journal_dirs / AZL4: removed (no systemd_journal_t type on AZL4)
+ifdef(`systemd_list_journal_dirs',`
+    systemd_list_journal_dirs(trident_t)
+')
+# AZL3: systemd_read_networkd_units / AZL4: systemd_read_unit_files (generic)
+ifdef(`systemd_read_networkd_units',`
+    systemd_read_networkd_units(trident_t)
+',`
+    systemd_read_unit_files(trident_t)
+')
+# AZL3: systemd_read_user_runtime_units_files / AZL4: removed, covered by systemd_read_unit_files above
+ifdef(`systemd_read_user_runtime_units_files',`
+    systemd_read_user_runtime_units_files(trident_t)
+')
 systemd_dbus_chat_logind(trident_t)
-systemd_read_user_unit_files(trident_t)
+# AZL3: systemd_read_user_unit_files / AZL4: systemd_read_unit_files (generic)
+ifdef(`systemd_read_user_unit_files',`
+    systemd_read_user_unit_files(trident_t)
+',`
+    systemd_read_unit_files(trident_t)
+')
 
 # Optional read access to cloud init state
 optional_policy(`
@@ -720,7 +840,12 @@ files_list_var(trident_t)
 files_manage_boot_files(trident_t)
 files_manage_etc_dirs(trident_t)
 files_manage_etc_symlinks(trident_t)
-files_mounton_runtime_dirs(trident_t)
+# AZL3: files_mounton_runtime_dirs / AZL4: removed, inline equivalent
+ifdef(`files_mounton_runtime_dirs',`
+    files_mounton_runtime_dirs(trident_t)
+',`
+    allow trident_t var_run_t:dir mounton;
+')
 files_read_etc_files(trident_t)
 files_read_default_symlinks(trident_t)
 files_read_kernel_symbol_table(trident_t)
@@ -738,10 +863,19 @@ fstools_relabelto_entry_files(trident_t)
 fs_getattr_hugetlbfs(trident_t)
 fs_getattr_iso9660_files(trident_t)
 fs_getattr_iso9660_fs(trident_t)
-fs_getattr_pstorefs(trident_t)
-fs_getattr_tracefs(trident_t)
+# AZL3: fs_getattr_pstorefs / AZL4: removed
+ifdef(`fs_getattr_pstorefs',`
+    fs_getattr_pstorefs(trident_t)
+')
+# AZL3: fs_getattr_tracefs / AZL4: removed
+ifdef(`fs_getattr_tracefs',`
+    fs_getattr_tracefs(trident_t)
+')
 fs_getattr_xattr_fs(trident_t)
-fs_list_efivars(trident_t)
+# AZL3: fs_list_efivars / AZL4: removed
+ifdef(`fs_list_efivars',`
+    fs_list_efivars(trident_t)
+')
 fs_list_hugetlbfs(trident_t)
 fs_manage_dos_dirs(trident_t)
 fs_manage_dos_files(trident_t)
@@ -756,18 +890,34 @@ optional_policy(`
     }
     allow trident_t cgroup_t:file { ioctl read write getattr setattr lock append open };
 ')
-mount_list_runtime(trident_t)
+# AZL3: mount_list_runtime / AZL4: removed, inline equivalent
+ifdef(`mount_list_runtime',`
+    mount_list_runtime(trident_t)
+',`
+    allow trident_t MOUNT_RUNTIME_T:dir list_dir_perms;
+')
 
 ###########################################
 # Network Management
 ###########################################
 iptables_exec(trident_t)
 iptables_read_config(trident_t)
-iptables_status(trident_t)
+# AZL3: iptables_status / AZL4: iptables_systemctl
+ifdef(`iptables_status',`
+    iptables_status(trident_t)
+',`
+    iptables_systemctl(trident_t)
+')
 sysnet_exec_ifconfig(trident_t)
 sysnet_read_config(trident_t)
 sysnet_read_dhcp_config(trident_t)
-sysnet_relabel_config(trident_t)
+# AZL3: sysnet_relabel_config / AZL4: split into relabelto + relabelfrom
+ifdef(`sysnet_relabel_config',`
+    sysnet_relabel_config(trident_t)
+',`
+    sysnet_relabelto_net_conf(trident_t)
+    sysnet_relabelfrom_net_conf(trident_t)
+')
 sysnet_write_config(trident_t)
 
 ###########################################
@@ -777,9 +927,14 @@ dev_rw_loop_control(trident_t)
 dev_rw_lvm_control(trident_t)
 lvm_exec(trident_t)
 lvm_domtrans(trident_t)
-lvm_manage_runtime_files(trident_t)
+# AZL3: lvm_manage_runtime_files / AZL4: lvm_manage_var_run
+ifdef(`lvm_manage_runtime_files',`
+    lvm_manage_runtime_files(trident_t)
+',`
+    lvm_manage_var_run(trident_t)
+')
 lvm_read_config(trident_t)
-manage_files_pattern(trident_t, mount_runtime_t, mount_runtime_t)
+manage_files_pattern(trident_t, MOUNT_RUNTIME_T, MOUNT_RUNTIME_T)
 storage_getattr_fuse_dev(trident_t)
 storage_getattr_scsi_generic_dev(trident_t)
 storage_raw_read_removable_device(trident_t)
@@ -792,7 +947,12 @@ storage_raw_write_fixed_disk(trident_t)
 corecmd_relabel_bin_files(trident_t)
 files_relabel_etc_files(trident_t)
 files_relabel_kernel_modules(trident_t)
-files_relabelto_etc_runtime_files(trident_t)
+# AZL3: files_relabelto_etc_runtime_files / AZL4: removed, inline equivalent
+ifdef(`files_relabelto_etc_runtime_files',`
+    files_relabelto_etc_runtime_files(trident_t)
+',`
+    allow trident_t etc_runtime_t:file relabelto;
+')
 files_relabelto_usr_files(trident_t)
 libs_relabel_ld_so(trident_t)
 libs_relabelto_lib_files(trident_t)
@@ -813,7 +973,12 @@ seutil_read_default_contexts(trident_t)
 seutil_read_bin_policy(trident_t)
 seutil_run_setfiles(trident_t, system_r)
 seutil_run_setfiles(trident_t, unconfined_r)
-udev_relabel_rules_files(trident_t)
+# AZL3: udev_relabel_rules_files / AZL4: removed, inline equivalent
+ifdef(`udev_relabel_rules_files',`
+    udev_relabel_rules_files(trident_t)
+',`
+    allow trident_t udev_rules_t:file relabel_file_perms;
+')
 
 ###########################################
 # Package Management
@@ -837,21 +1002,47 @@ optional_policy(`
 # Device Management
 ###########################################
 corenet_getattr_ppp_dev(trident_t)
-corenet_read_tun_tap_dev(trident_t)
-dev_getattr_acpi_bios_dev(trident_t)
+# AZL3: corenet_read_tun_tap_dev / AZL4: removed
+ifdef(`corenet_read_tun_tap_dev',`
+    corenet_read_tun_tap_dev(trident_t)
+')
+# AZL3: dev_getattr_acpi_bios_dev / AZL4: dev_getattr_apm_bios_dev
+ifdef(`dev_getattr_acpi_bios_dev',`
+    dev_getattr_acpi_bios_dev(trident_t)
+',`
+    dev_getattr_apm_bios_dev(trident_t)
+')
 dev_getattr_autofs_dev(trident_t)
 dev_getattr_framebuffer_dev(trident_t)
 dev_getattr_generic_usb_dev(trident_t)
 dev_getattr_mouse_dev(trident_t)
-dev_getattr_pmqos_dev(trident_t)
-dev_getattr_sysfs(trident_t)
+# AZL3: dev_getattr_pmqos_dev / AZL4: removed
+ifdef(`dev_getattr_pmqos_dev',`
+    dev_getattr_pmqos_dev(trident_t)
+')
+# AZL3: dev_getattr_sysfs / AZL4: dev_getattr_sysfs_fs
+ifdef(`dev_getattr_sysfs',`
+    dev_getattr_sysfs(trident_t)
+',`
+    dev_getattr_sysfs_fs(trident_t)
+')
 dev_getattr_xserver_misc_dev(trident_t)
 dev_list_sysfs(trident_t)
 dev_manage_generic_blk_files(trident_t)
 dev_manage_generic_dirs(trident_t)
 dev_mounton(trident_t)
-dev_mounton_sysfs_dirs(trident_t)
-dev_read_input_dev(trident_t)
+# AZL3: dev_mounton_sysfs_dirs / AZL4: dev_mounton_sysfs
+ifdef(`dev_mounton_sysfs_dirs',`
+    dev_mounton_sysfs_dirs(trident_t)
+',`
+    dev_mounton_sysfs(trident_t)
+')
+# AZL3: dev_read_input_dev / AZL4: dev_read_input
+ifdef(`dev_read_input_dev',`
+    dev_read_input_dev(trident_t)
+',`
+    dev_read_input(trident_t)
+')
 dev_read_kmsg(trident_t)
 dev_read_rand(trident_t)
 dev_read_raw_memory(trident_t)
@@ -860,7 +1051,10 @@ dev_read_sysfs(trident_t)
 dev_read_watchdog(trident_t)
 dev_read_urand(trident_t)
 dev_relabelfrom_generic_chr_files(trident_t)
-dev_relabelfrom_vfio_dev(trident_t)
+# AZL3: dev_relabelfrom_vfio_dev / AZL4: removed
+ifdef(`dev_relabelfrom_vfio_dev',`
+    dev_relabelfrom_vfio_dev(trident_t)
+')
 dev_rw_nvram(trident_t)
 dev_rw_tpm(trident_t)
 dev_rw_vhost(trident_t)
@@ -871,7 +1065,12 @@ term_getattr_ptmx(trident_t)
 term_use_virtio_console(trident_t)
 term_getattr_pty_fs(trident_t)
 udev_manage_rules_files(trident_t)
-udev_read_runtime_files(trident_t)
+# AZL3: udev_read_runtime_files / AZL4: udev_read_pid_files
+ifdef(`udev_read_runtime_files',`
+    udev_read_runtime_files(trident_t)
+',`
+    udev_read_pid_files(trident_t)
+')
 udev_read_state(trident_t)
 
 ###########################################
@@ -918,17 +1117,34 @@ optional_policy(`
 ###########################################
 logging_read_audit_config(trident_t)
 logging_read_audit_log(trident_t)
-logging_relabelto_devlog_sock_files(trident_t)
+# AZL3: logging_relabelto_devlog_sock_files / AZL4: logging_relabel_devlog_dev
+ifdef(`logging_relabelto_devlog_sock_files',`
+    logging_relabelto_devlog_sock_files(trident_t)
+',`
+    logging_relabel_devlog_dev(trident_t)
+')
 logging_search_logs(trident_t)
-logging_stream_connect_journald_varlink(trident_t)
-logging_manage_generic_log_dirs(trident_t)
+# AZL3: logging_stream_connect_journald_varlink / AZL4: logging_stream_connect_syslog
+ifdef(`logging_stream_connect_journald_varlink',`
+    logging_stream_connect_journald_varlink(trident_t)
+',`
+    logging_stream_connect_syslog(trident_t)
+')
+# AZL3: logging_manage_generic_log_dirs / AZL4: removed (covered by logging_manage_generic_logs)
+ifdef(`logging_manage_generic_log_dirs',`
+    logging_manage_generic_log_dirs(trident_t)
+')
 logging_manage_generic_logs(trident_t)
 
 ###########################################
 # Miscellaneous
 ###########################################
 optional_policy(`
-    miscfiles_read_generic_tls_privkey(trident_t)
+    ifdef(`miscfiles_read_generic_tls_privkey',`
+        miscfiles_read_generic_tls_privkey(trident_t)
+    ',`
+        miscfiles_read_all_certs(trident_t)
+    ')
 ')
 optional_policy(`
     miscfiles_read_man_pages(trident_t)
@@ -1088,12 +1304,27 @@ modutils_read_module_deps(udevadm_t)
 sysnet_read_config(udevadm_t)
 
 # List systemd networkd runtime files
-systemd_list_networkd_runtime(udevadm_t)
+# AZL3: systemd_list_networkd_runtime / AZL4: removed, inline equivalent
+ifdef(`systemd_list_networkd_runtime',`
+    systemd_list_networkd_runtime(udevadm_t)
+',`
+    allow udevadm_t SYSTEMD_NETWORKD_RUNTIME_T:dir list_dir_perms;
+')
 
 # Manage udev rules, runtime directories, and files
 udev_manage_rules_files(udevadm_t)
-udev_manage_runtime_dirs(udevadm_t)
-udev_manage_runtime_files(udevadm_t)
+# AZL3: udev_manage_runtime_dirs / AZL4: udev_manage_pid_dirs
+ifdef(`udev_manage_runtime_dirs',`
+    udev_manage_runtime_dirs(udevadm_t)
+',`
+    udev_manage_pid_dirs(udevadm_t)
+')
+# AZL3: udev_manage_runtime_files / AZL4: udev_manage_pid_files
+ifdef(`udev_manage_runtime_files',`
+    udev_manage_runtime_files(udevadm_t)
+',`
+    udev_manage_pid_files(udevadm_t)
+')
 
 # Read symbolic links in cgroup directories and search sysfs
 optional_policy(`

--- a/scripts/extract-binary.sh
+++ b/scripts/extract-binary.sh
@@ -8,6 +8,7 @@ set -eux
 RPM_DIR=$1
 OUTPUT_PATH=$2
 ARCHITECTURE=$3
+DISTRO=$4
 
 RPM_ARCH=""
 case "$ARCHITECTURE" in
@@ -23,8 +24,21 @@ case "$ARCHITECTURE" in
     ;;
 esac
 
+case "$DISTRO" in
+  azl3 | azl4)
+    ;;
+  *)
+    echo "Unsupported distro: $DISTRO"
+    exit 1
+    ;;
+esac
+
 TMP_DIR=$(mktemp -d)
-RPM=$(find $RPM_DIR | grep -P "trident-\d.*\.${RPM_ARCH}\.rpm")
+RPM=$(find "$RPM_DIR" | grep -P "trident-\d.*\.${DISTRO}\.${RPM_ARCH}\.rpm" | head -n 1 || true)
+if [ -z "$RPM" ]; then
+  echo "No Trident RPM found in '$RPM_DIR' matching distro=${DISTRO} arch=${RPM_ARCH}"
+  exit 1
+fi
 
 cp "$RPM" "$TMP_DIR/trident.rpm"
 
@@ -32,10 +46,13 @@ pushd "$TMP_DIR"
 rpm2cpio trident.rpm | cpio -idmv
 popd
 
-mv "$TMP_DIR/usr/bin/trident" $OUTPUT_PATH
+# OUTPUT_PATH is provided by the caller and determines distro layout
+# (azl3 at the artifact base for backward compatibility, azl4 under azl4/).
+mkdir -p "$OUTPUT_PATH"
+mv "$TMP_DIR/usr/bin/trident" "$OUTPUT_PATH"
 
 # Extract trident-acl-agent binary from the acl-agent sub-package RPM
-ACL_AGENT_RPM=$(find "$RPM_DIR" | grep -P "trident-acl-agent-\d.*\.${RPM_ARCH}\.rpm" | head -n 1 || true)
+ACL_AGENT_RPM=$(find "$RPM_DIR" | grep -P "trident-acl-agent-\d.*\.${DISTRO}\.${RPM_ARCH}\.rpm" | head -n 1 || true)
 if [ -n "$ACL_AGENT_RPM" ]; then
   ACL_TMP_DIR=$(mktemp -d)
   cp "$ACL_AGENT_RPM" "$ACL_TMP_DIR/trident-acl-agent.rpm"


### PR DESCRIPTION
## Summary

Adds support for building Azure Linux 4 (azl4) Trident RPMs alongside the existing azl3 RPMs, parameterized by a `DISTRO` variable. When `DISTRO` is unset it defaults to `azl3`, so existing behavior is unchanged.

## Changes

**Docker / build tooling**
- Renames `Dockerfile.azl3` -> `Dockerfile.azl` and `Dockerfile.azl3-builder` -> `Dockerfile.azl-builder`, parameterized by distro.
- Parameterizes `Dockerfile.full`, `Dockerfile.full.public`, and `Dockerfile.runtime` with a build-arg for the target distro.
- `scripts/extract-binary.sh`: distro-aware extraction. The `trident` and `trident-acl-agent` RPM greps filter by `.${DISTRO}.`, and the output path is caller-controlled (azl3 -> base, azl4 -> `azl4/` subdirectory) with an `mkdir -p` safety guard.
- `Makefile`: adds `DISTRO ?= azl3`, a guard that errors on any value other than `azl3`/`azl4`, and a `TRIDENT_RPM_BIN_DIR` that routes azl3 through the native host build path and azl4 through `target/azl4/release`.

**SELinux**
- `packaging/selinux-policy-trident/trident.te`: AZL3 (refpolicy) / AZL4 (Fedora policy) compatibility for the policy compiled into the RPM.

**Pipelines**
- `trident_rpms/build-source.yml` + `release.yml`: build azl3 to the base artifact path and azl4 to an `azl4/` subdirectory.
- `download_staged/download-staged.yml`: matches the azl3-base / azl4-subdirectory layout on download.
- Distro-filtering on every consumer that downloads the `trident-binaries` artifact, so wrong-distro RPMs are filtered out:
  - `build_docker_image/trident-container.yml`
  - `common_tasks/download-universal-artifact.yml`
  - `build_image/build-image-template.yml`
  - `trident_images/trident-testimg-template.yml`

## Artifact layout

- azl3 RPMs are published at the base artifact path; azl4 RPMs live under `azl4/`.
- Consumer filters default to the azl3 RPM glob.


## Note on RPM release string

Both azl3 and azl4 RPMs now carry an explicit distro tag in their release string (e.g. `...azl3.x86_64.rpm` / `...azl4.x86_64.rpm`). The `Release:` line in `trident.spec` is overwritten at build time by `Dockerfile.full` (`RPM_REL` build-arg), so the distro tag is sourced from `RPM_REL="$prerelease.${distro}"`. This explicit `.azl3` / `.azl4` suffix is required for the distro-aware extraction (`extract-binary.sh`) and the consumer-side `*azl3*.rpm` / `*azl4*.rpm` filtering to select the correct RPM in a dual-distro world. The azl3 package contents are unchanged; only the release string now includes the `.azl3` tag.
