### PR TITLE
pipelines: remove azl-cicd and pr-e2e-azure from check-pipelines validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,8 @@ endif
 	# Note: the az-cli version in pipelines does not like --parallel, so run sequentially.
 	./scripts/test-pipeline $(PARALLEL_FLAG) -q $(BRANCH_FLAG) \
 		prism-cicd \
-		azl-cicd \
 		pr \
 		pr-e2e \
-		pr-e2e-azure \
 		ci \
 		pre \
 		rel \


### PR DESCRIPTION
Removes the following pipelines from the check-pipelines validation (Makefile target):

- [azl-cicd (definitionId=5068)](https://dev.azure.com/mariner-org/ECF/_build?definitionId=5068)
- [pr-e2e-azure (definitionId=5072)](https://dev.azure.com/mariner-org/ECF/_build?definitionId=5072)

The pipeline alias-to-id mappings remain in `scripts/test-pipeline` so the pipelines can still be previewed manually; only the `check-pipelines` Make target invocation list is reduced.