### PR TITLE
Fix publishing and release to include all rpms

### DIFF
--- a/.pipelines/templates/stages/publishing/publish.yml
+++ b/.pipelines/templates/stages/publishing/publish.yml
@@ -54,7 +54,7 @@ stages:
             inputs:
               buildType: current
               patterns: |
-                *.rpm
+                **/*.rpm
               targetPath: /tmp/rpms
               artifactName: trident-binaries
             displayName: "Download Trident RPMs"
@@ -63,7 +63,7 @@ stages:
             inputs:
               buildType: current
               patterns: |
-                *.rpm
+                **/*.rpm
               targetPath: /tmp/rpms
               artifactName: trident-binaries-arm64
             displayName: "Download Trident RPMs (arm64)"

--- a/.pipelines/templates/stages/publishing/release-artifacts.yml
+++ b/.pipelines/templates/stages/publishing/release-artifacts.yml
@@ -40,7 +40,7 @@ stages:
             inputs:
               buildType: current
               patterns: |
-                *.rpm
+                **/*.rpm
               targetPath: $(Pipeline.Workspace)/rpms
               artifactName: trident-binaries
             displayName: "Download Trident RPMs"
@@ -49,7 +49,7 @@ stages:
             inputs:
               buildType: current
               patterns: |
-                *.rpm
+                **/*.rpm
               targetPath: $(Pipeline.Workspace)/rpms
               artifactName: trident-binaries-arm64
             displayName: "Download Trident RPMs (arm64)"
@@ -60,8 +60,9 @@ stages:
               TAR_FILE_NAME="trident-rpms-$(Build.BuildNumber).tar.gz"
 
               STAGING_DIR=$(mktemp -d)
-              mkdir -p "${STAGING_DIR}/$(Build.BuildNumber)"
+              mkdir -p "${STAGING_DIR}/$(Build.BuildNumber)/azl4"
               cp $(Pipeline.Workspace)/rpms/*.rpm "${STAGING_DIR}/$(Build.BuildNumber)/"
+              cp $(Pipeline.Workspace)/rpms/azl4/*.rpm "${STAGING_DIR}/$(Build.BuildNumber)/azl4/"
               tar -czf $(ob_outputDirectory)/$TAR_FILE_NAME \
                 -C "${STAGING_DIR}" \
                 "$(Build.BuildNumber)"


### PR DESCRIPTION
RPMs exist at more than just the top-level of trident-binaries.  Use `**/*.rpm` to download them all.