### PR TITLE
pipeline: trident-release tries to download arm64 RPMs before they are created

### DIFF
--- a/.pipelines/templates/stages/publishing/release-artifacts.yml
+++ b/.pipelines/templates/stages/publishing/release-artifacts.yml
@@ -8,6 +8,7 @@ stages:
   - stage: ReleaseArtifacts
     dependsOn:
       - GetTridentBinaries_rpms_amd64
+      - GetTridentBinaries_rpms_arm64
     condition: succeeded()
 
     jobs:


### PR DESCRIPTION
# 🔍 Description
 
trident-release is missing "GetTridentBinaries_rpms_arm64" dependency