### PR TITLE
engineering: bump version to 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "trident"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/trident/Cargo.toml
+++ b/crates/trident/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trident"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2024"
 publish = false
 rust-version = "1.85.0"


### PR DESCRIPTION
Bump version from 0.25.0 to 0.26.0 after the v0.25.0 release.