### PR TITLE
Avoid pypi.org usage in baremetal and VM E2E test jobs

### DIFF
--- a/.pipelines/templates/stages/testing_baremetal/baremetal-testing.yml
+++ b/.pipelines/templates/stages/testing_baremetal/baremetal-testing.yml
@@ -134,6 +134,7 @@ stages:
 
         steps:
           - template: ../common_tasks/checkout_trident.yml
+          - template: ../common_tasks/avoid-pypi-usage.yml
 
           - bash: |
               set -xe

--- a/.pipelines/templates/stages/testing_vm/netlaunch-testing.yml
+++ b/.pipelines/templates/stages/testing_vm/netlaunch-testing.yml
@@ -126,6 +126,7 @@ stages:
 
         steps:
           - template: ../common_tasks/checkout_trident.yml
+          - template: ../common_tasks/avoid-pypi-usage.yml
 
           - bash: |
               if [ ${{ variables['tridentConfigurationName'] }} == 'split' ]; then


### PR DESCRIPTION
The `Run E2E Test` (baremetal) and `DeploymentTesting_host`/`DeploymentTesting_container` (VM) jobs check out trident but never authenticate pip against the internal feed or block pypi.org, unlike the container/host E2E test jobs in `test_execution_template.yml`.

- `testing_baremetal/baremetal-testing.yml` installs Poetry directly from `install.python-poetry.org`.
- Both jobs call `testing_common/e2e-test-run.yml`, which runs `pip3 install pytest`/`fabric` with a comment assuming a prior `PipAuthenticate` task — one was never present in either job.

This adds `../common_tasks/avoid-pypi-usage.yml` right after checkout in both jobs, matching the pattern already used elsewhere in the CICD templates.