### PR TITLE
ACL: firstboot UKI addon only applies for clean install

### DIFF
--- a/crates/trident/src/engine/boot/uki.rs
+++ b/crates/trident/src/engine/boot/uki.rs
@@ -655,16 +655,15 @@ pub(crate) fn enforce_firstboot_addon_policy(
     esp_mount_path: &Path,
     servicing_type: ServicingType,
 ) -> Result<(), Error> {
-    let is_clean_install = match servicing_type {
-        ServicingType::CleanInstall => true,
-        ServicingType::AbUpdate => false,
-        other => {
-            return Err(anyhow!(
-                "enforce_firstboot_addon_policy called with unexpected servicing type \
-                 {other:?}; expected CleanInstall or AbUpdate"
-            ))
-        }
-    };
+    ensure!(
+        matches!(
+            servicing_type,
+            ServicingType::CleanInstall | ServicingType::AbUpdate
+        ),
+        "enforce_firstboot_addon_policy called with unexpected servicing type \
+         {servicing_type:?}; expected CleanInstall or AbUpdate"
+    );
+    let is_clean_install = servicing_type == ServicingType::CleanInstall;
 
     let staging_addon_dir = join_relative(mount_point, esp_mount_path)
         .join(UKI_DIRECTORY)

--- a/crates/trident/src/engine/boot/uki.rs
+++ b/crates/trident/src/engine/boot/uki.rs
@@ -639,7 +639,7 @@ const FIRSTBOOT_ADDON_FILENAME: &str = "firstboot.addon.efi";
 /// This is ACL-specific; callers gate on `ctx.image_distro().is_acl()`,
 /// matching the verity addon's existing convention — non-ACL images never
 /// reach this function.
-pub fn enforce_firstboot_addon_policy(
+pub(crate) fn enforce_firstboot_addon_policy(
     image_esp_mount: &Path,
     mount_point: &Path,
     esp_mount_path: &Path,

--- a/crates/trident/src/engine/boot/uki.rs
+++ b/crates/trident/src/engine/boot/uki.rs
@@ -1562,6 +1562,14 @@ mod tests {
             err.to_string().contains("unexpected servicing type"),
             "Expected 'unexpected servicing type' error, got: {err}"
         );
+        // Confirms the servicing type's actual Debug value is interpolated
+        // via the captured identifier ({servicing_type:?}), not left as a
+        // literal placeholder — Rust supports captured identifiers in
+        // format/ensure! strings since 1.58.
+        assert!(
+            err.to_string().contains("RuntimeUpdate"),
+            "Expected the actual servicing type value in the error, got: {err}"
+        );
     }
 
     /// Helper: creates an ESP directory structure with UKI files and returns

--- a/crates/trident/src/engine/boot/uki.rs
+++ b/crates/trident/src/engine/boot/uki.rs
@@ -617,18 +617,17 @@ const FIRSTBOOT_ADDON_FILENAME: &str = "firstboot.addon.efi";
 /// a clean install, and never present in the staged addon directory for any
 /// other servicing type (AB-update, runtime update, rollback).
 ///
-/// `firstboot.addon.efi` may originate from either of two places on an ACL
-/// image's ESP:
-///   - `acl/uki-addons/firstboot.addon.efi` (the template library, alongside
-///     the verity-a/verity-b templates), or
-///   - the image's own live `<uki>.efi.extra.d/` directory, which
-///     `stage_uki_on_esp` already copies verbatim — ACL images ship this
-///     addon pre-populated there so a genuine first boot works out of the
-///     box without any activation step.
+/// `firstboot.addon.efi` is sourced *only* from the image's own live
+/// `<uki>.efi.extra.d/` directory, which `stage_uki_on_esp` already copies
+/// verbatim onto the target ESP before this function runs — ACL images ship
+/// this addon pre-populated there so a genuine first boot works out of the
+/// box without any activation step.
 ///
-/// On a clean install, either source is fine: if it's already staged (via
-/// the live `.extra.d/` copy) nothing further is needed; if only the
-/// template exists, it's copied in.
+/// Unlike the verity addon, it is intentionally never sourced from the
+/// `ACL_ADDON_TEMPLATES_DIR` template library, even for a clean install: if
+/// it's absent from the live directory, it stays absent — we never promote
+/// it in from the template. This avoids accidentally reintroducing it for
+/// an image variant that has deliberately dropped it from the live copy.
 ///
 /// On any other servicing type, the addon must NOT reach the target ESP:
 /// every ACL AB-update COSI is built from a never-booted image, so its live
@@ -650,7 +649,6 @@ const FIRSTBOOT_ADDON_FILENAME: &str = "firstboot.addon.efi";
 /// bool) so an unexpected value — which would indicate that invariant no
 /// longer holds — is a hard error instead of silently doing the wrong thing.
 pub(crate) fn enforce_firstboot_addon_policy(
-    image_esp_mount: &Path,
     mount_point: &Path,
     esp_mount_path: &Path,
     servicing_type: ServicingType,
@@ -663,57 +661,21 @@ pub(crate) fn enforce_firstboot_addon_policy(
         "enforce_firstboot_addon_policy called with unexpected servicing type \
          {servicing_type:?}; expected CleanInstall or AbUpdate"
     );
-    let is_clean_install = servicing_type == ServicingType::CleanInstall;
+
+    if servicing_type == ServicingType::CleanInstall {
+        // Nothing to do: if the addon is already staged (via
+        // stage_uki_on_esp's verbatim copy of the image's live .extra.d/),
+        // it's left as-is. If it's absent, it's never promoted in from the
+        // ACL_ADDON_TEMPLATES_DIR template library — see doc comment above.
+        return Ok(());
+    }
 
     let staging_addon_dir = join_relative(mount_point, esp_mount_path)
         .join(UKI_DIRECTORY)
         .join(TMP_UKI_ADDON_DIR_NAME);
     let staged_firstboot = staging_addon_dir.join(FIRSTBOOT_ADDON_FILENAME);
 
-    if is_clean_install {
-        if staged_firstboot.exists() {
-            // Already present via stage_uki_on_esp's verbatim copy of the
-            // image's live .extra.d/ directory. Nothing further to do.
-            trace!(
-                "'{FIRSTBOOT_ADDON_FILENAME}' already staged from the image's live addon \
-                 directory; leaving as-is for clean install"
-            );
-            return Ok(());
-        }
-
-        let template_path = image_esp_mount
-            .join(ACL_ADDON_TEMPLATES_DIR)
-            .join(FIRSTBOOT_ADDON_FILENAME);
-        if !template_path.exists() {
-            trace!(
-                "No '{FIRSTBOOT_ADDON_FILENAME}' found in the image's live addon directory or \
-                 in '{ACL_ADDON_TEMPLATES_DIR}'; nothing to activate for clean install"
-            );
-            return Ok(());
-        }
-
-        if !staging_addon_dir.exists() {
-            fs::create_dir_all(&staging_addon_dir).with_context(|| {
-                format!(
-                    "Failed to create staged addon directory '{}'",
-                    staging_addon_dir.display()
-                )
-            })?;
-        }
-
-        debug!(
-            "Activating firstboot addon for clean install: '{}' → '{}'",
-            template_path.display(),
-            staged_firstboot.display()
-        );
-        fs::copy(&template_path, &staged_firstboot).with_context(|| {
-            format!(
-                "Failed to copy firstboot addon template '{}' to '{}'",
-                template_path.display(),
-                staged_firstboot.display()
-            )
-        })?;
-    } else if staged_firstboot.exists() {
+    if staged_firstboot.exists() {
         // Every ACL AB-update COSI is built from a never-booted image, so
         // its live .extra.d/ directory still carries this addon even though
         // this is not a genuine first boot. Strip it so Ignition does not
@@ -1392,9 +1354,6 @@ mod tests {
     /// by stage_uki_on_esp from the image's live .extra.d/) is left as-is.
     #[test]
     fn test_enforce_firstboot_clean_install_already_staged() {
-        let image_esp = tempdir().unwrap();
-        // No template — simulates the addon arriving only via the live copy.
-
         let mount_point = tempdir().unwrap();
         prepare_esp_for_uki(mount_point.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap();
         let staged_addon_dir = join_relative(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH)
@@ -1408,7 +1367,6 @@ mod tests {
         .unwrap();
 
         enforce_firstboot_addon_policy(
-            image_esp.path(),
             mount_point.path(),
             Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
             ServicingType::CleanInstall,
@@ -1421,9 +1379,11 @@ mod tests {
         );
     }
 
-    /// Clean install: firstboot addon only in the template dir gets copied in.
+    /// Clean install: firstboot addon present only in the template dir is
+    /// intentionally NOT copied in — unlike the verity addon, this addon is
+    /// only ever sourced from the image's live .extra.d/ directory.
     #[test]
-    fn test_enforce_firstboot_clean_install_from_template() {
+    fn test_enforce_firstboot_clean_install_ignores_template() {
         let image_esp = tempdir().unwrap();
         let template_dir = image_esp.path().join(ACL_ADDON_TEMPLATES_DIR);
         fs::create_dir_all(&template_dir).unwrap();
@@ -1437,7 +1397,6 @@ mod tests {
         prepare_esp_for_uki(mount_point.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap();
 
         enforce_firstboot_addon_policy(
-            image_esp.path(),
             mount_point.path(),
             Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
             ServicingType::CleanInstall,
@@ -1447,21 +1406,16 @@ mod tests {
         let staged_addon_dir = join_relative(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH)
             .join(UKI_DIRECTORY)
             .join(TMP_UKI_ADDON_DIR_NAME);
-        assert_eq!(
-            fs::read(staged_addon_dir.join(FIRSTBOOT_ADDON_FILENAME)).unwrap(),
-            b"template-firstboot-content"
-        );
+        assert!(!staged_addon_dir.join(FIRSTBOOT_ADDON_FILENAME).exists());
     }
 
     /// Clean install: firstboot addon absent from both sources is a silent no-op.
     #[test]
     fn test_enforce_firstboot_clean_install_absent_everywhere() {
-        let image_esp = tempdir().unwrap();
         let mount_point = tempdir().unwrap();
         prepare_esp_for_uki(mount_point.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap();
 
         enforce_firstboot_addon_policy(
-            image_esp.path(),
             mount_point.path(),
             Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
             ServicingType::CleanInstall,
@@ -1479,8 +1433,6 @@ mod tests {
     /// the Ignition re-fetch hang on Azure AB-updates.
     #[test]
     fn test_enforce_firstboot_update_removes_staged_addon() {
-        let image_esp = tempdir().unwrap();
-
         let mount_point = tempdir().unwrap();
         prepare_esp_for_uki(mount_point.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap();
         let staged_addon_dir = join_relative(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH)
@@ -1496,7 +1448,6 @@ mod tests {
         fs::write(staged_addon_dir.join("oem.addon.efi"), b"oem-content").unwrap();
 
         enforce_firstboot_addon_policy(
-            image_esp.path(),
             mount_point.path(),
             Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
             ServicingType::AbUpdate,
@@ -1514,20 +1465,10 @@ mod tests {
     /// silent no-op (and the template, if any, is never consulted/copied).
     #[test]
     fn test_enforce_firstboot_update_no_op_when_absent() {
-        let image_esp = tempdir().unwrap();
-        let template_dir = image_esp.path().join(ACL_ADDON_TEMPLATES_DIR);
-        fs::create_dir_all(&template_dir).unwrap();
-        fs::write(
-            template_dir.join(FIRSTBOOT_ADDON_FILENAME),
-            b"template-firstboot-content",
-        )
-        .unwrap();
-
         let mount_point = tempdir().unwrap();
         prepare_esp_for_uki(mount_point.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap();
 
         enforce_firstboot_addon_policy(
-            image_esp.path(),
             mount_point.path(),
             Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
             ServicingType::AbUpdate,
@@ -1546,12 +1487,10 @@ mod tests {
     /// indicate that invariant no longer holds.
     #[test]
     fn test_enforce_firstboot_errors_on_unexpected_servicing_type() {
-        let image_esp = tempdir().unwrap();
         let mount_point = tempdir().unwrap();
         prepare_esp_for_uki(mount_point.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap();
 
         let err = enforce_firstboot_addon_policy(
-            image_esp.path(),
             mount_point.path(),
             Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
             ServicingType::RuntimeUpdate,

--- a/crates/trident/src/engine/boot/uki.rs
+++ b/crates/trident/src/engine/boot/uki.rs
@@ -19,7 +19,7 @@ use trident_api::{
         AB_VOLUME_A_NAME, AB_VOLUME_B_NAME, AZURE_LINUX_INSTALL_ID_PREFIX, ESP_EFI_DIRECTORY,
     },
     error::{InternalError, ReportError, ServicingError, TridentError, TridentResultExt},
-    status::AbVolumeSelection,
+    status::{AbVolumeSelection, ServicingType},
 };
 
 use crate::engine::EngineContext;
@@ -641,12 +641,31 @@ const FIRSTBOOT_ADDON_FILENAME: &str = "firstboot.addon.efi";
 /// This is ACL-specific; callers gate on `ctx.image_distro().is_acl()`,
 /// matching the verity addon's existing convention — non-ACL images never
 /// reach this function.
+///
+/// Only reachable for `ServicingType::CleanInstall` or `ServicingType::AbUpdate`:
+/// `EspSubsystem` doesn't override `Subsystem::runs_on()`, so it inherits
+/// the default `REQUIRES_REBOOT` list (`[CleanInstall, AbUpdate]`) — no
+/// other servicing type ever reaches `copy_file_artifacts`, and thus this
+/// function. Takes the servicing type directly (rather than a pre-computed
+/// bool) so an unexpected value — which would indicate that invariant no
+/// longer holds — is a hard error instead of silently doing the wrong thing.
 pub(crate) fn enforce_firstboot_addon_policy(
     image_esp_mount: &Path,
     mount_point: &Path,
     esp_mount_path: &Path,
-    is_clean_install: bool,
+    servicing_type: ServicingType,
 ) -> Result<(), Error> {
+    let is_clean_install = match servicing_type {
+        ServicingType::CleanInstall => true,
+        ServicingType::AbUpdate => false,
+        other => {
+            return Err(anyhow!(
+                "enforce_firstboot_addon_policy called with unexpected servicing type \
+                 {other:?}; expected CleanInstall or AbUpdate"
+            ))
+        }
+    };
+
     let staging_addon_dir = join_relative(mount_point, esp_mount_path)
         .join(UKI_DIRECTORY)
         .join(TMP_UKI_ADDON_DIR_NAME);
@@ -1393,7 +1412,7 @@ mod tests {
             image_esp.path(),
             mount_point.path(),
             Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
-            true,
+            ServicingType::CleanInstall,
         )
         .unwrap();
 
@@ -1422,7 +1441,7 @@ mod tests {
             image_esp.path(),
             mount_point.path(),
             Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
-            true,
+            ServicingType::CleanInstall,
         )
         .unwrap();
 
@@ -1446,7 +1465,7 @@ mod tests {
             image_esp.path(),
             mount_point.path(),
             Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
-            true,
+            ServicingType::CleanInstall,
         )
         .unwrap();
 
@@ -1481,7 +1500,7 @@ mod tests {
             image_esp.path(),
             mount_point.path(),
             Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
-            false,
+            ServicingType::AbUpdate,
         )
         .unwrap();
 
@@ -1512,7 +1531,7 @@ mod tests {
             image_esp.path(),
             mount_point.path(),
             Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
-            false,
+            ServicingType::AbUpdate,
         )
         .unwrap();
 

--- a/crates/trident/src/engine/boot/uki.rs
+++ b/crates/trident/src/engine/boot/uki.rs
@@ -529,8 +529,10 @@ pub fn find_previous_uki(esp_dir_path: &Path) -> Result<PathBuf, TridentError> {
     }
 }
 
-/// Path within the image ESP where ACL stores verity addon templates for A/B slots.
-const VERITY_ADDON_TEMPLATES_DIR: &str = "acl/uki-addons";
+/// Path within the image ESP where ACL stores addon templates shared across
+/// servicing scenarios: per-slot verity addons (`verity-a`/`verity-b`) and
+/// the first-boot addon (see `enforce_firstboot_addon_policy`).
+const ACL_ADDON_TEMPLATES_DIR: &str = "acl/uki-addons";
 
 /// Filename of the active verity addon placed in the UKI's `.extra.d/` directory.
 const VERITY_ADDON_FILENAME: &str = "verity.addon.efi";
@@ -549,7 +551,7 @@ pub fn activate_verity_addon_for_target_volume(
     esp_mount_path: &Path,
     target_volume: AbVolumeSelection,
 ) -> Result<(), Error> {
-    let template_dir = image_esp_mount.join(VERITY_ADDON_TEMPLATES_DIR);
+    let template_dir = image_esp_mount.join(ACL_ADDON_TEMPLATES_DIR);
     if !template_dir.exists() {
         // Image does not use PARTUUID-based verity addons (non-ACL or older ACL).
         trace!(
@@ -662,12 +664,12 @@ pub(crate) fn enforce_firstboot_addon_policy(
         }
 
         let template_path = image_esp_mount
-            .join(VERITY_ADDON_TEMPLATES_DIR)
+            .join(ACL_ADDON_TEMPLATES_DIR)
             .join(FIRSTBOOT_ADDON_FILENAME);
         if !template_path.exists() {
             trace!(
                 "No '{FIRSTBOOT_ADDON_FILENAME}' found in the image's live addon directory or \
-                 in '{VERITY_ADDON_TEMPLATES_DIR}'; nothing to activate for clean install"
+                 in '{ACL_ADDON_TEMPLATES_DIR}'; nothing to activate for clean install"
             );
             return Ok(());
         }
@@ -1180,7 +1182,7 @@ mod tests {
 
     /// Helper: creates a mock image ESP with verity addon templates.
     fn setup_image_with_verity_templates(image_esp: &Path) -> (PathBuf, PathBuf) {
-        let template_dir = image_esp.join(VERITY_ADDON_TEMPLATES_DIR);
+        let template_dir = image_esp.join(ACL_ADDON_TEMPLATES_DIR);
         fs::create_dir_all(&template_dir).unwrap();
         let a_path = template_dir.join("verity-a.addon.efi");
         let b_path = template_dir.join("verity-b.addon.efi");
@@ -1273,7 +1275,7 @@ mod tests {
     #[test]
     fn test_activate_verity_addon_missing_selected_template() {
         let image_esp = tempdir().unwrap();
-        let template_dir = image_esp.path().join(VERITY_ADDON_TEMPLATES_DIR);
+        let template_dir = image_esp.path().join(ACL_ADDON_TEMPLATES_DIR);
         fs::create_dir_all(&template_dir).unwrap();
         // Only write verity-a, not verity-b
         fs::write(template_dir.join("verity-a.addon.efi"), b"a-content").unwrap();
@@ -1405,7 +1407,7 @@ mod tests {
     #[test]
     fn test_enforce_firstboot_clean_install_from_template() {
         let image_esp = tempdir().unwrap();
-        let template_dir = image_esp.path().join(VERITY_ADDON_TEMPLATES_DIR);
+        let template_dir = image_esp.path().join(ACL_ADDON_TEMPLATES_DIR);
         fs::create_dir_all(&template_dir).unwrap();
         fs::write(
             template_dir.join(FIRSTBOOT_ADDON_FILENAME),
@@ -1495,7 +1497,7 @@ mod tests {
     #[test]
     fn test_enforce_firstboot_update_no_op_when_absent() {
         let image_esp = tempdir().unwrap();
-        let template_dir = image_esp.path().join(VERITY_ADDON_TEMPLATES_DIR);
+        let template_dir = image_esp.path().join(ACL_ADDON_TEMPLATES_DIR);
         fs::create_dir_all(&template_dir).unwrap();
         fs::write(
             template_dir.join(FIRSTBOOT_ADDON_FILENAME),

--- a/crates/trident/src/engine/boot/uki.rs
+++ b/crates/trident/src/engine/boot/uki.rs
@@ -604,6 +604,115 @@ pub fn activate_verity_addon_for_target_volume(
     Ok(())
 }
 
+/// Filename of the ACL first-boot UKI addon. Adds `flatcar.first_boot=detected`
+/// to the kernel cmdline (systemd-boot auto-discovers it alongside the UKI),
+/// which triggers Ignition to run. See `ignition-quench.service` (patched
+/// into the `bootengine` package) for the corresponding cleanup after a
+/// genuine first boot.
+const FIRSTBOOT_ADDON_FILENAME: &str = "firstboot.addon.efi";
+
+/// ACL-specific: enforces that the first-boot UKI addon is present only for
+/// a clean install, and never present in the staged addon directory for any
+/// other servicing type (AB-update, runtime update, rollback).
+///
+/// `firstboot.addon.efi` may originate from either of two places on an ACL
+/// image's ESP:
+///   - `acl/uki-addons/firstboot.addon.efi` (the template library, alongside
+///     the verity-a/verity-b templates), or
+///   - the image's own live `<uki>.efi.extra.d/` directory, which
+///     `stage_uki_on_esp` already copies verbatim — ACL images ship this
+///     addon pre-populated there so a genuine first boot works out of the
+///     box without any activation step.
+///
+/// On a clean install, either source is fine: if it's already staged (via
+/// the live `.extra.d/` copy) nothing further is needed; if only the
+/// template exists, it's copied in.
+///
+/// On any other servicing type, the addon must NOT reach the target ESP:
+/// every ACL AB-update COSI is built from a never-booted image, so its live
+/// `.extra.d/` directory (already staged by `stage_uki_on_esp` before this
+/// function runs) still carries this addon regardless of whether this is
+/// truly a first boot. Left unremoved, it reintroduces
+/// `flatcar.first_boot=detected` on every update, hanging
+/// `ignition-fetch.service` after the post-update reboot.
+///
+/// This is ACL-specific; callers gate on `ctx.image_distro().is_acl()`,
+/// matching the verity addon's existing convention — non-ACL images never
+/// reach this function.
+pub fn enforce_firstboot_addon_policy(
+    image_esp_mount: &Path,
+    mount_point: &Path,
+    esp_mount_path: &Path,
+    is_clean_install: bool,
+) -> Result<(), Error> {
+    let staging_addon_dir = join_relative(mount_point, esp_mount_path)
+        .join(UKI_DIRECTORY)
+        .join(TMP_UKI_ADDON_DIR_NAME);
+    let staged_firstboot = staging_addon_dir.join(FIRSTBOOT_ADDON_FILENAME);
+
+    if is_clean_install {
+        if staged_firstboot.exists() {
+            // Already present via stage_uki_on_esp's verbatim copy of the
+            // image's live .extra.d/ directory. Nothing further to do.
+            trace!(
+                "'{FIRSTBOOT_ADDON_FILENAME}' already staged from the image's live addon \
+                 directory; leaving as-is for clean install"
+            );
+            return Ok(());
+        }
+
+        let template_path = image_esp_mount
+            .join(VERITY_ADDON_TEMPLATES_DIR)
+            .join(FIRSTBOOT_ADDON_FILENAME);
+        if !template_path.exists() {
+            trace!(
+                "No '{FIRSTBOOT_ADDON_FILENAME}' found in the image's live addon directory or \
+                 in '{VERITY_ADDON_TEMPLATES_DIR}'; nothing to activate for clean install"
+            );
+            return Ok(());
+        }
+
+        if !staging_addon_dir.exists() {
+            fs::create_dir_all(&staging_addon_dir).with_context(|| {
+                format!(
+                    "Failed to create staged addon directory '{}'",
+                    staging_addon_dir.display()
+                )
+            })?;
+        }
+
+        debug!(
+            "Activating firstboot addon for clean install: '{}' → '{}'",
+            template_path.display(),
+            staged_firstboot.display()
+        );
+        fs::copy(&template_path, &staged_firstboot).with_context(|| {
+            format!(
+                "Failed to copy firstboot addon template '{}' to '{}'",
+                template_path.display(),
+                staged_firstboot.display()
+            )
+        })?;
+    } else if staged_firstboot.exists() {
+        // Every ACL AB-update COSI is built from a never-booted image, so
+        // its live .extra.d/ directory still carries this addon even though
+        // this is not a genuine first boot. Strip it so Ignition does not
+        // re-trigger and hang on the post-update reboot.
+        debug!(
+            "Removing '{}' from staged addon directory — not a clean install",
+            staged_firstboot.display()
+        );
+        fs::remove_file(&staged_firstboot).with_context(|| {
+            format!(
+                "Failed to remove firstboot addon '{}' for a non-clean-install servicing type",
+                staged_firstboot.display()
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
 /// Construct the previous UKI filename and set it as the default boot entry.
 pub fn use_previous_uki_as_default(esp_dir_path: &Path) -> Result<(), TridentError> {
     let previous_uki_entry_path = find_previous_uki(esp_dir_path)?;
@@ -1255,6 +1364,160 @@ mod tests {
             fs::read(staged_addon_dir.join("firstboot.addon.efi")).unwrap(),
             b"firstboot-data"
         );
+    }
+
+    // ── enforce_firstboot_addon_policy tests ────────────────────────────────
+
+    /// Clean install: firstboot addon already staged (as if copied verbatim
+    /// by stage_uki_on_esp from the image's live .extra.d/) is left as-is.
+    #[test]
+    fn test_enforce_firstboot_clean_install_already_staged() {
+        let image_esp = tempdir().unwrap();
+        // No template — simulates the addon arriving only via the live copy.
+
+        let mount_point = tempdir().unwrap();
+        prepare_esp_for_uki(mount_point.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap();
+        let staged_addon_dir = join_relative(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH)
+            .join(UKI_DIRECTORY)
+            .join(TMP_UKI_ADDON_DIR_NAME);
+        fs::create_dir_all(&staged_addon_dir).unwrap();
+        fs::write(
+            staged_addon_dir.join(FIRSTBOOT_ADDON_FILENAME),
+            b"live-firstboot-content",
+        )
+        .unwrap();
+
+        enforce_firstboot_addon_policy(
+            image_esp.path(),
+            mount_point.path(),
+            Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read(staged_addon_dir.join(FIRSTBOOT_ADDON_FILENAME)).unwrap(),
+            b"live-firstboot-content"
+        );
+    }
+
+    /// Clean install: firstboot addon only in the template dir gets copied in.
+    #[test]
+    fn test_enforce_firstboot_clean_install_from_template() {
+        let image_esp = tempdir().unwrap();
+        let template_dir = image_esp.path().join(VERITY_ADDON_TEMPLATES_DIR);
+        fs::create_dir_all(&template_dir).unwrap();
+        fs::write(
+            template_dir.join(FIRSTBOOT_ADDON_FILENAME),
+            b"template-firstboot-content",
+        )
+        .unwrap();
+
+        let mount_point = tempdir().unwrap();
+        prepare_esp_for_uki(mount_point.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap();
+
+        enforce_firstboot_addon_policy(
+            image_esp.path(),
+            mount_point.path(),
+            Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
+            true,
+        )
+        .unwrap();
+
+        let staged_addon_dir = join_relative(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH)
+            .join(UKI_DIRECTORY)
+            .join(TMP_UKI_ADDON_DIR_NAME);
+        assert_eq!(
+            fs::read(staged_addon_dir.join(FIRSTBOOT_ADDON_FILENAME)).unwrap(),
+            b"template-firstboot-content"
+        );
+    }
+
+    /// Clean install: firstboot addon absent from both sources is a silent no-op.
+    #[test]
+    fn test_enforce_firstboot_clean_install_absent_everywhere() {
+        let image_esp = tempdir().unwrap();
+        let mount_point = tempdir().unwrap();
+        prepare_esp_for_uki(mount_point.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap();
+
+        enforce_firstboot_addon_policy(
+            image_esp.path(),
+            mount_point.path(),
+            Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
+            true,
+        )
+        .unwrap();
+
+        let staged_addon_dir = join_relative(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH)
+            .join(UKI_DIRECTORY)
+            .join(TMP_UKI_ADDON_DIR_NAME);
+        assert!(!staged_addon_dir.join(FIRSTBOOT_ADDON_FILENAME).exists());
+    }
+
+    /// Not a clean install (AB-update): firstboot addon staged verbatim from
+    /// the image's live .extra.d/ is removed — this is the actual fix for
+    /// the Ignition re-fetch hang on Azure AB-updates.
+    #[test]
+    fn test_enforce_firstboot_update_removes_staged_addon() {
+        let image_esp = tempdir().unwrap();
+
+        let mount_point = tempdir().unwrap();
+        prepare_esp_for_uki(mount_point.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap();
+        let staged_addon_dir = join_relative(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH)
+            .join(UKI_DIRECTORY)
+            .join(TMP_UKI_ADDON_DIR_NAME);
+        fs::create_dir_all(&staged_addon_dir).unwrap();
+        fs::write(
+            staged_addon_dir.join(FIRSTBOOT_ADDON_FILENAME),
+            b"live-firstboot-content",
+        )
+        .unwrap();
+        // Another addon that must be preserved.
+        fs::write(staged_addon_dir.join("oem.addon.efi"), b"oem-content").unwrap();
+
+        enforce_firstboot_addon_policy(
+            image_esp.path(),
+            mount_point.path(),
+            Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
+            false,
+        )
+        .unwrap();
+
+        assert!(!staged_addon_dir.join(FIRSTBOOT_ADDON_FILENAME).exists());
+        assert_eq!(
+            fs::read(staged_addon_dir.join("oem.addon.efi")).unwrap(),
+            b"oem-content"
+        );
+    }
+
+    /// Not a clean install: firstboot addon absent from the staged dir is a
+    /// silent no-op (and the template, if any, is never consulted/copied).
+    #[test]
+    fn test_enforce_firstboot_update_no_op_when_absent() {
+        let image_esp = tempdir().unwrap();
+        let template_dir = image_esp.path().join(VERITY_ADDON_TEMPLATES_DIR);
+        fs::create_dir_all(&template_dir).unwrap();
+        fs::write(
+            template_dir.join(FIRSTBOOT_ADDON_FILENAME),
+            b"template-firstboot-content",
+        )
+        .unwrap();
+
+        let mount_point = tempdir().unwrap();
+        prepare_esp_for_uki(mount_point.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap();
+
+        enforce_firstboot_addon_policy(
+            image_esp.path(),
+            mount_point.path(),
+            Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
+            false,
+        )
+        .unwrap();
+
+        let staged_addon_dir = join_relative(mount_point.path(), DEFAULT_ESP_MOUNT_POINT_PATH)
+            .join(UKI_DIRECTORY)
+            .join(TMP_UKI_ADDON_DIR_NAME);
+        assert!(!staged_addon_dir.join(FIRSTBOOT_ADDON_FILENAME).exists());
     }
 
     /// Helper: creates an ESP directory structure with UKI files and returns

--- a/crates/trident/src/engine/boot/uki.rs
+++ b/crates/trident/src/engine/boot/uki.rs
@@ -1540,6 +1540,30 @@ mod tests {
         assert!(!staged_addon_dir.join(FIRSTBOOT_ADDON_FILENAME).exists());
     }
 
+    /// Any servicing type other than CleanInstall/AbUpdate is a hard error:
+    /// this function is only ever reachable for those two (EspSubsystem
+    /// inherits the default REQUIRES_REBOOT gate), so any other value would
+    /// indicate that invariant no longer holds.
+    #[test]
+    fn test_enforce_firstboot_errors_on_unexpected_servicing_type() {
+        let image_esp = tempdir().unwrap();
+        let mount_point = tempdir().unwrap();
+        prepare_esp_for_uki(mount_point.path(), Path::new(DEFAULT_ESP_MOUNT_POINT_PATH)).unwrap();
+
+        let err = enforce_firstboot_addon_policy(
+            image_esp.path(),
+            mount_point.path(),
+            Path::new(DEFAULT_ESP_MOUNT_POINT_PATH),
+            ServicingType::RuntimeUpdate,
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("unexpected servicing type"),
+            "Expected 'unexpected servicing type' error, got: {err}"
+        );
+    }
+
     /// Helper: creates an ESP directory structure with UKI files and returns
     /// the mock root mount point (tempdir) and the UKI directory path.
     fn setup_esp_for_cleanup(ukis: &[&str]) -> (tempfile::TempDir, PathBuf) {

--- a/crates/trident/src/subsystems/esp.rs
+++ b/crates/trident/src/subsystems/esp.rs
@@ -325,7 +325,7 @@ fn copy_file_artifacts(
                     temp_mount_dir,
                     mount_point,
                     &ctx.esp_mount_path,
-                    ctx.servicing_type == ServicingType::CleanInstall,
+                    ctx.servicing_type,
                 )?;
             }
         }

--- a/crates/trident/src/subsystems/esp.rs
+++ b/crates/trident/src/subsystems/esp.rs
@@ -322,7 +322,6 @@ fn copy_file_artifacts(
                 // so Ignition doesn't re-trigger and hang on the post-update
                 // reboot.
                 uki::enforce_firstboot_addon_policy(
-                    temp_mount_dir,
                     mount_point,
                     &ctx.esp_mount_path,
                     ctx.servicing_type,

--- a/crates/trident/src/subsystems/esp.rs
+++ b/crates/trident/src/subsystems/esp.rs
@@ -317,9 +317,9 @@ fn copy_file_artifacts(
                 // stage_uki_on_esp) so a genuine first boot works out of the
                 // box. But every ACL AB-update COSI is built from a
                 // never-booted image, so that addon is still present even
-                // when this is not actually a first boot. Enforce it's only
-                // ever staged for a clean install; strip it otherwise so
-                // Ignition doesn't re-trigger and hang on the post-update
+                // when this is not actually a first boot. Enforce that it's
+                // only ever staged for a clean install; strip it otherwise
+                // so Ignition doesn't re-trigger and hang on the post-update
                 // reboot.
                 uki::enforce_firstboot_addon_policy(
                     temp_mount_dir,

--- a/crates/trident/src/subsystems/esp.rs
+++ b/crates/trident/src/subsystems/esp.rs
@@ -311,6 +311,22 @@ fn copy_file_artifacts(
                     &ctx.esp_mount_path,
                     target_volume,
                 )?;
+
+                // ACL images ship the first-boot addon pre-populated in the
+                // image's live .extra.d/ (already staged verbatim above by
+                // stage_uki_on_esp) so a genuine first boot works out of the
+                // box. But every ACL AB-update COSI is built from a
+                // never-booted image, so that addon is still present even
+                // when this is not actually a first boot. Enforce it's only
+                // ever staged for a clean install; strip it otherwise so
+                // Ignition doesn't re-trigger and hang on the post-update
+                // reboot.
+                uki::enforce_firstboot_addon_policy(
+                    temp_mount_dir,
+                    mount_point,
+                    &ctx.esp_mount_path,
+                    ctx.servicing_type == ServicingType::CleanInstall,
+                )?;
             }
         }
     } else {


### PR DESCRIPTION
# 🔍 Description

ACL AB-update COSI payloads are typically built from a VHD that may (for Azure) be configured via <uki>.efi.extra.d/firstboot.addon.efi to treat the next boot as the first boot. COSI files can be used for install or update, so trident must choose when to apply firstboot.addon.efi in the target OS according to whether install or update is invoked.

`enforce_firstboot_addon_policy(...)`: 
* ACL-specific
* on a clean install, leaves the addon as staged (or copies it from the acl/uki-addons/ template if only present there)
* on any other servicing type, removes it from the staged addon directory if present

Trident validation: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1169144&view=results
ACL validation: https://dev.azure.com/mariner-org/ACL/_build/results?buildId=1169180&view=results