### PR TITLE
trident-acl-agent: add --validate-connection

### DIFF
--- a/crates/trident-acl-agent/src/k8s.rs
+++ b/crates/trident-acl-agent/src/k8s.rs
@@ -41,16 +41,27 @@ pub enum K8sClientError {
 pub struct NodeClient {
     api: Api<Node>,
     poll_interval: std::time::Duration,
+    cluster_url: String,
 }
 
 impl NodeClient {
     pub async fn new(config: &KubernetesConfig) -> Result<Self, K8sClientError> {
         let client_config = load_client_config(config).await?;
+        let cluster_url = client_config.cluster_url.to_string();
         let client = Client::try_from(client_config).map_err(anyhow::Error::new)?;
         Ok(Self {
             api: Api::all(client),
             poll_interval: config.watch_poll_interval,
+            cluster_url,
         })
+    }
+
+    /// The API server URL this client actually connects to - resolved from
+    /// `kubernetes.kubeconfig`'s own server, unless overridden by
+    /// `kubernetes.api_server`. Useful for diagnostics/logging that want to
+    /// report the real effective server rather than guessing from config.
+    pub fn cluster_url(&self) -> &str {
+        &self.cluster_url
     }
 
     pub async fn get_node(&self, name: &str) -> Result<Node, K8sClientError> {

--- a/crates/trident-acl-agent/src/lib.rs
+++ b/crates/trident-acl-agent/src/lib.rs
@@ -108,6 +108,27 @@ pub async fn run_omaha_only(config: &config::AgentConfig) -> Result<(), anyhow::
     }
 }
 
+/// Checks that the Omaha/Nebraska server at `url` is reachable and speaking
+/// the Omaha protocol, without treating any app-level result (including a
+/// non-OK app/update-check status) as a failure. Unlike [`query_for_update`],
+/// this only fails on network/transport problems or a response that isn't
+/// well-formed Omaha XML -- it's meant for a pure "can we talk to this
+/// server at all" check (e.g. `--validate-connection nebraska`), not for
+/// deciding whether an update is available.
+pub fn check_nebraska_reachable(
+    url: &Url,
+    app_id: &str,
+    track: &str,
+    machine_id_source: IdSource,
+) -> Result<(), HarpoonError> {
+    let request = Request::default().with_app(
+        AppRequest::new(app_id, Version::new(0, 0, 0), track, machine_id_source)?
+            .with_update_check(),
+    );
+    omaha::send(url, &request)?;
+    Ok(())
+}
+
 /// Query the Omaha server at the given URL for the given app and track.
 pub fn query_for_update(
     url: &Url,
@@ -469,5 +490,52 @@ mod tests {
 
         omaha_mock.assert();
         assert!(matches!(response.result, QueryResult::NoUpdate));
+    }
+
+    #[test]
+    fn test_check_nebraska_reachable_succeeds_on_error_app_status() {
+        // check_nebraska_reachable() is meant to be a pure "can we reach
+        // this server and does it speak Omaha" check, unlike
+        // query_for_update() which also validates app-level semantics. A
+        // well-formed response with a non-OK app status should still count
+        // as "reachable" here, even though query_for_update() would reject
+        // the same response as a QueryError.
+        let mut server = mockito::Server::new();
+
+        let omaha_mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .match_body(Matcher::Regex(".*<updatecheck.*".to_string()))
+            .with_body(indoc::indoc! {r#"
+                <?xml version="1.0" encoding="UTF-8"?>
+                <response protocol="3.0" server="mock">
+                    <daystart elapsed_seconds="0"/>
+                    <app appid="test" status="error-unknownApplication">
+                        <updatecheck status="error-internal"><urls></urls></updatecheck>
+                    </app>
+                </response>"#})
+            .expect(2)
+            .create();
+
+        check_nebraska_reachable(
+            &Url::parse(&server.url()).unwrap(),
+            "test",
+            "track",
+            IdSource::MachineIdHashed,
+        )
+        .unwrap();
+
+        // Confirm the same response *would* be rejected by query_for_update(),
+        // to document the intentional behavior difference.
+        assert!(query_for_update(
+            &Url::parse(&server.url()).unwrap(),
+            "test",
+            "track",
+            &Version::new(0, 1, 0),
+            IdSource::MachineIdHashed,
+        )
+        .is_err());
+
+        omaha_mock.assert();
     }
 }

--- a/crates/trident-acl-agent/src/main.rs
+++ b/crates/trident-acl-agent/src/main.rs
@@ -1,12 +1,16 @@
 use std::path::PathBuf;
 
+use anyhow::Context;
 use clap::Parser;
 use log::{LevelFilter, Log, Metadata, Record};
 
 use trident_acl_agent::{
     config::{AgentConfig, GoalSource, DEFAULT_CONFIG_PATH},
+    k8s::NodeClient,
     orchestrator::Orchestrator,
-    run_omaha_only,
+    query_for_update, run_omaha_only,
+    trident::TridentClient,
+    IdSource, DEFAULT_NEBRASKA_TRACK,
 };
 
 /// Module/target prefixes for the underlying HTTP/gRPC/watch client stack.
@@ -91,6 +95,103 @@ struct Args {
     /// clear error.
     #[arg()]
     url: Option<url::Url>,
+
+    /// Validate connectivity to a single dependency and exit immediately,
+    /// instead of running the agent. Useful for troubleshooting one
+    /// connection in isolation (e.g. a systemd ExecStartPre check, or manual
+    /// diagnostics on-node) without running the full orchestrator loop.
+    /// Exits with status 0 if the connection could be established, non-zero
+    /// (with an error message) otherwise.
+    #[arg(long, value_enum)]
+    validate_connection: Option<ConnectionTarget>,
+}
+
+/// A single dependency `--validate-connection` can check.
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+enum ConnectionTarget {
+    /// Validates reachability of the Kubernetes API server by fetching this
+    /// node's own Node object (the same access the agent's reconcile loop
+    /// already requires).
+    Kubernetes,
+    /// Validates reachability of tridentd by connecting to its gRPC Unix
+    /// socket. Connecting is sufficient - no RPC call is needed, since the
+    /// connection itself fails immediately if nothing is listening.
+    Tridentd,
+    /// Validates reachability of the Nebraska/Omaha server by issuing a real
+    /// update-check query. Any well-formed Omaha response (including "no
+    /// update available") counts as success - only a network/transport
+    /// failure is treated as unreachable.
+    Nebraska,
+}
+
+/// Checks connectivity to exactly one of `target`'s dependencies and returns
+/// `Ok(())` on success. The caller (`main`) surfaces any `Err` the normal way
+/// (`anyhow`'s `Termination` impl prints the error and exits non-zero), so
+/// this function only needs to produce a descriptive error on failure - no
+/// explicit `process::exit` is required.
+async fn validate_connection(
+    target: ConnectionTarget,
+    config: &AgentConfig,
+) -> Result<(), anyhow::Error> {
+    match target {
+        ConnectionTarget::Kubernetes => {
+            let client = NodeClient::new(&config.kubernetes)
+                .await
+                .context("failed to build Kubernetes client")?;
+            client
+                .get_node(&config.kubernetes.node_name)
+                .await
+                .with_context(|| {
+                    format!(
+                        "failed to reach Kubernetes API server at {} (get Node {:?})",
+                        config.kubernetes.api_server, config.kubernetes.node_name
+                    )
+                })?;
+            log::info!(
+                "kubernetes: reached API server at {} and fetched Node {:?}",
+                config.kubernetes.api_server,
+                config.kubernetes.node_name
+            );
+        }
+        ConnectionTarget::Tridentd => {
+            TridentClient::connect(&config.trident.socket)
+                .await
+                .with_context(|| {
+                    format!("failed to reach tridentd at {}", config.trident.socket)
+                })?;
+            log::info!("tridentd: connected to {}", config.trident.socket);
+        }
+        ConnectionTarget::Nebraska => {
+            let endpoint = config.nebraska.endpoint.clone().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "nebraska.endpoint is not configured (set [nebraska].endpoint in config.toml, or pass a URL on the CLI)"
+                )
+            })?;
+            let app_id = config.nebraska.app_id.clone();
+            // query_for_update() is a blocking call (reqwest::blocking under
+            // the hood, see omaha::send) - calling it directly from this
+            // async fn can panic ("Cannot drop a runtime in a context where
+            // blocking is not allowed") because reqwest::blocking spins up
+            // its own inner Tokio runtime per call, which isn't safe to tear
+            // down from inside an already-running async task. Run it on a
+            // dedicated blocking thread instead.
+            let endpoint_for_task = endpoint.clone();
+            tokio::task::spawn_blocking(move || {
+                query_for_update(
+                    &endpoint_for_task,
+                    &app_id,
+                    DEFAULT_NEBRASKA_TRACK,
+                    &semver::Version::new(0, 0, 0),
+                    IdSource::MachineIdHashed,
+                )
+            })
+            .await
+            .context("Nebraska connectivity check task panicked")?
+            .with_context(|| format!("failed to reach Nebraska server at {endpoint}"))?;
+            log::info!("nebraska: reached server at {endpoint}");
+        }
+    }
+    Ok(())
 }
 
 #[tokio::main]
@@ -130,6 +231,10 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let config = AgentConfig::load(&config_path, explicit_config)?.unwrap_or_default();
     let config = config.with_cli_endpoint(args.url.clone());
+
+    if let Some(target) = args.validate_connection {
+        return validate_connection(target, &config).await;
+    }
 
     match config.orchestration.goal_source {
         // Historical one-shot flow: query Nebraska once, apply an update if

--- a/crates/trident-acl-agent/src/main.rs
+++ b/crates/trident-acl-agent/src/main.rs
@@ -5,10 +5,11 @@ use clap::Parser;
 use log::{LevelFilter, Log, Metadata, Record};
 
 use trident_acl_agent::{
+    check_nebraska_reachable,
     config::{AgentConfig, GoalSource, DEFAULT_CONFIG_PATH},
     k8s::NodeClient,
     orchestrator::Orchestrator,
-    query_for_update, run_omaha_only,
+    run_omaha_only,
     trident::TridentClient,
     IdSource, DEFAULT_NEBRASKA_TRACK,
 };
@@ -91,8 +92,8 @@ struct Args {
     config: Option<PathBuf>,
 
     /// Optional Omaha/Nebraska URL override. When omitted, Harpoon uses the
-    /// endpoint from config.toml. When both are missing, startup fails with a
-    /// clear error.
+    /// endpoint from trident-acl-agent.conf. When both are missing, startup
+    /// fails with a clear error.
     #[arg()]
     url: Option<url::Url>,
 
@@ -164,24 +165,30 @@ async fn validate_connection(
         ConnectionTarget::Nebraska => {
             let endpoint = config.nebraska.endpoint.clone().ok_or_else(|| {
                 anyhow::anyhow!(
-                    "nebraska.endpoint is not configured (set [nebraska].endpoint in config.toml, or pass a URL on the CLI)"
+                    "nebraska.endpoint is not configured (set [nebraska].endpoint in trident-acl-agent.conf, or pass a URL on the CLI)"
                 )
             })?;
             let app_id = config.nebraska.app_id.clone();
-            // query_for_update() is a blocking call (reqwest::blocking under
-            // the hood, see omaha::send) - calling it directly from this
+            // check_nebraska_reachable() is a blocking call (reqwest::blocking
+            // under the hood, see omaha::send) - calling it directly from this
             // async fn can panic ("Cannot drop a runtime in a context where
             // blocking is not allowed") because reqwest::blocking spins up
             // its own inner Tokio runtime per call, which isn't safe to tear
             // down from inside an already-running async task. Run it on a
             // dedicated blocking thread instead.
+            //
+            // Deliberately uses check_nebraska_reachable() rather than
+            // query_for_update(): the latter also validates app-level
+            // semantics (app ID match, non-error app/update-check status),
+            // which would make this a "can we get a valid update check" test
+            // rather than the pure reachability check documented on
+            // ConnectionTarget::Nebraska above.
             let endpoint_for_task = endpoint.clone();
             tokio::task::spawn_blocking(move || {
-                query_for_update(
+                check_nebraska_reachable(
                     &endpoint_for_task,
                     &app_id,
                     DEFAULT_NEBRASKA_TRACK,
-                    &semver::Version::new(0, 0, 0),
                     IdSource::MachineIdHashed,
                 )
             })

--- a/crates/trident-acl-agent/src/main.rs
+++ b/crates/trident-acl-agent/src/main.rs
@@ -139,18 +139,23 @@ async fn validate_connection(
             let client = NodeClient::new(&config.kubernetes)
                 .await
                 .context("failed to build Kubernetes client")?;
+            // Report the actually-resolved server (kubeconfig's own server,
+            // unless overridden by kubernetes.api_server), not a value
+            // guessed from config - the two only match when an override is
+            // set.
+            let cluster_url = client.cluster_url();
             client
                 .get_node(&config.kubernetes.node_name)
                 .await
                 .with_context(|| {
                     format!(
                         "failed to reach Kubernetes API server at {} (get Node {:?})",
-                        config.kubernetes.api_server, config.kubernetes.node_name
+                        cluster_url, config.kubernetes.node_name
                     )
                 })?;
             log::info!(
                 "kubernetes: reached API server at {} and fetched Node {:?}",
-                config.kubernetes.api_server,
+                cluster_url,
                 config.kubernetes.node_name
             );
         }

--- a/crates/trident-acl-agent/src/main.rs
+++ b/crates/trident-acl-agent/src/main.rs
@@ -11,7 +11,7 @@ use trident_acl_agent::{
     orchestrator::Orchestrator,
     run_omaha_only,
     trident::TridentClient,
-    IdSource, DEFAULT_NEBRASKA_TRACK,
+    IdSource,
 };
 
 /// Module/target prefixes for the underlying HTTP/gRPC/watch client stack.
@@ -184,11 +184,12 @@ async fn validate_connection(
             // rather than the pure reachability check documented on
             // ConnectionTarget::Nebraska above.
             let endpoint_for_task = endpoint.clone();
+            let track = config.nebraska.track.clone();
             tokio::task::spawn_blocking(move || {
                 check_nebraska_reachable(
                     &endpoint_for_task,
                     &app_id,
-                    DEFAULT_NEBRASKA_TRACK,
+                    &track,
                     IdSource::MachineIdHashed,
                 )
             })


### PR DESCRIPTION
Add `--validate-connection <kubernetes|tridentd|nebraska>` CLI flag that checks reachability of exactly one service based on trident-acl-agent config and exits immediately (0 on success, non-zero with a descriptive error on failure), instead of running the agent. Useful for on-node troubleshooting or a systemd ExecStartPre-style check without invoking the full orchestrator loop.

Unclear if this should merge or not.