### PR TITLE
trident-selinux: avoid pulling in auditd via policycoreutils-python-utils

### DIFF
--- a/packaging/rpm/trident.spec
+++ b/packaging/rpm/trident.spec
@@ -177,6 +177,7 @@ BuildRequires:       selinux-policy-devel
 # is unrelated to loading a compiled SELinux policy module and is not needed here.
 Requires(post):      libselinux-utils
 Requires(post):      policycoreutils
+Requires(postun):    libselinux-utils
 Requires(postun):    policycoreutils
 
 %description selinux

--- a/packaging/rpm/trident.spec
+++ b/packaging/rpm/trident.spec
@@ -169,7 +169,15 @@ BuildArch:           noarch
 Requires:            selinux-policy-%{selinuxtype}
 Requires(post):      selinux-policy-%{selinuxtype}
 BuildRequires:       selinux-policy-devel
-%{?selinux_requires}
+# Explicit scriptlet-time deps for %%selinux_modules_install/%%selinux_modules_uninstall
+# (semodule, selinuxenabled, load_policy) used below. Deliberately NOT using the
+# %%{?selinux_requires} macro: on Azure Linux it also adds
+# Requires(post): policycoreutils-python-utils, which transitively pulls in the
+# full audit daemon package via audit-libs-python3/python3-audit. That package set
+# is unrelated to loading a compiled SELinux policy module and is not needed here.
+Requires(post):      libselinux-utils
+Requires(post):      policycoreutils
+Requires(postun):    policycoreutils
 
 %description selinux
 Custom SELinux policy module


### PR DESCRIPTION
trident-selinux used the `%{?selinux_requires}` macro, which adds `Requires(post): policycoreutils-python-utils` which requires `udit-libs-python3` which pulls in `Audit` and starts `auditd.service`.

`%{?selinux_requires_min}` would avoid this, but isn't supported by azl3.

Use equivalent:
```
Requires(post):      libselinux-utils
Requires(post):      policycoreutils
Requires(postun):    libselinux-utils
Requires(postun):    policycoreutils
```

## Validation

Locally build RPMs with change and install in container, judge whether auditd.service is enabled.

pr-e2e: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1177183&view=results

Ran container install with RPMs from above pipeline to validate as well.