### PR TITLE
packaging: add %license LICENSE to all subpackages

### DIFF
--- a/packaging/rpm/trident.spec
+++ b/packaging/rpm/trident.spec
@@ -82,6 +82,7 @@ Trident. This package provides the Trident tool
 and its dependencies for managing the lifecycle of Azure Linux hosts.
 
 %files
+%license LICENSE
 %{_bindir}/%{name}
 %dir /etc/%{name}
 %{_unitdir}/%{name}d.service
@@ -106,6 +107,7 @@ Requires:       %{name} = %{version}-%{release}
 Trident files for the provisioning OS
 
 %files provisioning
+%license LICENSE
 %{_unitdir}/%{name}-network.service
 
 %post provisioning
@@ -128,6 +130,7 @@ Conflicts:      %{name}-install-service
 Trident files for SystemD commit services
 
 %files service
+%license LICENSE
 %{_unitdir}/%{name}.service
 
 %post service
@@ -150,6 +153,7 @@ Conflicts:      %{name}-service
 Trident files for SystemD install service
 
 %files install-service
+%license LICENSE
 %{_unitdir}/%{name}-install.service
 
 %post install-service
@@ -184,6 +188,7 @@ Requires(postun):    policycoreutils
 Custom SELinux policy module
 
 %files selinux
+%license LICENSE
 %{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2
 %{_datadir}/selinux/devel/include/distributed/%{name}.if
 %ghost %verify(not md5 size mode mtime) %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
@@ -216,6 +221,7 @@ Statically defined .pcrlock files for PCR-based encryption. This is a workaround
 be removed once the fix is merged in AZL 4.0.
 
 %files static-pcrlock-files
+%license LICENSE
 %{_sharedstatedir}/pcrlock.d
 
 # ------------------------------------------------------------------------------
@@ -229,6 +235,7 @@ Requires:       %{name} = %{version}-%{release}
 The Trident ACL Agent triggers updates of ACL images.
 
 %files acl-agent
+%license LICENSE
 %{_bindir}/%{name}-acl-agent
 %endif
 


### PR DESCRIPTION
## What

Add `%license LICENSE` to every `%files` section in `packaging/rpm/trident.spec` — the main `trident` package and all subpackages (`provisioning`, `service`, `install-service`, `selinux`, `static-pcrlock-files`, `acl-agent`).

## Why

Packaging guidelines require each (sub)package to ship its license file via the `%license` directive rather than relying on the license only being present in the main package. This ensures the MIT `LICENSE` is installed alongside every produced RPM (under the license dir), which is important since the subpackages can be installed independently of the main package (e.g. `selinux`, `static-pcrlock-files`).

The top-level `LICENSE` file already exists in the source tree and is present in both build paths (the `%autosetup`-unpacked tarball for the Azure Linux distro build, and the in-tree checkout for the Trident repo build), so `%license LICENSE` resolves in both.

## Validation

- `rpmspec -P` parses cleanly on both build paths (with and without `rpm_ver` defined).
- 7 `%license LICENSE` entries, one per `%files` section.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>