### PR TITLE
spec: package LICENSE file with %license directive

### DIFF
--- a/packaging/docker/Dockerfile.azl
+++ b/packaging/docker/Dockerfile.azl
@@ -19,6 +19,7 @@ RUN tdnf install -y \
 WORKDIR /work
 
 COPY packaging/rpm/trident.spec .
+COPY LICENSE .
 COPY packaging ./packaging
 COPY bin/trident ./target/release/trident
 COPY bin/trident-acl-agent ./target/release/trident-acl-agent

--- a/packaging/docker/Dockerfile.full
+++ b/packaging/docker/Dockerfile.full
@@ -23,6 +23,7 @@ RUN tdnf install -y \
 WORKDIR /work
 
 COPY packaging/rpm/trident.spec .
+COPY LICENSE .
 COPY packaging ./packaging
 
 COPY .cargo/config.toml ./.cargo/config.toml

--- a/packaging/docker/Dockerfile.full.public
+++ b/packaging/docker/Dockerfile.full.public
@@ -12,6 +12,7 @@ RUN tdnf install -y rpmdevtools openssl-devel clang-devel protobuf-devel ${RUST_
 WORKDIR /work
 
 COPY trident.spec .
+COPY LICENSE .
 COPY packaging ./packaging
 
 COPY .cargo/config ./.cargo/config

--- a/packaging/rpm/trident.spec
+++ b/packaging/rpm/trident.spec
@@ -82,6 +82,7 @@ Trident. This package provides the Trident tool
 and its dependencies for managing the lifecycle of Azure Linux hosts.
 
 %files
+%license LICENSE
 %{_bindir}/%{name}
 %dir /etc/%{name}
 %{_unitdir}/%{name}d.service


### PR DESCRIPTION
trident.spec declares License: MIT but never installs the license text via %license, so the built RPM does not carry LICENSE under %{_licensedir} as required by packaging guidelines.

- Add %license LICENSE to the main package %files section.
- COPY LICENSE . into the Docker build contexts (Dockerfile.full, Dockerfile.azl, Dockerfile.full.public) that build the RPM via pmbuild --build-in-place, since it was not previously copied into the build context.

Verified locally: pmspec -q parses the updated spec correctly, and a docker build using Dockerfile.azl progresses through %install/packaging (finding and packaging LICENSE) without error; the only failure seen was in %check due to a placeholder test binary unrelated to this change.