### PR TITLE
spec: package LICENSE file with %license directive

### DIFF
--- a/packaging/docker/Dockerfile.azl
+++ b/packaging/docker/Dockerfile.azl
@@ -19,6 +19,7 @@ RUN tdnf install -y \
 WORKDIR /work
 
 COPY packaging/rpm/trident.spec .
+COPY LICENSE .
 COPY packaging ./packaging
 COPY bin/trident ./target/release/trident
 COPY bin/trident-acl-agent ./target/release/trident-acl-agent

--- a/packaging/docker/Dockerfile.full
+++ b/packaging/docker/Dockerfile.full
@@ -23,6 +23,7 @@ RUN tdnf install -y \
 WORKDIR /work
 
 COPY packaging/rpm/trident.spec .
+COPY LICENSE .
 COPY packaging ./packaging
 
 COPY .cargo/config.toml ./.cargo/config.toml

--- a/packaging/docker/Dockerfile.full.public
+++ b/packaging/docker/Dockerfile.full.public
@@ -11,11 +11,11 @@ RUN tdnf install -y rpmdevtools openssl-devel clang-devel protobuf-devel ${RUST_
 
 WORKDIR /work
 
-COPY trident.spec .
+COPY packaging/rpm/trident.spec .
 COPY LICENSE .
 COPY packaging ./packaging
 
-COPY .cargo/config ./.cargo/config
+COPY .cargo/config.toml ./.cargo/config.toml
 COPY Cargo.toml .
 COPY Cargo.lock .
 COPY crates/ ./crates/

--- a/packaging/docker/Dockerfile.full.public
+++ b/packaging/docker/Dockerfile.full.public
@@ -12,6 +12,7 @@ RUN tdnf install -y rpmdevtools openssl-devel clang-devel protobuf-devel ${RUST_
 WORKDIR /work
 
 COPY trident.spec .
+COPY LICENSE .
 COPY packaging ./packaging
 
 COPY .cargo/config ./.cargo/config

--- a/packaging/rpm/trident.spec
+++ b/packaging/rpm/trident.spec
@@ -107,6 +107,7 @@ Requires:       %{name} = %{version}-%{release}
 Trident files for the provisioning OS
 
 %files provisioning
+%license LICENSE
 %{_unitdir}/%{name}-network.service
 
 %post provisioning
@@ -129,6 +130,7 @@ Conflicts:      %{name}-install-service
 Trident files for SystemD commit services
 
 %files service
+%license LICENSE
 %{_unitdir}/%{name}.service
 
 %post service
@@ -151,6 +153,7 @@ Conflicts:      %{name}-service
 Trident files for SystemD install service
 
 %files install-service
+%license LICENSE
 %{_unitdir}/%{name}-install.service
 
 %post install-service
@@ -185,6 +188,7 @@ Requires(postun):    policycoreutils
 Custom SELinux policy module
 
 %files selinux
+%license LICENSE
 %{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2
 %{_datadir}/selinux/devel/include/distributed/%{name}.if
 %ghost %verify(not md5 size mode mtime) %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
@@ -217,6 +221,7 @@ Statically defined .pcrlock files for PCR-based encryption. This is a workaround
 be removed once the fix is merged in AZL 4.0.
 
 %files static-pcrlock-files
+%license LICENSE
 %{_sharedstatedir}/pcrlock.d
 
 # ------------------------------------------------------------------------------
@@ -230,6 +235,7 @@ Requires:       %{name} = %{version}-%{release}
 The Trident ACL Agent triggers updates of ACL images.
 
 %files acl-agent
+%license LICENSE
 %{_bindir}/%{name}-acl-agent
 %endif
 

--- a/packaging/rpm/trident.spec
+++ b/packaging/rpm/trident.spec
@@ -82,6 +82,7 @@ Trident. This package provides the Trident tool
 and its dependencies for managing the lifecycle of Azure Linux hosts.
 
 %files
+%license LICENSE
 %{_bindir}/%{name}
 %dir /etc/%{name}
 %{_unitdir}/%{name}d.service


### PR DESCRIPTION
trident.spec declares `License: MIT` but never installed the license text via `%license`, so built RPMs did not carry `LICENSE` under `%{_licensedir}` as required by packaging guidelines.

- Add `%license LICENSE` to every `%files` section: the main `trident` package and all subpackages (`provisioning`, `service`, `install-service`, `selinux`, `static-pcrlock-files`, `acl-agent`), since subpackages can be installed independently and should each carry the license.
- `COPY LICENSE .` into the Docker build contexts (`Dockerfile.full`, `Dockerfile.azl`, `Dockerfile.full.public`) that build the RPM via `rpmbuild --build-in-place`, since `LICENSE` was not previously copied into the build context for the Trident-repo build path.

Verified locally: `rpmspec -q` parses the updated spec correctly (7 `%license LICENSE` entries total), and a `docker build` using `Dockerfile.azl` progresses through `%install`/packaging (finding and packaging `LICENSE`) without error; the only failure seen was in `%check` due to a placeholder test binary unrelated to this change.
