### PR TITLE
infra: CodeQL Advanced Mode

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,41 +1,39 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
+# CodeQL code scanning, advanced setup.
 #
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
+# This repository uses advanced setup (this workflow) rather than default setup
+# because default setup does not run on pull requests from forks, which leaves
+# external contributions permanently blocked by the `code_scanning` rule in the
+# `main` ruleset. See https://github.com/github/codeql/issues/19698.
 #
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
+# Default setup and advanced setup are mutually exclusive: while default setup is
+# enabled, uploads from this workflow are rejected with "CodeQL analyses from
+# advanced configurations cannot be processed when the default setup is enabled".
 #
+# The `pull_request` trigger is used deliberately, not `pull_request_target`.
+# Fork pull requests receive a read-only GITHUB_TOKEN, but github/codeql-action
+# uploads its SARIF through an endpoint that is exempt from the usual
+# `security-events: write` requirement, so analysis of fork pull requests works
+# without granting write tokens to untrusted code.
+
 name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
     - cron: '26 19 * * 2'
 
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
-    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     permissions:
-      # required for all workflows
+      # Required to upload analysis results.
       security-events: write
-
-      # required to fetch internal or private CodeQL packs
+      # Required to fetch internal or private CodeQL packs.
       packages: read
-
-      # only required for workflows in private repositories
       actions: read
       contents: read
 
@@ -43,65 +41,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: actions
-          build-mode: none
-        - language: go
-          build-mode: autobuild
-        - language: javascript-typescript
-          build-mode: none
-        - language: python
-          build-mode: none
-        - language: rust
-          build-mode: none
-        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
-        # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
-        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
-        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: autobuild
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: rust
+            build-mode: none
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v7
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    # - name: Run manual build steps
-    #   if: matrix.build-mode == 'manual'
-    #   shell: bash
-    #   run: |
-    #     echo 'If you are using a "manual" build mode for one or more of the' \
-    #       'languages you are analyzing, replace this with the commands to build' \
-    #       'your code, for example:'
-    #     echo '  make bootstrap'
-    #     echo '  make release'
-    #     exit 1
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,107 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '26 19 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: go
+          build-mode: autobuild
+        - language: javascript-typescript
+          build-mode: none
+        - language: python
+          build-mode: none
+        - language: rust
+          build-mode: none
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+
+    # Add any setup steps before running the `github/codeql-action/init` action.
+    # This includes steps like installing compilers or runtimes (`actions/setup-node`
+    # or others). This is typically only required for manual builds.
+    # - name: Setup runtime (example)
+    #   uses: actions/setup-example@v1
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    # - name: Run manual build steps
+    #   if: matrix.build-mode == 'manual'
+    #   shell: bash
+    #   run: |
+    #     echo 'If you are using a "manual" build mode for one or more of the' \
+    #       'languages you are analyzing, replace this with the commands to build' \
+    #       'your code, for example:'
+    #     echo '  make bootstrap'
+    #     echo '  make release'
+    #     exit 1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Set up CodeQL in "advanced" mode (a checked-in workflow) instead of "default" mode
(GitHub-injected, no workflow file).

## Why

The `main` ruleset has a `code_scanning` rule requiring CodeQL results before a pull
request can merge. **CodeQL default setup does not run on pull requests from forks
at all** — it produces zero check runs, so the rule never resolves and the pull
request hangs indefinitely on "Code scanning is waiting for results from CodeQL".
This is a known and currently unfixed limitation of default setup, confirmed by the
CodeQL team in https://github.com/github/codeql/issues/19698 and
https://github.com/github/codeql-action/issues/2136; their recommended remedy is to
move to advanced setup.

This has already cost us two external contributions:

- #743 (`bfjelds`) was closed and re-pushed as an in-repo branch to get around it.
- #748 (`danfiedler-msft`) is currently blocked on exactly this.

Advanced setup runs from a `pull_request` trigger, which does fire for fork pull
requests, so the required check resolves normally.

## Notes on the workflow

- Uses `pull_request`, deliberately **not** `pull_request_target`. Fork pull
  requests get a read-only `GITHUB_TOKEN`, but `github/codeql-action` uploads its
  SARIF through an endpoint exempt from the usual `security-events: write`
  requirement, so analysis works without handing a write token to untrusted code.
  `pull_request_target` would require checking out fork code under a privileged
  token, which is the "pwn request" pattern.
- Actions are pinned to full-length commit SHAs, following the convention from #748,
  so this workflow does not itself trip the `actions` CodeQL queries it enables.

## Rollout order (important)

Default setup and advanced setup are mutually exclusive. While default setup is
enabled, this workflow fails with:

> Code Scanning could not process the submitted SARIF file:
> CodeQL analyses from advanced configurations cannot be processed when the default
> setup is enabled

So the order must be:

1. Disable CodeQL default setup (Settings → Advanced Security → CodeQL analysis →
   switch off / change to Advanced). **Requires repository admin.**
2. Re-run this pull request's `CodeQL Advanced` workflow; it should now pass.
3. Merge this pull request so `codeql.yml` is on `main`.
4. Re-trigger #748 so it picks up the workflow from the merge ref.

Between steps 1 and 3 no CodeQL results are produced for other branches, so keep the
window short.
