### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cosi-schema-validation.yaml
+++ b/.github/workflows/cosi-schema-validation.yaml
@@ -22,9 +22,9 @@ jobs:
       SCHEMA_DIR: docs/Reference/Composable-OS-Image
       SAMPLES_ROOT: tests/cosi/metadata_samples
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.x"
 

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -28,10 +28,10 @@ jobs:
     name: Build Github Pages artifact
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20.x
 
@@ -61,7 +61,7 @@ jobs:
           npm run build
 
       - name: Upload website artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ./website/build
 
@@ -90,4 +90,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
Re-pushes @danfiedler-msft's #748 as an in-repository branch so it can actually be merged.
The commit is unchanged and authorship is preserved (`Dan Fiedler <danfiedler@microsoft.com>`,
cherry-picked from `0bbd2e6`).

## Why this exists

#748 is a fork pull request, and fork pull requests currently cannot merge into this repository:

1. **CodeQL default setup does not run on pull requests from forks.** It produces zero check runs,
   so the `code_scanning` rule in the `main` ruleset never resolves and the pull request hangs on
   "Code scanning is waiting for results from CodeQL". This is a confirmed, still-open limitation of
   default setup — see github/codeql#19698 and github/codeql-action#2136. The fix is to move to
   advanced setup, which is #749.
2. **Azure Pipelines withholds `System.AccessToken` from fork builds.** Every ADO job on #748 fails at
   startup with `authenticationToken is set to use System.AccessToken, but no System.AccessToken
   variable is set`, because the OneBranch `resources.repositories` checkout needs that token.

The same thing happened to #743, which was resolved the same way.

As an in-repo branch, both problems disappear: CodeQL default setup runs, and the ADO pipelines get
their token.

## Follow-ups

- #749 switches CodeQL to advanced setup so future fork pull requests are not blocked by (1).
- (2) is still open and needs a fork-safe validation story.

Closes #748.

Co-authored-by: Dan Fiedler <danfiedler@microsoft.com>
