### PR TITLE
engineering: osutils: move generic log wrappers (MultiLogger, LogFilter) to osutils::logging

### DIFF
--- a/crates/osutils/Cargo.toml
+++ b/crates/osutils/Cargo.toml
@@ -17,7 +17,7 @@ hex = {workspace = true}
 hostname = {workspace = true}
 indoc = {workspace = true}
 inventory = {workspace = true}
-log = {workspace = true}
+log = {workspace = true, features = ["std"]}
 netplan-types = {workspace = true}
 nix = {workspace = true, features = ["fs"]}
 once_cell = {workspace = true}

--- a/crates/osutils/src/lib.rs
+++ b/crates/osutils/src/lib.rs
@@ -17,6 +17,7 @@ pub mod grub;
 pub mod grub_mkconfig;
 pub mod hostname;
 pub mod installation_media;
+pub mod logging;
 pub mod lsblk;
 pub mod lsof;
 pub mod machine_id;

--- a/crates/osutils/src/logging/filter.rs
+++ b/crates/osutils/src/logging/filter.rs
@@ -1,3 +1,14 @@
+//! A [`Log`] wrapper that filters records before delegating to an inner
+//! logger.
+//!
+//! [`LogFilter`] drops any record whose level is more verbose than a
+//! configurable max level, and additionally applies per-target ceilings
+//! (matched by target prefix) so a noisy module can be turned down without
+//! affecting the rest. Records that survive both checks are forwarded to the
+//! wrapped logger unchanged; `enabled`/`flush` pass through. It is generic
+//! over any inner `Log`, so filters can be layered or placed in front of a
+//! single sink.
+
 use log::{LevelFilter, Log};
 
 pub struct LogFilter<T>
@@ -21,13 +32,12 @@ where
         }
     }
 
-    #[allow(dead_code)]
     pub fn with_max_level(mut self, max_level: LevelFilter) -> Self {
         self.max_level = max_level;
         self
     }
 
-    #[cfg(test)]
+    /// Consumes the filter and returns the wrapped inner logger.
     pub fn into_inner(self) -> T {
         self.inner
     }

--- a/crates/osutils/src/logging/mod.rs
+++ b/crates/osutils/src/logging/mod.rs
@@ -1,0 +1,4 @@
+//! Generic, dependency-free wrappers around the [`log`] facade.
+
+pub mod filter;
+pub mod multilog;

--- a/crates/osutils/src/logging/multilog.rs
+++ b/crates/osutils/src/logging/multilog.rs
@@ -1,3 +1,12 @@
+//! A [`Log`] implementation that fans each record out to several loggers.
+//!
+//! [`MultiLogger`] holds a set of `Box<dyn Log>` sinks and forwards every
+//! record to each one that reports itself `enabled`, so a process can log to
+//! (say) journald, a file, and a remote stream at once through a single
+//! installed logger. It applies a global max level plus per-target ceilings
+//! (matched by target prefix) before dispatching, and `flush` fans out to all
+//! sinks. [`MultiLogger::init`] installs it as the process-global logger.
+
 use log::{LevelFilter, Log};
 
 pub struct MultiLogger {

--- a/crates/trident/src/lib.rs
+++ b/crates/trident/src/lib.rs
@@ -56,9 +56,8 @@ pub use crate::{
     },
     grpc_client::client_main,
     logging::{
-        background_log::BackgroundLog, background_uploader::BackgroundUploader, filter::LogFilter,
-        logfwd::LogForwarder, logstream::Logstream, multilog::MultiLogger,
-        tracestream::TraceStream,
+        background_log::BackgroundLog, background_uploader::BackgroundUploader,
+        logfwd::LogForwarder, logstream::Logstream, tracestream::TraceStream,
     },
     orchestrate::OrchestratorConnection,
     reboot::request_reboot_with_wait,

--- a/crates/trident/src/logging/logstream.rs
+++ b/crates/trident/src/logging/logstream.rs
@@ -11,9 +11,10 @@ use anyhow::{anyhow, Context, Error};
 use log::{info, LevelFilter, Log, Metadata, Record};
 use url::Url;
 
+use osutils::logging::filter::LogFilter;
+
 use super::{
     background_uploader::{BackgroundUploadHandle, BACKGROUND_LOG_MODULE},
-    filter::LogFilter,
     LogEntry,
 };
 

--- a/crates/trident/src/logging/mod.rs
+++ b/crates/trident/src/logging/mod.rs
@@ -3,10 +3,8 @@ use serde::{Deserialize, Serialize};
 
 pub(super) mod background_log;
 pub(super) mod background_uploader;
-pub(super) mod filter;
 pub(super) mod logfwd;
 pub(super) mod logstream;
-pub(super) mod multilog;
 pub(super) mod tracestream;
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/trident/src/main.rs
+++ b/crates/trident/src/main.rs
@@ -4,13 +4,14 @@ use anyhow::{Context, Error};
 use clap::Parser;
 use log::{error, info, LevelFilter, Log};
 
+use osutils::logging::{filter::LogFilter, multilog::MultiLogger};
 use trident::{
     agentconfig::AgentConfig,
     cli::{self, Cli, Commands, GetKind, TridentExitCodes},
     init::offline,
     manual_rollback::{self, utils::ManualRollbackRequestKind},
-    validation, BackgroundLog, BackgroundUploader, DataStore, ExitKind, LogFilter, LogForwarder,
-    Logstream, MultiLogger, TraceStream, Trident, TRIDENT_BACKGROUND_LOG_PATH,
+    validation, BackgroundLog, BackgroundUploader, DataStore, ExitKind, LogForwarder, Logstream,
+    TraceStream, Trident, TRIDENT_BACKGROUND_LOG_PATH,
 };
 use trident_api::{
     config::HostConfigurationSource,


### PR DESCRIPTION
## What

Move the two strictly-generic `log`-facade wrappers out of the `trident` binary and into a new `osutils::logging` module:

- `crates/trident/src/logging/multilog.rs` → `crates/osutils/src/logging/multilog.rs` (`MultiLogger`)
- `crates/trident/src/logging/filter.rs` → `crates/osutils/src/logging/filter.rs` (`LogFilter<T>`)

## Why

Both are thin, dependency-free wrappers around the `log` facade — no Trident types, no I/O, no policy (a non-Trident project could use them verbatim). Per the crate-layering guidelines ("Is it a thin wrapper around a system tool/syscall…? → `osutils`"; lower layers own reusable, behavior-light building blocks), they belong in `osutils`, not the top-level binary.

## Changes

- New `osutils::logging` module (`mod.rs` + registered in `osutils/src/lib.rs`), with module-level docs on each wrapper describing purpose/capabilities.
- Enable the `log` crate's `std` feature for `osutils` — `MultiLogger::init` uses `set_boxed_logger`/`set_max_level`, which are `std`-gated and were previously only satisfied transitively in the `trident` dependency graph.
- `LogFilter::into_inner` promoted from `#[cfg(test)]` to a normal public accessor (its only test caller now lives in a different crate, where `osutils` builds without test cfg); dropped the now-unnecessary `#[allow(dead_code)]` on `with_max_level`.
- Consumers import directly from `osutils::logging::{filter,multilog}` — `main.rs` and `logging/logstream.rs` updated; no re-export left in `trident/src/lib.rs`.

## Validation

- `cargo check`/`clippy` clean for both `osutils` and `trident` (no unused imports).
- `cargo test -p osutils logging::` — the 4 moved unit tests pass.
- `cargo test -p trident --lib logging::` — all 20 logging tests pass (including the cross-crate `LogFilter::into_inner` path in `logstream`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>