### PR TITLE
notice: pin zerocopy license selection to stop validate-notice flake

### DIFF
--- a/packaging/notice/about.toml
+++ b/packaging/notice/about.toml
@@ -41,3 +41,28 @@ ignore-transitive-dependencies = false
 # the repository's own top-level LICENSE, not by third-party notices.
 [private]
 ignore = true
+
+# Deterministic license selection for the zerocopy family.
+#
+# These crates are multi-licensed (`BSD-2-Clause OR Apache-2.0 OR MIT`) and ship
+# all three license files. cargo-about's per-host harvesting resolves the `OR`
+# expression to a different concrete MIT *text* on different hosts (dev vs CI),
+# which moved `zerocopy` between two MIT groups and broke the checked-in-vs-CI
+# `NOTICE` diff on every run. Pinning the license to MIT sourced from the crate's
+# own `LICENSE-MIT` (identical bytes across all four family members, verified by
+# the shared checksum below) makes the resolved text identical on every host.
+# `render_notice.py` already de-dupes by exact text; this fixes the one input
+# cargo-about itself produces non-deterministically.
+[zerocopy.clarify]
+license = "MIT"
+
+[[zerocopy.clarify.files]]
+path = "LICENSE-MIT"
+checksum = "1a2f5c12ddc934d58956aa5dbdd3255fe55fd957633ab7d0d39e4f0daa73f7df"
+
+[zerocopy-derive.clarify]
+license = "MIT"
+
+[[zerocopy-derive.clarify.files]]
+path = "LICENSE-MIT"
+checksum = "1a2f5c12ddc934d58956aa5dbdd3255fe55fd957633ab7d0d39e4f0daa73f7df"


### PR DESCRIPTION
## Problem

The **Validate third-party NOTICE** CI check has been failing on essentially every run, with the identical diff each time:

```
4067d4066
<     - zerocopy 0.7.35
4970a4970
>     - zerocopy 0.7.35
```

i.e. `zerocopy 0.7.35` shows up under a *different* MIT license group in the CI-generated NOTICE than in the checked-in one. Confirmed identical across builds 1187863, 1188419, 1189534, 1189554, 1190372, ….

## Root cause

`zerocopy` (and `zerocopy-derive`) are multi-licensed — `BSD-2-Clause OR Apache-2.0 OR MIT` — and ship all three license files. `cargo-about`'s per-host license harvesting resolves that `OR` expression to a **different concrete MIT text** on the CI host than on the host that generated the checked-in NOTICE, so the crate lands in a different `(license-id, text)` group. Both are "MIT License", just different copyright text.

`render_notice.py` already de-dupes by exact license text, but it can't fix an input that `cargo-about` itself produces differently per host — the bytes it hands the renderer genuinely differ.

## Fix

Add `cargo-about` **`clarify`** entries pinning the zerocopy family to `MIT`, sourced from each crate's own `LICENSE-MIT` (byte-identical across all four family members — same sha256). `clarify` skips harvesting/scoring entirely and uses the specified file, so the resolved text is identical on every host.

Config-only change: the checked-in **NOTICE is unchanged** (the pinned file is what the local resolution already produced), so CI now resolves `zerocopy` to the same text and the drift check passes.

## Validation

- `make validate-notice` passes locally (regenerate + diff → "Trident NOTICE is OK!").
- Verified the clarify is actually applied: a deliberately wrong checksum produces `checksum mismatch` warnings for `zerocopy 0.7.35 / 0.8.17 / zerocopy-derive`; the correct checksum applies cleanly.
- `git diff` touches only `packaging/notice/about.toml`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>