### PR TITLE
pipelines: comment out BaremetalDeploymentTesting dependsOn in publish stage

### DIFF
--- a/.pipelines/templates/stages/publishing/publish.yml
+++ b/.pipelines/templates/stages/publishing/publish.yml
@@ -22,8 +22,8 @@ stages:
           - DeploymentTesting_host
           - DeploymentTesting_container
           - FunctionalTesting
-          - BaremetalDeploymentTesting_host
-          - BaremetalDeploymentTesting_container
+          # - BaremetalDeploymentTesting_host
+          # - BaremetalDeploymentTesting_container
           - ServicingTesting
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main') )
 


### PR DESCRIPTION
Comments out BaremetalDeploymentTesting_host and BaremetalDeploymentTesting_container in the dependsOn list of the Publishing stage in .pipelines/templates/stages/publishing/publish.yml.