### PR TITLE
packaging: rename trident-acl-agent subpackage to trident-acl

### DIFF
--- a/docs/Explanation/Trident-ACL-Agent.md
+++ b/docs/Explanation/Trident-ACL-Agent.md
@@ -13,12 +13,12 @@ distribution and honors the agent's per-node protocol.
 
 ## Deployment
 
-`trident-acl-agent` ships as its own `trident-acl-agent` RPM subpackage
+`trident-acl-agent` ships as its own `trident-acl` RPM subpackage
 (built alongside, and `Requires:` the same version of, the main `trident`
 package). Installing it:
 
 ```console
-$ tdnf install trident-acl-agent
+$ tdnf install trident-acl
 ```
 
 lays down the `/usr/bin/trident-acl-agent` binary and its

--- a/docs/Explanation/Trident-ACL-Agent.md
+++ b/docs/Explanation/Trident-ACL-Agent.md
@@ -13,7 +13,7 @@ distribution and honors the agent's per-node protocol.
 
 ## Deployment
 
-`trident-acl-agent` ships as its own `trident-acl` RPM subpackage
+`trident-acl-agent` ships in the `trident-acl` RPM subpackage
 (built alongside, and `Requires:` the same version of, the main `trident`
 package). Installing it:
 

--- a/packaging/rpm/trident.spec
+++ b/packaging/rpm/trident.spec
@@ -227,11 +227,11 @@ be removed once the fix is merged in AZL 4.0.
 # ------------------------------------------------------------------------------
 
 %package acl
-Summary:        Trident ACL Agent
+Summary:        Trident ACL Components
 Requires:       %{name} = %{version}-%{release}
 
 %description acl
-The Trident ACL Agent triggers updates of ACL images.
+The Trident ACL components required to orchestrate servicing of ACL images.
 
 %files acl
 %license LICENSE NOTICE

--- a/packaging/rpm/trident.spec
+++ b/packaging/rpm/trident.spec
@@ -226,25 +226,25 @@ be removed once the fix is merged in AZL 4.0.
 
 # ------------------------------------------------------------------------------
 
-%package acl-agent
+%package acl
 Summary:        Trident ACL Agent
 Requires:       %{name} = %{version}-%{release}
 
-%description acl-agent
+%description acl
 The Trident ACL Agent triggers updates of ACL images.
 
-%files acl-agent
+%files acl
 %license LICENSE NOTICE
 %{_bindir}/%{name}-acl-agent
 %{_unitdir}/%{name}-acl-agent.service
 
-%post acl-agent
+%post acl
 %systemd_post %{name}-acl-agent.service
 
-%preun acl-agent
+%preun acl
 %systemd_preun %{name}-acl-agent.service
 
-%postun acl-agent
+%postun acl
 %systemd_postun_with_restart %{name}-acl-agent.service
 
 # ------------------------------------------------------------------------------

--- a/scripts/extract-binary.sh
+++ b/scripts/extract-binary.sh
@@ -51,8 +51,8 @@ popd
 mkdir -p "$OUTPUT_PATH"
 mv "$TMP_DIR/usr/bin/trident" "$OUTPUT_PATH"
 
-# Extract trident-acl-agent binary from the acl-agent sub-package RPM
-ACL_AGENT_RPM=$(find "$RPM_DIR" | grep -P "trident-acl-agent-\d.*\.${DISTRO}\.${RPM_ARCH}\.rpm" | head -n 1 || true)
+# Extract trident-acl-agent binary from the acl sub-package RPM
+ACL_AGENT_RPM=$(find "$RPM_DIR" | grep -P "trident-acl-\d.*\.${DISTRO}\.${RPM_ARCH}\.rpm" | head -n 1 || true)
 if [ -n "$ACL_AGENT_RPM" ]; then
   ACL_TMP_DIR=$(mktemp -d)
   cp "$ACL_AGENT_RPM" "$ACL_TMP_DIR/trident-acl-agent.rpm"


### PR DESCRIPTION
Renames the RPM subpackage from `trident-acl-agent` to `trident-acl` in `packaging/rpm/trident.spec`. The underlying binary, systemd unit, and cargo crate names are unchanged; only the subpackage name/tags (`%package`, `%description`, `%files`, `%post`, `%preun`, `%postun`) are updated.