### PR TITLE
storm/aclagent: pull ephemeral Postgres from maritimusdev ACR

### DIFF
--- a/.pipelines/templates/e2e-template.yml
+++ b/.pipelines/templates/e2e-template.yml
@@ -274,6 +274,7 @@ stages:
   - template: stages/testing_acl_agent/trident-acl-agent-test.yml
     parameters:
       dependsOnStage: ${{ parameters.baseImageArtifactStage }}
+      acrServiceConnectionName: ${{ parameters.acrServiceConnectionName }}
 
   # TESTING stages for PRERELEASE
   - ${{ if eq(parameters.stageType, 'pre') }}:

--- a/.pipelines/templates/stages/testing_acl_agent/trident-acl-agent-test.yml
+++ b/.pipelines/templates/stages/testing_acl_agent/trident-acl-agent-test.yml
@@ -37,6 +37,16 @@ parameters:
       - maritimus-dev-acr-write-umi
       - trident-dev-acr-write-umi-ECF
 
+  # Container image for the ephemeral Postgres instance backing the fake
+  # Nebraska endpoint (see tools/storm/aclagent/utils/config.TestConfig's
+  # --postgres-image flag). Trident's own pipelines default to the
+  # maritimusdev ACR mirror, since the pool this stage runs on restricts
+  # egress to an allow-list that does not include Docker Hub; a local/fork
+  # run without ACR access should pass "postgres:16-alpine" instead.
+  - name: postgresImage
+    type: string
+    default: maritimusdev.azurecr.io/postgres:16-alpine
+
 stages:
   - stage: BuildImagesAclAgent
     displayName: Build Base and Update Images for trident-acl-agent
@@ -134,28 +144,28 @@ stages:
               ls -la $(Build.ArtifactStagingDirectory)/
             displayName: List downloaded image artifacts
 
-          - task: AzureCLI@2
-            inputs:
-              azureSubscription: ${{ parameters.acrServiceConnectionName }}
-              scriptType: bash
-              scriptLocation: inlineScript
-              inlineScript: |
-                set -eux
-                # NebraskaProxy's ephemeral Postgres (must match
-                # tools/storm/aclagent/proxies/constants.go's PostgresImage)
-                # is started by the storm-trident binary via a plain
-                # `docker run`, not through this task. Log in and pull it
-                # here instead, as root to match the `sudo ./bin/storm-trident
-                # run aclagent` step below (docker credentials are
-                # per-user, but a pulled image lands in the daemon's shared
-                # image cache, so this is the only step that needs the ACR
-                # login - the later `docker run` just finds it locally and
-                # never touches the network or the ACR credential).
-                POSTGRES_IMAGE="maritimusdev.azurecr.io/postgres:16-alpine"
-                sudo az acr login -n maritimusdev
-                sudo docker pull "$POSTGRES_IMAGE"
-            displayName: "Pull ephemeral Postgres image from maritimusdev ACR"
-            retryCountOnTaskFailure: 3
+          - ${{ if startsWith(parameters.postgresImage, 'maritimusdev.azurecr.io/') }}:
+              - task: AzureCLI@2
+                inputs:
+                  azureSubscription: ${{ parameters.acrServiceConnectionName }}
+                  scriptType: bash
+                  scriptLocation: inlineScript
+                  inlineScript: |
+                    set -eux
+                    # NebraskaProxy's ephemeral Postgres (--postgres-image
+                    # below must match) is started by the storm-trident
+                    # binary via a plain `docker run`, not through this
+                    # task. Log in and pull it here instead, as root to
+                    # match the `sudo ./bin/storm-trident run aclagent` step
+                    # below (docker credentials are per-user, but a pulled
+                    # image lands in the daemon's shared image cache, so
+                    # this is the only step that needs the ACR login - the
+                    # later `docker run` just finds it locally and never
+                    # touches the network or the ACR credential).
+                    sudo az acr login -n maritimusdev
+                    sudo docker pull "${{ parameters.postgresImage }}"
+                displayName: "Pull ephemeral Postgres image from maritimusdev ACR"
+                retryCountOnTaskFailure: 3
 
           - bash: |
               set -eux
@@ -165,6 +175,7 @@ stages:
               sudo ./bin/storm-trident run aclagent $FLAGS \
                 --output-path $(ob_outputDirectory) \
                 --artifacts-dir $(Build.ArtifactStagingDirectory) \
-                --ssh-private-key-path ~/.ssh/id_rsa
+                --ssh-private-key-path ~/.ssh/id_rsa \
+                --postgres-image "${{ parameters.postgresImage }}"
             displayName: "🧪 Run trident-acl-agent A/B update + rollback scenario"
             workingDirectory: $(TRIDENT_SOURCE_DIR)

--- a/.pipelines/templates/stages/testing_acl_agent/trident-acl-agent-test.yml
+++ b/.pipelines/templates/stages/testing_acl_agent/trident-acl-agent-test.yml
@@ -167,7 +167,7 @@ stages:
                     # network or the ACR credential.
                     az acr login -n martimusexternal
                     docker pull "${{ parameters.postgresImage }}"
-                displayName: "Pull ephemeral Postgres image from martimusexternal ACR"
+                displayName: "Pull Postgres image"
                 retryCountOnTaskFailure: 3
 
           - bash: |

--- a/.pipelines/templates/stages/testing_acl_agent/trident-acl-agent-test.yml
+++ b/.pipelines/templates/stages/testing_acl_agent/trident-acl-agent-test.yml
@@ -40,12 +40,12 @@ parameters:
   # Container image for the ephemeral Postgres instance backing the fake
   # Nebraska endpoint (see tools/storm/aclagent/utils/config.TestConfig's
   # --postgres-image flag). Trident's own pipelines default to the
-  # maritimusexternal ACR mirror, since the pool this stage runs on restricts
+  # martimusexternal ACR mirror, since the pool this stage runs on restricts
   # egress to an allow-list that does not include Docker Hub; a local/fork
   # run without ACR access should pass "postgres:16-alpine" instead.
   - name: postgresImage
     type: string
-    default: maritimusexternal.azurecr.io/postgres:16-alpine
+    default: martimusexternal.azurecr.io/postgres:16-alpine
 
 stages:
   - stage: BuildImagesAclAgent
@@ -144,7 +144,7 @@ stages:
               ls -la $(Build.ArtifactStagingDirectory)/
             displayName: List downloaded image artifacts
 
-          - ${{ if startsWith(parameters.postgresImage, 'maritimusexternal.azurecr.io/') }}:
+          - ${{ if startsWith(parameters.postgresImage, 'martimusexternal.azurecr.io/') }}:
               - task: AzureCLI@2
                 inputs:
                   azureSubscription: ${{ parameters.acrServiceConnectionName }}
@@ -165,9 +165,9 @@ stages:
                     # `sudo ./bin/storm-trident run aclagent` step still
                     # finds the image locally and never touches the
                     # network or the ACR credential.
-                    az acr login -n maritimusexternal
+                    az acr login -n martimusexternal
                     docker pull "${{ parameters.postgresImage }}"
-                displayName: "Pull ephemeral Postgres image from maritimusexternal ACR"
+                displayName: "Pull ephemeral Postgres image from martimusexternal ACR"
                 retryCountOnTaskFailure: 3
 
           - bash: |

--- a/.pipelines/templates/stages/testing_acl_agent/trident-acl-agent-test.yml
+++ b/.pipelines/templates/stages/testing_acl_agent/trident-acl-agent-test.yml
@@ -40,12 +40,12 @@ parameters:
   # Container image for the ephemeral Postgres instance backing the fake
   # Nebraska endpoint (see tools/storm/aclagent/utils/config.TestConfig's
   # --postgres-image flag). Trident's own pipelines default to the
-  # maritimusdev ACR mirror, since the pool this stage runs on restricts
+  # maritimusexternal ACR mirror, since the pool this stage runs on restricts
   # egress to an allow-list that does not include Docker Hub; a local/fork
   # run without ACR access should pass "postgres:16-alpine" instead.
   - name: postgresImage
     type: string
-    default: maritimusdev.azurecr.io/postgres:16-alpine
+    default: maritimusexternal.azurecr.io/postgres:16-alpine
 
 stages:
   - stage: BuildImagesAclAgent
@@ -144,7 +144,7 @@ stages:
               ls -la $(Build.ArtifactStagingDirectory)/
             displayName: List downloaded image artifacts
 
-          - ${{ if startsWith(parameters.postgresImage, 'maritimusdev.azurecr.io/') }}:
+          - ${{ if startsWith(parameters.postgresImage, 'maritimusexternal.azurecr.io/') }}:
               - task: AzureCLI@2
                 inputs:
                   azureSubscription: ${{ parameters.acrServiceConnectionName }}
@@ -165,9 +165,9 @@ stages:
                     # `sudo ./bin/storm-trident run aclagent` step still
                     # finds the image locally and never touches the
                     # network or the ACR credential.
-                    az acr login -n maritimusdev
+                    az acr login -n maritimusexternal
                     docker pull "${{ parameters.postgresImage }}"
-                displayName: "Pull ephemeral Postgres image from maritimusdev ACR"
+                displayName: "Pull ephemeral Postgres image from maritimusexternal ACR"
                 retryCountOnTaskFailure: 3
 
           - bash: |

--- a/.pipelines/templates/stages/testing_acl_agent/trident-acl-agent-test.yml
+++ b/.pipelines/templates/stages/testing_acl_agent/trident-acl-agent-test.yml
@@ -155,15 +155,18 @@ stages:
                     # NebraskaProxy's ephemeral Postgres (--postgres-image
                     # below must match) is started by the storm-trident
                     # binary via a plain `docker run`, not through this
-                    # task. Log in and pull it here instead, as root to
-                    # match the `sudo ./bin/storm-trident run aclagent` step
-                    # below (docker credentials are per-user, but a pulled
-                    # image lands in the daemon's shared image cache, so
-                    # this is the only step that needs the ACR login - the
-                    # later `docker run` just finds it locally and never
-                    # touches the network or the ACR credential).
-                    sudo az acr login -n maritimusdev
-                    sudo docker pull "${{ parameters.postgresImage }}"
+                    # task. Log in and pull it here as the agent user (not
+                    # sudo - the AzureCLI@2 task's service-connection auth
+                    # context lives under this user's home directory, and
+                    # sudo would run az/docker as root with no such
+                    # context, breaking the login). Docker images land in
+                    # the daemon's shared image cache regardless of which
+                    # user pulled them, so the later
+                    # `sudo ./bin/storm-trident run aclagent` step still
+                    # finds the image locally and never touches the
+                    # network or the ACR credential.
+                    az acr login -n maritimusdev
+                    docker pull "${{ parameters.postgresImage }}"
                 displayName: "Pull ephemeral Postgres image from maritimusdev ACR"
                 retryCountOnTaskFailure: 3
 

--- a/.pipelines/templates/stages/testing_acl_agent/trident-acl-agent-test.yml
+++ b/.pipelines/templates/stages/testing_acl_agent/trident-acl-agent-test.yml
@@ -27,6 +27,16 @@ parameters:
     type: boolean
     default: false
 
+  # Define which service connection to use for accessing ACR.
+  #   `maritimus-dev-acr-write-umi` is the service connection for the Polar SC
+  #   `trident-dev-acr-write-umi-ECF` is the service connection for the ECF SC
+  - name: acrServiceConnectionName
+    type: string
+    default: trident-dev-acr-write-umi-ECF
+    values:
+      - maritimus-dev-acr-write-umi
+      - trident-dev-acr-write-umi-ECF
+
 stages:
   - stage: BuildImagesAclAgent
     displayName: Build Base and Update Images for trident-acl-agent
@@ -123,6 +133,23 @@ stages:
               set -eux
               ls -la $(Build.ArtifactStagingDirectory)/
             displayName: List downloaded image artifacts
+
+          - task: AzureCLI@2
+            inputs:
+              azureSubscription: ${{ parameters.acrServiceConnectionName }}
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                set -eux
+                # NebraskaProxy's ephemeral Postgres (maritimusdev.azurecr.io/postgres:16-alpine,
+                # see tools/storm/aclagent/proxies/constants.go's PostgresImage) is pulled by the
+                # storm-trident binary via a plain `docker run`, not through this task, so log in
+                # here first and let the docker credential helper cache the token for that later
+                # step. Runs as root to match the `sudo ./bin/storm-trident run aclagent` step
+                # below, since docker credentials are per-user.
+                sudo az acr login -n maritimusdev
+            displayName: "Log in to maritimusdev ACR for ephemeral Postgres pull"
+            retryCountOnTaskFailure: 3
 
           - bash: |
               set -eux

--- a/.pipelines/templates/stages/testing_acl_agent/trident-acl-agent-test.yml
+++ b/.pipelines/templates/stages/testing_acl_agent/trident-acl-agent-test.yml
@@ -141,14 +141,20 @@ stages:
               scriptLocation: inlineScript
               inlineScript: |
                 set -eux
-                # NebraskaProxy's ephemeral Postgres (maritimusdev.azurecr.io/postgres:16-alpine,
-                # see tools/storm/aclagent/proxies/constants.go's PostgresImage) is pulled by the
-                # storm-trident binary via a plain `docker run`, not through this task, so log in
-                # here first and let the docker credential helper cache the token for that later
-                # step. Runs as root to match the `sudo ./bin/storm-trident run aclagent` step
-                # below, since docker credentials are per-user.
+                # NebraskaProxy's ephemeral Postgres (must match
+                # tools/storm/aclagent/proxies/constants.go's PostgresImage)
+                # is started by the storm-trident binary via a plain
+                # `docker run`, not through this task. Log in and pull it
+                # here instead, as root to match the `sudo ./bin/storm-trident
+                # run aclagent` step below (docker credentials are
+                # per-user, but a pulled image lands in the daemon's shared
+                # image cache, so this is the only step that needs the ACR
+                # login - the later `docker run` just finds it locally and
+                # never touches the network or the ACR credential).
+                POSTGRES_IMAGE="maritimusdev.azurecr.io/postgres:16-alpine"
                 sudo az acr login -n maritimusdev
-            displayName: "Log in to maritimusdev ACR for ephemeral Postgres pull"
+                sudo docker pull "$POSTGRES_IMAGE"
+            displayName: "Pull ephemeral Postgres image from maritimusdev ACR"
             retryCountOnTaskFailure: 3
 
           - bash: |

--- a/docs/Development/Testing/TridentAclAgent-Tests.md
+++ b/docs/Development/Testing/TridentAclAgent-Tests.md
@@ -144,8 +144,18 @@ sudo bin/storm-trident run aclagent \
     --artifacts-dir ./artifacts \
     --output-path /tmp/aclagent-output \
     --ssh-private-key-path ./artifacts/id_rsa \
+    --postgres-image postgres:16-alpine \
     --verbose
 ```
+
+`--postgres-image` already defaults to the public `postgres:16-alpine` image
+from Docker Hub, so it only needs to be passed explicitly here to make that
+default visible; a plain internet connection is all this scenario (and its
+`go test ./tools/storm/aclagent/proxies/...` unit tests) need to pull it.
+Trident's own pipelines override this to an internal ACR mirror instead,
+since the pools they run on restrict egress to an allow-list that excludes
+Docker Hub - see `postgresImage` in
+`.pipelines/templates/stages/testing_acl_agent/trident-acl-agent-test.yml`.
 
 ### Test Cases
 
@@ -180,6 +190,7 @@ The scenario runs these test cases in order:
 | `--nebraska-port` | Port for the fake Nebraska/Omaha server | `18081` |
 | `--host-endpoint-ip` | Host IP the VM reaches the fake endpoints at | `192.168.122.1` |
 | `--image-path` | Real `.cosi` update image to serve during staging | first `*.cosi` found under `--artifacts-dir` |
+| `--postgres-image` | Container image for the ephemeral Postgres instance backing the fake Nebraska endpoint | `postgres:16-alpine` |
 | `--verbose` | Enable verbose logging | `false` |
 | `--test-case-to-run` | Run a specific test case only | `all` |
 

--- a/tools/storm/aclagent/proxies/constants.go
+++ b/tools/storm/aclagent/proxies/constants.go
@@ -8,4 +8,13 @@ const (
 
 	DefaultNodeName   = "trident-node"
 	DefaultMarkerFile = "./trident-acl-agent-reboot-signal"
+
+	// PostgresImage is the ephemeral Postgres image NebraskaProxy runs to
+	// back the real Nebraska server it links in-process. Pulled from the
+	// maritimusdev ACR (mirroring the same registry push-to-acr.yml uses for
+	// the Polar SC, see maritimus-dev-acr-write-umi) rather than unqualified
+	// from Docker Hub, since some pipeline pools (e.g. OneBranch-governed
+	// ones) restrict egress to an allow-list that does not include Docker
+	// Hub.
+	PostgresImage = "maritimusdev.azurecr.io/postgres:16-alpine"
 )

--- a/tools/storm/aclagent/proxies/constants.go
+++ b/tools/storm/aclagent/proxies/constants.go
@@ -9,12 +9,15 @@ const (
 	DefaultNodeName   = "trident-node"
 	DefaultMarkerFile = "./trident-acl-agent-reboot-signal"
 
-	// PostgresImage is the ephemeral Postgres image NebraskaProxy runs to
-	// back the real Nebraska server it links in-process. Pulled from the
-	// maritimusdev ACR (mirroring the same registry push-to-acr.yml uses for
-	// the Polar SC, see maritimus-dev-acr-write-umi) rather than unqualified
-	// from Docker Hub, since some pipeline pools (e.g. OneBranch-governed
-	// ones) restrict egress to an allow-list that does not include Docker
-	// Hub.
-	PostgresImage = "maritimusdev.azurecr.io/postgres:16-alpine"
+	// DefaultPostgresImage is the ephemeral Postgres image NebraskaProxy runs
+	// to back the real Nebraska server it links in-process, used whenever a
+	// caller (or the --postgres-image CLI flag, see
+	// utils/config.TestConfig.PostgresImage) does not set
+	// NebraskaProxy.PostgresImage explicitly. This is the public Docker Hub
+	// image deliberately, not an internal registry, so the harness (and its
+	// unit tests) work unmodified for anyone with plain internet access - no
+	// Microsoft-internal credentials or network access required. Trident's
+	// own pipelines run on network-restricted pools and override this to an
+	// internal ACR mirror via that same flag.
+	DefaultPostgresImage = "postgres:16-alpine"
 )

--- a/tools/storm/aclagent/proxies/nebraska.go
+++ b/tools/storm/aclagent/proxies/nebraska.go
@@ -362,7 +362,7 @@ func startEphemeralPostgres(ctx context.Context) (dbURL string, containerID stri
 		"-e", "POSTGRES_PASSWORD=nebraska",
 		"-e", "POSTGRES_DB=nebraska",
 		"-p", "127.0.0.1::5432",
-		"postgres:16-alpine",
+		PostgresImage,
 	).Output()
 	if err != nil {
 		return "", "", fmt.Errorf("docker run postgres: %w", err)

--- a/tools/storm/aclagent/proxies/nebraska.go
+++ b/tools/storm/aclagent/proxies/nebraska.go
@@ -71,6 +71,14 @@ func LoadNebraskaScenario(path string) (*NebraskaScenario, error) {
 type NebraskaProxy struct {
 	Scenario *NebraskaScenario
 
+	// PostgresImage is the container image ListenAndServe pulls/runs for the
+	// ephemeral Postgres instance. Empty uses DefaultPostgresImage (the
+	// public postgres:16-alpine), which is what the unit tests in this
+	// package do; storm-trident's aclagent scenario always sets this from
+	// TestConfig.PostgresImage (--postgres-image), so it can be pointed at
+	// an internal registry mirror on network-restricted CI pools.
+	PostgresImage string
+
 	containerID string
 	dbURL       string
 	api         *api.API
@@ -137,7 +145,11 @@ func (p *NebraskaProxy) Handler() http.Handler {
 // listenAddr. The Postgres container and http server are both torn down
 // when ctx is cancelled.
 func (p *NebraskaProxy) ListenAndServe(ctx context.Context, listenAddr string) (net.Listener, error) {
-	dbURL, containerID, err := startEphemeralPostgres(ctx)
+	image := p.PostgresImage
+	if image == "" {
+		image = DefaultPostgresImage
+	}
+	dbURL, containerID, err := startEphemeralPostgres(ctx, image)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start ephemeral Postgres for Nebraska: %w", err)
 	}
@@ -354,15 +366,16 @@ func formatStatuses(statuses []int) string {
 	return "[" + strings.Join(names, " -> ") + "]"
 }
 
-// startEphemeralPostgres starts a disposable Postgres container for this
-// Nebraska instance to use, waits for it to accept connections, and returns
-// a connection URL for it plus its container ID (for teardown).
-func startEphemeralPostgres(ctx context.Context) (dbURL string, containerID string, err error) {
+// startEphemeralPostgres starts a disposable Postgres container (from
+// image) for this Nebraska instance to use, waits for it to accept
+// connections, and returns a connection URL for it plus its container ID
+// (for teardown).
+func startEphemeralPostgres(ctx context.Context, image string) (dbURL string, containerID string, err error) {
 	out, err := exec.CommandContext(ctx, "docker", "run", "-d", "--rm",
 		"-e", "POSTGRES_PASSWORD=nebraska",
 		"-e", "POSTGRES_DB=nebraska",
 		"-p", "127.0.0.1::5432",
-		PostgresImage,
+		image,
 	).Output()
 	if err != nil {
 		return "", "", fmt.Errorf("docker run postgres: %w", err)

--- a/tools/storm/aclagent/tests/update.go
+++ b/tools/storm/aclagent/tests/update.go
@@ -208,13 +208,16 @@ func RunABUpdate(testConfig stormaclconfig.TestConfig, vmConfig stormvmconfig.Al
 		nebraskaSHA384 = hash
 	}
 
-	nebraska := &stormproxies.NebraskaProxy{Scenario: &stormproxies.NebraskaScenario{
-		Available:   true,
-		Version:     testConfig.TargetVersion,
-		URL:         nebraskaCodebase,
-		SHA384:      nebraskaSHA384,
-		PackageName: nebraskaPackageName,
-	}}
+	nebraska := &stormproxies.NebraskaProxy{
+		Scenario: &stormproxies.NebraskaScenario{
+			Available:   true,
+			Version:     testConfig.TargetVersion,
+			URL:         nebraskaCodebase,
+			SHA384:      nebraskaSHA384,
+			PackageName: nebraskaPackageName,
+		},
+		PostgresImage: testConfig.PostgresImage,
+	}
 	if _, err := nebraska.ListenAndServe(ctx, fmt.Sprintf("%s:%d", testConfig.HostEndpointIP, testConfig.NebraskaPort)); err != nil {
 		return fmt.Errorf("failed to start fake Nebraska endpoint: %w", err)
 	}

--- a/tools/storm/aclagent/utils/config/config.go
+++ b/tools/storm/aclagent/utils/config/config.go
@@ -16,4 +16,5 @@ type TestConfig struct {
 	NodeName              string `help:"Node name served by the fake apiserver; must match the VM image's hostname (Image Customizer 'hostname' setting in baseimg-acl-agent.yaml), since trident-acl-agent's [kubernetes].node_name defaults to the node's own real hostname" default:"trident-acl-agent-testimg"`
 	HostEndpointIP        string `help:"Host IP the VM can reach the fake apiserver/Nebraska endpoints at" default:"192.168.122.1"`
 	ExpectedInitialVolume string `help:"Expected active volume immediately after deployment" default:"volume-a"`
+	PostgresImage         string `help:"Container image for the ephemeral Postgres instance backing the fake Nebraska endpoint; override with an internal registry mirror on network-restricted CI pools" default:"postgres:16-alpine"`
 }


### PR DESCRIPTION
NebraskaProxy's ephemeral Postgres container was pulled unqualified (docker.io/library/postgres:16-alpine), which OneBranch-governed pipeline pools cannot reach. Cache container in maritimusdev.azurecr.io