### PR TITLE
trident-acl-agent: require https for Nebraska server and package URLs

### DIFF
--- a/crates/trident-acl-agent/src/annotations/protocol.rs
+++ b/crates/trident-acl-agent/src/annotations/protocol.rs
@@ -219,13 +219,9 @@ impl UpdateRequest {
                         "server is required for stage/finalize".to_string(),
                     ));
                 }
-                if self
-                    .server
-                    .as_ref()
-                    .is_some_and(|u| !matches!(u.scheme(), "http" | "https"))
-                {
+                if self.server.as_ref().is_some_and(|u| u.scheme() != "https") {
                     return Err(AgentError::InvalidRequest(
-                        "server must be an http(s) URL".to_string(),
+                        "server must be an https URL".to_string(),
                     ));
                 }
                 if self.app_id.as_deref().unwrap_or("").is_empty() {
@@ -1235,26 +1231,30 @@ mod tests {
     }
 
     #[test]
-    fn validate_accepts_plain_http_server() {
-        // Deliberately not https-only: test/dev harnesses (e.g. the storm
-        // E2E suite) point `server` at a local, unencrypted Nebraska stub.
+    fn validate_rejects_plain_http_server() {
+        // https-only: the Nebraska control channel must be transport-secured
+        // in production, and the storm E2E suite now serves its Nebraska
+        // stub over https (installing its ephemeral CA into the VM's own
+        // system trust store) rather than being given an unencrypted-http
+        // carve-out here.
         for operation in [RequestedOperation::Stage, RequestedOperation::Finalize] {
             let mut request = valid_nebraska_request(operation);
             request.server = Some(Url::parse("http://127.0.0.1:8080/v1/update").unwrap());
-            request
+            let err = request
                 .validate()
-                .unwrap_or_else(|err| panic!("{operation:?} with http:// server: {err}"));
+                .expect_err("a plain-http server must be rejected");
+            assert!(err.to_string().contains("server"), "{err}");
         }
     }
 
     #[test]
-    fn validate_rejects_stage_and_finalize_non_http_scheme_server() {
+    fn validate_rejects_stage_and_finalize_non_https_scheme_server() {
         for operation in [RequestedOperation::Stage, RequestedOperation::Finalize] {
             let mut request = valid_nebraska_request(operation);
             request.server = Some(Url::parse("ftp://nebraska.example/v1/update").unwrap());
             let err = request
                 .validate()
-                .expect_err("a non-http(s) server scheme must be rejected");
+                .expect_err("a non-https server scheme must be rejected");
             assert!(err.to_string().contains("server"), "{err}");
         }
     }

--- a/crates/trident-acl-agent/src/core/nebraska/client.rs
+++ b/crates/trident-acl-agent/src/core/nebraska/client.rs
@@ -14,6 +14,18 @@ use super::{
     wire::{self, App},
 };
 
+/// Schemes a resolved package URL is allowed to carry before it is ever
+/// forwarded to Trident. Nebraska's job is to point at a *remote* artifact
+/// (typically on a different host than Nebraska itself - a blob store or
+/// CDN); `http`/`file` are excluded even though Trident's own downloader
+/// would otherwise accept them: `http` because the artifact must be
+/// integrity/authenticity-protected in transit the same way the Nebraska
+/// channel itself is, and `file` because it crosses from "fetch a remote
+/// artifact" into "read a path off the local disk of whichever machine
+/// opens this URL" (root-privileged `tridentd`), a capability no legitimate
+/// Nebraska response has any reason to invoke.
+const ALLOWED_PACKAGE_URL_SCHEMES: &[&str] = &["https", "oci"];
+
 /// The outcome of an update check.
 ///
 /// `UpdateInProgress` is a first-class outcome rather than an error because
@@ -706,6 +718,15 @@ impl<T: Transport> Client<T> {
             ))
         })?;
 
+        if !ALLOWED_PACKAGE_URL_SCHEMES.contains(&url.scheme()) {
+            return Err(NebraskaError::UnexpectedResponse(format!(
+                "package '{}' resolved to disallowed URL scheme '{}' (only {} permitted)",
+                package.name,
+                url.scheme(),
+                ALLOWED_PACKAGE_URL_SCHEMES.join("/"),
+            )));
+        }
+
         let hash = package.hash.as_ref().map(|sha1| PackageHash {
             sha1: sha1.clone(),
             sha256: package.hash_sha256.clone(),
@@ -846,6 +867,44 @@ mod tests {
             }
             other => panic!("expected an update offer, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn check_rejects_offer_with_http_codebase() {
+        let client = client_with(
+            r#"<response protocol="3.0" server="n"><app appid="app-1" status="ok"><updatecheck status="ok"><urls><url codebase="http://updates.example.com/"/></urls><manifest version="2.0.0"><packages><package name="os.cosi" required="true"/></packages></manifest></updatecheck></app></response>"#,
+        );
+        let err = client
+            .check_for_update(&Version::new(1, 0, 0))
+            .expect_err("a plain-http package URL must be rejected");
+        assert!(
+            matches!(err, NebraskaError::UnexpectedResponse(_)),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn check_rejects_offer_with_file_codebase() {
+        let client = client_with(
+            r#"<response protocol="3.0" server="n"><app appid="app-1" status="ok"><updatecheck status="ok"><urls><url codebase="file:///etc/"/></urls><manifest version="2.0.0"><packages><package name="passwd" required="true"/></packages></manifest></updatecheck></app></response>"#,
+        );
+        let err = client
+            .check_for_update(&Version::new(1, 0, 0))
+            .expect_err("a file:// package URL must be rejected");
+        assert!(
+            matches!(err, NebraskaError::UnexpectedResponse(_)),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn check_accepts_offer_with_oci_codebase() {
+        let client = client_with(
+            r#"<response protocol="3.0" server="n"><app appid="app-1" status="ok"><updatecheck status="ok"><urls><url codebase="oci://registry.example.com/os/"/></urls><manifest version="2.0.0"><packages><package name="os.cosi" required="true"/></packages></manifest></updatecheck></app></response>"#,
+        );
+        client
+            .check_for_update(&Version::new(1, 0, 0))
+            .expect("an oci:// package URL is a legitimate remote artifact reference");
     }
 
     #[test]

--- a/docs/Explanation/Trident-ACL-Agent.md
+++ b/docs/Explanation/Trident-ACL-Agent.md
@@ -88,7 +88,15 @@ A request annotation looks like:
   `stage`/`finalize` requests, with **no static fallback** — a request
   missing them is rejected with `InvalidRequest` rather than falling back to
   a built-in endpoint, so a node can never update from a source the
-  orchestrator did not explicitly choose.
+  orchestrator did not explicitly choose. `server` must be an `https` URL —
+  a plain-`http` (or any other scheme) value is rejected outright, since
+  Nebraska's response drives a root-privileged `tridentd` fetch and must not
+  be readable/tamperable by a network-position attacker. Likewise, the
+  package/image URL Nebraska's response resolves to is only accepted if it
+  is `https` or `oci`; `http` and `file` are rejected, closing off an SSRF
+  vector where a compromised/spoofed Nebraska response could otherwise
+  direct `tridentd` to fetch or open an arbitrary local file or unencrypted
+  network resource.
 
 `operation` maps to Trident invocations as follows:
 


### PR DESCRIPTION
Nebraska's response drives a root-privileged tridentd fetch, so both URLs it supplies must be transport-secured:

- `server` (the update-request annotation's Nebraska endpoint) must now be `https` - a plain-`http` (or any other scheme) value is rejected with InvalidRequest, closing off a network-position attacker reading or tampering with the update-check/event-report channel.
- The package/image URL Nebraska's response resolves to is only accepted if it is `https` or `oci`; `http` and `file` are rejected, closing an SSRF vector where a compromised/spoofed Nebraska response could otherwise direct tridentd to fetch or open an arbitrary local file or unencrypted network resource.

trident-acl-agent has no CA-override configuration of its own: a private CA is expected to be trusted via the node's system trust store, installed at image-build time, not via a runtime agent config knob.

Updates docs/Explanation/Trident-ACL-Agent.md accordingly.

Validated with [pr-e2e with commit targeting pr 731](https://dev.azure.com/mariner-org/ECF/_build/results?buildId=1196400&view=results)
