### PR TITLE
Demote functional tests that do not require the VM

### DIFF
--- a/crates/osmodifier/src/hostname.rs
+++ b/crates/osmodifier/src/hostname.rs
@@ -20,16 +20,12 @@ pub fn update(ctx: &OsModifierContext, hostname: &str) -> Result<(), Error> {
         .with_context(|| format!("Failed to write hostname to '{}'", path.display()))
 }
 
-#[cfg_attr(not(test), allow(unused_imports, dead_code))]
-mod functional_test {
+#[cfg(test)]
+mod tests {
     use super::*;
     use tempfile::tempdir;
 
-    use pytest_gen::functional_test;
-
-    use crate::OsModifierContext;
-
-    #[functional_test(feature = "core")]
+    #[test]
     fn test_update_hostname() {
         let tmp = tempdir().unwrap();
         fs::create_dir_all(tmp.path().join("etc")).unwrap();
@@ -43,7 +39,7 @@ mod functional_test {
         assert_eq!(content.trim(), "my-test-host");
     }
 
-    #[functional_test(feature = "core")]
+    #[test]
     fn test_update_hostname_overwrites() {
         let tmp = tempdir().unwrap();
         fs::create_dir_all(tmp.path().join("etc")).unwrap();

--- a/crates/osmodifier/src/lib.rs
+++ b/crates/osmodifier/src/lib.rs
@@ -244,6 +244,107 @@ fn format_corruption_option(opt: &CorruptionOption) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+    use std::fs;
+    use tempfile::tempdir;
+    use trident_api::config::{LoadMode, Module, Services};
+
+    #[test]
+    fn test_modify_os_hostname_and_modules() {
+        let tmp = tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("etc")).unwrap();
+
+        let ctx = OsModifierContext {
+            root: tmp.path().to_path_buf(),
+        };
+
+        let config = OSModifierConfig {
+            hostname: Some("integration-test-host".to_string()),
+            modules: vec![Module {
+                name: "vfio_pci".to_string(),
+                load_mode: LoadMode::Always,
+                options: HashMap::new(),
+            }],
+            ..Default::default()
+        };
+
+        modify_os(&ctx, &config).unwrap();
+
+        // Verify hostname
+        let hostname = fs::read_to_string(tmp.path().join("etc/hostname")).unwrap();
+        assert_eq!(hostname.trim(), "integration-test-host");
+
+        // Verify module loaded
+        let load_conf =
+            fs::read_to_string(tmp.path().join("etc/modules-load.d/modules-load.conf")).unwrap();
+        assert!(
+            load_conf.contains("vfio_pci"),
+            "Expected vfio_pci in modules-load.conf"
+        );
+    }
+
+    #[test]
+    fn test_modify_os_empty_config() {
+        let tmp = tempdir().unwrap();
+        let ctx = OsModifierContext {
+            root: tmp.path().to_path_buf(),
+        };
+
+        let config = OSModifierConfig::default();
+
+        // Empty config should be a no-op
+        modify_os(&ctx, &config).unwrap();
+    }
+
+    #[test]
+    fn test_modify_os_with_services() {
+        let tmp = tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("etc")).unwrap();
+
+        // Create a minimal systemd tree with a synthetic service
+        let unit_dir = tmp.path().join("usr/lib/systemd/system");
+        fs::create_dir_all(&unit_dir).unwrap();
+        fs::create_dir_all(
+            tmp.path()
+                .join("etc/systemd/system/multi-user.target.wants"),
+        )
+        .unwrap();
+        fs::write(
+            unit_dir.join("test-integration.service"),
+            "[Unit]\nDescription=Test\n\n[Service]\nType=oneshot\nExecStart=/bin/true\n\n[Install]\nWantedBy=multi-user.target\n",
+        )
+        .unwrap();
+
+        let ctx = OsModifierContext {
+            root: tmp.path().to_path_buf(),
+        };
+
+        let config = OSModifierConfig {
+            hostname: Some("svc-test-host".to_string()),
+            services: Some(Services {
+                enable: vec!["test-integration.service".to_string()],
+                disable: vec![],
+            }),
+            ..Default::default()
+        };
+
+        modify_os(&ctx, &config).unwrap();
+
+        // Verify hostname
+        let hostname = fs::read_to_string(tmp.path().join("etc/hostname")).unwrap();
+        assert_eq!(hostname.trim(), "svc-test-host");
+
+        // Verify service enabled — symlink may be dangling (target is absolute /usr/...
+        // but only exists under the temp root), so check is_symlink() not exists()
+        let symlink = tmp
+            .path()
+            .join("etc/systemd/system/multi-user.target.wants/test-integration.service");
+        assert!(
+            symlink.is_symlink(),
+            "Service should be enabled (symlink at {})",
+            symlink.display()
+        );
+    }
 
     #[test]
     fn path_default_root_returns_absolute_path_unchanged() {
@@ -297,113 +398,5 @@ mod tests {
         };
         // A bare "/" should resolve to the root itself
         assert_eq!(ctx.path("/"), PathBuf::from("/tmp/testroot"));
-    }
-}
-
-#[cfg_attr(not(test), allow(unused_imports, dead_code))]
-mod functional_test {
-    use super::*;
-    use std::collections::HashMap;
-    use std::fs;
-    use tempfile::tempdir;
-
-    use pytest_gen::functional_test;
-    use trident_api::config::{LoadMode, Module, Services};
-
-    #[functional_test(feature = "core")]
-    fn test_modify_os_hostname_and_modules() {
-        let tmp = tempdir().unwrap();
-        fs::create_dir_all(tmp.path().join("etc")).unwrap();
-
-        let ctx = OsModifierContext {
-            root: tmp.path().to_path_buf(),
-        };
-
-        let config = OSModifierConfig {
-            hostname: Some("integration-test-host".to_string()),
-            modules: vec![Module {
-                name: "vfio_pci".to_string(),
-                load_mode: LoadMode::Always,
-                options: HashMap::new(),
-            }],
-            ..Default::default()
-        };
-
-        modify_os(&ctx, &config).unwrap();
-
-        // Verify hostname
-        let hostname = fs::read_to_string(tmp.path().join("etc/hostname")).unwrap();
-        assert_eq!(hostname.trim(), "integration-test-host");
-
-        // Verify module loaded
-        let load_conf =
-            fs::read_to_string(tmp.path().join("etc/modules-load.d/modules-load.conf")).unwrap();
-        assert!(
-            load_conf.contains("vfio_pci"),
-            "Expected vfio_pci in modules-load.conf"
-        );
-    }
-
-    #[functional_test(feature = "core")]
-    fn test_modify_os_empty_config() {
-        let tmp = tempdir().unwrap();
-        let ctx = OsModifierContext {
-            root: tmp.path().to_path_buf(),
-        };
-
-        let config = OSModifierConfig::default();
-
-        // Empty config should be a no-op
-        modify_os(&ctx, &config).unwrap();
-    }
-
-    #[functional_test(feature = "core")]
-    fn test_modify_os_with_services() {
-        let tmp = tempdir().unwrap();
-        fs::create_dir_all(tmp.path().join("etc")).unwrap();
-
-        // Create a minimal systemd tree with a synthetic service
-        let unit_dir = tmp.path().join("usr/lib/systemd/system");
-        fs::create_dir_all(&unit_dir).unwrap();
-        fs::create_dir_all(
-            tmp.path()
-                .join("etc/systemd/system/multi-user.target.wants"),
-        )
-        .unwrap();
-        fs::write(
-            unit_dir.join("test-integration.service"),
-            "[Unit]\nDescription=Test\n\n[Service]\nType=oneshot\nExecStart=/bin/true\n\n[Install]\nWantedBy=multi-user.target\n",
-        )
-        .unwrap();
-
-        let ctx = OsModifierContext {
-            root: tmp.path().to_path_buf(),
-        };
-
-        let config = OSModifierConfig {
-            hostname: Some("svc-test-host".to_string()),
-            services: Some(Services {
-                enable: vec!["test-integration.service".to_string()],
-                disable: vec![],
-            }),
-            ..Default::default()
-        };
-
-        modify_os(&ctx, &config).unwrap();
-
-        // Verify hostname
-        let hostname = fs::read_to_string(tmp.path().join("etc/hostname")).unwrap();
-        assert_eq!(hostname.trim(), "svc-test-host");
-
-        // Verify service enabled — symlink may be dangling (target is absolute /usr/...
-        // but only exists under the temp root), so check is_symlink() not exists()
-        let symlink = tmp
-            .path()
-            .join("etc/systemd/system/multi-user.target.wants/test-integration.service");
-        assert!(
-            symlink.is_symlink(),
-            "Service should be enabled (symlink at {})",
-            symlink.display()
-        );
     }
 }

--- a/crates/osmodifier/src/modules.rs
+++ b/crates/osmodifier/src/modules.rs
@@ -189,16 +189,13 @@ fn write_config(path: &std::path::Path, lines: &[String]) -> Result<(), Error> {
     atomic_write_file(path, &content)
 }
 
-#[cfg_attr(not(test), allow(unused_imports, dead_code))]
-mod functional_test {
+#[cfg(test)]
+mod tests {
     use super::*;
     use std::collections::HashMap;
     use tempfile::tempdir;
 
-    use pytest_gen::functional_test;
     use trident_api::config::LoadMode;
-
-    use crate::OsModifierContext;
 
     fn make_ctx(tmp: &tempfile::TempDir) -> OsModifierContext {
         OsModifierContext {
@@ -206,7 +203,7 @@ mod functional_test {
         }
     }
 
-    #[functional_test(feature = "core")]
+    #[test]
     fn test_configure_modules_always_load() {
         let tmp = tempdir().unwrap();
         let ctx = make_ctx(&tmp);
@@ -227,7 +224,7 @@ mod functional_test {
         );
     }
 
-    #[functional_test(feature = "core")]
+    #[test]
     fn test_configure_modules_disable() {
         let tmp = tempdir().unwrap();
         let ctx = make_ctx(&tmp);
@@ -256,7 +253,7 @@ mod functional_test {
         );
     }
 
-    #[functional_test(feature = "core")]
+    #[test]
     fn test_configure_modules_with_options() {
         let tmp = tempdir().unwrap();
         let ctx = make_ctx(&tmp);
@@ -280,7 +277,7 @@ mod functional_test {
         );
     }
 
-    #[functional_test(feature = "core", negative = true)]
+    #[test]
     fn test_configure_modules_disable_with_options_fails() {
         let tmp = tempdir().unwrap();
         let ctx = make_ctx(&tmp);
@@ -301,7 +298,7 @@ mod functional_test {
         );
     }
 
-    #[functional_test(feature = "core")]
+    #[test]
     fn test_configure_modules_idempotent() {
         let tmp = tempdir().unwrap();
         let ctx = make_ctx(&tmp);
@@ -322,7 +319,7 @@ mod functional_test {
         assert_eq!(count, 1, "Module should appear exactly once, got {count}");
     }
 
-    #[functional_test(feature = "core")]
+    #[test]
     fn test_configure_modules_disable_removes_from_load() {
         let tmp = tempdir().unwrap();
         let ctx = make_ctx(&tmp);
@@ -358,7 +355,7 @@ mod functional_test {
         );
     }
 
-    #[functional_test(feature = "core", negative = true)]
+    #[test]
     fn test_configure_modules_inherit_disabled_with_options_fails() {
         let tmp = tempdir().unwrap();
         let ctx = make_ctx(&tmp);
@@ -388,7 +385,7 @@ mod functional_test {
         );
     }
 
-    #[functional_test(feature = "core")]
+    #[test]
     fn test_configure_modules_options_preserve_existing() {
         let tmp = tempdir().unwrap();
         let ctx = make_ctx(&tmp);

--- a/crates/osmodifier/src/selinux.rs
+++ b/crates/osmodifier/src/selinux.rs
@@ -94,17 +94,13 @@ pub fn update_grub_cmdline(
     default_grub.update_cmdline_args(SELINUX_CMDLINE_ARG_NAMES, &new_args)
 }
 
-#[cfg_attr(not(test), allow(unused_imports, dead_code))]
-mod functional_test {
+#[cfg(test)]
+mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
 
-    use pytest_gen::functional_test;
-
-    use crate::OsModifierContext;
-
-    #[functional_test(feature = "core")]
+    #[test]
     fn test_update_selinux_config_enforcing() {
         let tmp = tempdir().unwrap();
         let etc = tmp.path().join("etc/selinux");
@@ -133,7 +129,7 @@ mod functional_test {
         );
     }
 
-    #[functional_test(feature = "core")]
+    #[test]
     fn test_update_selinux_config_disabled() {
         let tmp = tempdir().unwrap();
         let etc = tmp.path().join("etc/selinux");
@@ -153,7 +149,7 @@ mod functional_test {
         );
     }
 
-    #[functional_test(feature = "core", negative = true)]
+    #[test]
     fn test_update_selinux_config_missing_file() {
         let tmp = tempdir().unwrap();
         let ctx = OsModifierContext {
@@ -167,7 +163,7 @@ mod functional_test {
         );
     }
 
-    #[functional_test(feature = "core")]
+    #[test]
     fn test_update_selinux_grub_cmdline_enforcing() {
         let tmp = tempdir().unwrap();
         let etc = tmp.path().join("etc/default");

--- a/crates/osmodifier/src/services.rs
+++ b/crates/osmodifier/src/services.rs
@@ -69,16 +69,13 @@ fn disable_service(ctx: &OsModifierContext, service: &str) -> Result<(), Error> 
     Ok(())
 }
 
-#[cfg_attr(not(test), allow(unused_imports, dead_code))]
-mod functional_test {
+#[cfg(test)]
+mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
 
-    use pytest_gen::functional_test;
     use trident_api::config::Services;
-
-    use crate::OsModifierContext;
 
     /// Create a minimal systemd tree with a synthetic service unit.
     fn setup_systemd_root(tmp: &std::path::Path) {
@@ -95,7 +92,7 @@ mod functional_test {
         .unwrap();
     }
 
-    #[functional_test(feature = "core")]
+    #[test]
     fn test_enable_service() {
         let tmp = tempdir().unwrap();
         setup_systemd_root(tmp.path());
@@ -123,7 +120,7 @@ mod functional_test {
         );
     }
 
-    #[functional_test(feature = "core")]
+    #[test]
     fn test_disable_service() {
         let tmp = tempdir().unwrap();
         setup_systemd_root(tmp.path());
@@ -156,7 +153,7 @@ mod functional_test {
         );
     }
 
-    #[functional_test(feature = "core")]
+    #[test]
     fn test_disable_already_disabled_service() {
         let tmp = tempdir().unwrap();
         setup_systemd_root(tmp.path());

--- a/crates/osutils/src/blkid.rs
+++ b/crates/osutils/src/blkid.rs
@@ -60,40 +60,11 @@ mod functional_test {
         // e.g. 8AA2-EE49
     }
 
-    #[functional_test(feature = "helpers", negative = true)]
-    fn test_run_fail_on_non_block_file() {
-        assert!(super::run(Path::new("/dev/null"), "PARTLABEL")
-            .unwrap_err()
-            .root_cause()
-            .to_string()
-            .contains("Dependency 'blkid' finished unsuccessfully"));
-    }
-
-    #[functional_test(feature = "helpers", negative = true)]
-    fn test_run_fail_on_missing_file() {
-        assert!(super::run(Path::new("/dev/does-not-exist"), "PARTLABEL")
-            .unwrap_err()
-            .root_cause()
-            .to_string()
-            .contains("Dependency 'blkid' finished unsuccessfully"));
-    }
-
     #[functional_test(feature = "helpers")]
     fn test_get_filesystem_uuid_raw_success() {
         let uuid = super::get_filesystem_uuid_raw(Path::new("/dev/sda2")).unwrap();
         Uuid::parse_str(&uuid).unwrap();
         assert_eq!(super::run(Path::new("/dev/sda2"), "UUID").unwrap(), uuid);
-    }
-
-    #[functional_test(feature = "helpers", negative = true)]
-    fn test_get_filesystem_uuid_raw_fail_on_missing_file() {
-        assert!(
-            super::get_filesystem_uuid_raw(Path::new("/dev/does-not-exist"))
-                .unwrap_err()
-                .root_cause()
-                .to_string()
-                .contains("Dependency 'blkid' finished unsuccessfully")
-        );
     }
 
     #[functional_test(feature = "helpers")]
@@ -103,15 +74,6 @@ mod functional_test {
             super::run(Path::new("/dev/sda2"), "UUID").unwrap(),
             uuid.to_string()
         );
-    }
-
-    #[functional_test(feature = "helpers", negative = true)]
-    fn test_get_filesystem_uuid_fail_on_missing_file() {
-        assert!(super::get_filesystem_uuid(Path::new("/dev/does-not-exist"))
-            .unwrap_err()
-            .root_cause()
-            .to_string()
-            .contains("Dependency 'blkid' finished unsuccessfully"));
     }
 
     #[functional_test(feature = "helpers", negative = true)]
@@ -130,8 +92,51 @@ mod functional_test {
         let partlabel = super::get_partition_label(Path::new("/dev/sda1")).unwrap();
         assert_eq!(partlabel, "esp");
     }
+}
 
-    #[functional_test(feature = "helpers", negative = true)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run_fail_on_non_block_file() {
+        assert!(super::run(Path::new("/dev/null"), "PARTLABEL")
+            .unwrap_err()
+            .root_cause()
+            .to_string()
+            .contains("Dependency 'blkid' finished unsuccessfully"));
+    }
+
+    #[test]
+    fn test_run_fail_on_missing_file() {
+        assert!(super::run(Path::new("/dev/does-not-exist"), "PARTLABEL")
+            .unwrap_err()
+            .root_cause()
+            .to_string()
+            .contains("Dependency 'blkid' finished unsuccessfully"));
+    }
+
+    #[test]
+    fn test_get_filesystem_uuid_raw_fail_on_missing_file() {
+        assert!(
+            super::get_filesystem_uuid_raw(Path::new("/dev/does-not-exist"))
+                .unwrap_err()
+                .root_cause()
+                .to_string()
+                .contains("Dependency 'blkid' finished unsuccessfully")
+        );
+    }
+
+    #[test]
+    fn test_get_filesystem_uuid_fail_on_missing_file() {
+        assert!(super::get_filesystem_uuid(Path::new("/dev/does-not-exist"))
+            .unwrap_err()
+            .root_cause()
+            .to_string()
+            .contains("Dependency 'blkid' finished unsuccessfully"));
+    }
+
+    #[test]
     fn test_get_partition_label_fail_on_missing_file() {
         assert!(super::get_partition_label(Path::new("/dev/does-not-exist"))
             .unwrap_err()

--- a/crates/osutils/src/block_devices.rs
+++ b/crates/osutils/src/block_devices.rs
@@ -298,6 +298,25 @@ mod tests {
             format!("Failed to canonicalize target path '{}'", target.display())
         );
     }
+
+    #[test]
+    fn test_partx_update_failure() {
+        let disk_path = Path::new("/dev/does-not-exist");
+        let err_out = partx_update(disk_path).unwrap_err();
+        // Check contextual error message
+        assert_eq!(
+            err_out.to_string(),
+            format!(
+                "Failed to re-read partition table for disk '{}'",
+                disk_path.display()
+            )
+        );
+        // Check DependencyError in root cause
+        assert!(err_out
+            .root_cause()
+            .to_string()
+            .contains("Dependency 'partx' finished unsuccessfully"));
+    }
 }
 
 #[cfg(feature = "functional-test")]
@@ -331,25 +350,6 @@ mod functional_test {
             get_disk_for_partition(partition).unwrap_err().to_string(),
             "Failed to get partition metadata for '/dev/sdc1'",
         );
-    }
-
-    #[functional_test]
-    fn test_partx_update_failure() {
-        let disk_path = Path::new("/dev/does-not-exist");
-        let err_out = partx_update(disk_path).unwrap_err();
-        // Check contextual error message
-        assert_eq!(
-            err_out.to_string(),
-            format!(
-                "Failed to re-read partition table for disk '{}'",
-                disk_path.display()
-            )
-        );
-        // Check DependencyError in root cause
-        assert!(err_out
-            .root_cause()
-            .to_string()
-            .contains("Dependency 'partx' finished unsuccessfully"));
     }
 
     #[functional_test]

--- a/crates/osutils/src/chroot.rs
+++ b/crates/osutils/src/chroot.rs
@@ -363,8 +363,7 @@ mod functional_test {
     }
 
     #[functional_test(feature = "helpers", negative = true)]
-    fn test_enter_chroot_fail_to_mount_special_dir() {
-        // Create a temporary directory to act as the chroot environment
+    fn test_enter_chroot_fail_to_mount_special_dir() {        // Create a temporary directory to act as the chroot environment
         let temp_dir = tempdir().unwrap();
         let chroot_path = temp_dir.path().to_path_buf();
 
@@ -413,8 +412,14 @@ mod functional_test {
 
         // Mounting a new /proc filesystem over the existing one does not fail
     }
+}
 
-    #[functional_test(feature = "helpers", negative = true)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trident_api::error::ErrorKind;
+
+    #[test]
     fn test_enter_chroot_fail_nonexistent_dir() {
         // Attempt to enter the chroot
         let result = Chroot::enter(Path::new("/nonexistent-dir"));

--- a/crates/osutils/src/chroot.rs
+++ b/crates/osutils/src/chroot.rs
@@ -363,7 +363,8 @@ mod functional_test {
     }
 
     #[functional_test(feature = "helpers", negative = true)]
-    fn test_enter_chroot_fail_to_mount_special_dir() {        // Create a temporary directory to act as the chroot environment
+    fn test_enter_chroot_fail_to_mount_special_dir() {
+        // Create a temporary directory to act as the chroot environment
         let temp_dir = tempdir().unwrap();
         let chroot_path = temp_dir.path().to_path_buf();
 

--- a/crates/osutils/src/lsblk.rs
+++ b/crates/osutils/src/lsblk.rs
@@ -1286,6 +1286,16 @@ mod tests {
         };
         assert_eq!(bd.device_path(), PathBuf::from("/dev/sda"));
     }
+
+    #[test]
+    fn test_get_fail_on_non_block_file() {
+        assert!(super::get(Path::new("/dev/null")).unwrap_err().root_cause().to_string().contains("stdout:\n{\n   \"blockdevices\": [\n\n   ]\n}\n\n\nstderr:\nlsblk: /dev/null: not a block device\n\n"));
+    }
+
+    #[test]
+    fn test_get_fail_on_missing_file() {
+        assert!(super::get(Path::new("/dev/does-not-exist")).unwrap_err().root_cause().to_string().contains("stdout:\n{\n   \"blockdevices\": [\n\n   ]\n}\n\n\nstderr:\nlsblk: /dev/does-not-exist: not a block device\n\n"));
+    }
 }
 
 #[cfg(feature = "functional-test")]
@@ -1337,15 +1347,5 @@ mod functional_test {
 
         assert_eq!(block_device.name, "/dev/sda");
         assert_eq!(block_device.children.len(), 5);
-    }
-
-    #[functional_test(feature = "helpers", negative = true)]
-    fn test_get_fail_on_non_block_file() {
-        assert!(super::get(Path::new("/dev/null")).unwrap_err().root_cause().to_string().contains("stdout:\n{\n   \"blockdevices\": [\n\n   ]\n}\n\n\nstderr:\nlsblk: /dev/null: not a block device\n\n"));
-    }
-
-    #[functional_test(feature = "helpers", negative = true)]
-    fn test_get_fail_on_missing_file() {
-        assert!(super::get(Path::new("/dev/does-not-exist")).unwrap_err().root_cause().to_string().contains("stdout:\n{\n   \"blockdevices\": [\n\n   ]\n}\n\n\nstderr:\nlsblk: /dev/does-not-exist: not a block device\n\n"));
     }
 }

--- a/crates/osutils/src/udevadm.rs
+++ b/crates/osutils/src/udevadm.rs
@@ -39,13 +39,18 @@ mod functional_test {
     use pytest_gen::functional_test;
 
     #[functional_test(feature = "helpers")]
-    fn test_settle() {
-        settle().unwrap();
-    }
-
-    #[functional_test(feature = "helpers")]
     fn test_trigger() {
         trigger().unwrap();
         wait(Path::new("/dev/sda")).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_settle() {
+        settle().unwrap();
     }
 }

--- a/crates/trident/src/datastore.rs
+++ b/crates/trident/src/datastore.rs
@@ -306,20 +306,14 @@ mod tests {
             .parse_host_status(Ok(serde_yaml::to_string(&valid_host_status).unwrap()))
             .is_some());
     }
-}
 
-#[cfg(feature = "functional-test")]
-#[cfg_attr(not(test), allow(unused_imports, dead_code))]
-mod functional_test {
-    use super::*;
-
-    use tempfile::TempDir;
-
-    use pytest_gen::functional_test;
-    use trident_api::{error::ErrorKind, status::ServicingState};
-
-    #[functional_test]
+    #[test]
     fn test_open_temporary_persist_reopen() {
+        use tempfile::TempDir;
+        use trident_api::{error::ErrorKind, status::ServicingState};
+
+        use super::{DataStore, DatastoreError, ServicingError};
+
         let temp_dir = TempDir::new().unwrap();
         let datastore_temp_path = temp_dir.path().join("db-tmp.sqlite");
         let datastore_path = temp_dir.path().join("db.sqlite");

--- a/crates/trident/src/engine/rollback.rs
+++ b/crates/trident/src/engine/rollback.rs
@@ -1045,7 +1045,6 @@ mod tests {
         )
         .unwrap());
     }
-
 }
 
 #[cfg(feature = "functional-test")]

--- a/crates/trident/src/engine/rollback.rs
+++ b/crates/trident/src/engine/rollback.rs
@@ -1026,12 +1026,43 @@ mod tests {
             PathBuf::from(formatcp!("{TEST_DISK_DEVICE_PATH}2"))
         );
     }
+
+    #[test]
+    fn test_compare_root_device_paths() {
+        // Test case #0: If current root device path is the same as the expected root device path,
+        // should return true.
+        assert!(compare_root_device_paths(
+            PathBuf::from(formatcp!("{TEST_DISK_DEVICE_PATH}2")),
+            PathBuf::from(formatcp!("{TEST_DISK_DEVICE_PATH}2"))
+        )
+        .unwrap());
+
+        // Test case #1: If current root device path is NOT the same as the expected root device
+        // path, should return false.
+        assert!(!compare_root_device_paths(
+            PathBuf::from(formatcp!("{TEST_DISK_DEVICE_PATH}2")),
+            PathBuf::from(formatcp!("{TEST_DISK_DEVICE_PATH}3"))
+        )
+        .unwrap());
+    }
+
 }
 
 #[cfg(feature = "functional-test")]
 #[cfg_attr(not(test), allow(unused_imports, dead_code))]
 mod functional_test {
     use super::*;
+
+    #[functional_test]
+    fn test_construct_by_partuuid_path() {
+        // Test with a valid device path having a part_uuid
+        let device_path = PathBuf::from(formatcp!("{OS_DISK_DEVICE_PATH}1"));
+        construct_by_partuuid_path(&device_path).unwrap();
+
+        // Test with an invalid device path
+        let device_path = PathBuf::from("/dev/invalid");
+        assert_eq!(construct_by_partuuid_path(&device_path), None);
+    }
 
     use std::path::PathBuf;
 
@@ -1052,36 +1083,6 @@ mod functional_test {
         error::ErrorKind,
         status::AbVolumeSelection,
     };
-
-    #[functional_test]
-    fn test_compare_root_device_paths() {
-        // Test case #0: If current root device path is the same as the expected root device path,
-        // should return true.
-        assert!(compare_root_device_paths(
-            PathBuf::from(formatcp!("{TEST_DISK_DEVICE_PATH}2")),
-            PathBuf::from(formatcp!("{TEST_DISK_DEVICE_PATH}2"))
-        )
-        .unwrap());
-
-        // Test case #1: If current root device path is NOT the same as the expected root device
-        // path, should return false.
-        assert!(!compare_root_device_paths(
-            PathBuf::from(formatcp!("{TEST_DISK_DEVICE_PATH}2")),
-            PathBuf::from(formatcp!("{TEST_DISK_DEVICE_PATH}3"))
-        )
-        .unwrap());
-    }
-
-    #[functional_test]
-    fn test_construct_by_partuuid_path() {
-        // Test with a valid device path having a part_uuid
-        let device_path = PathBuf::from(formatcp!("{OS_DISK_DEVICE_PATH}1"));
-        construct_by_partuuid_path(&device_path).unwrap();
-
-        // Test with an invalid device path
-        let device_path = PathBuf::from("/dev/invalid");
-        assert_eq!(construct_by_partuuid_path(&device_path), None);
-    }
 
     /// Validates that validate_ab_active_volume_internal() works as a expected.
     #[functional_test]

--- a/crates/trident/src/engine/storage/rebuild.rs
+++ b/crates/trident/src/engine/storage/rebuild.rs
@@ -427,8 +427,8 @@ mod tests {
     use osutils::testutils::repart::TEST_DISK_DEVICE_PATH;
     use trident_api::{
         config::{
-            Disk, FileSystemSource, MountOptions, MountPoint, Partition, PartitionSize,
-            PartitionType, RaidLevel, Storage,
+            AdoptedPartition, Disk, FileSystemSource, MountOptions, MountPoint, Partition,
+            PartitionSize, PartitionTableType, PartitionType, RaidLevel, Storage,
         },
         status::ServicingState,
     };
@@ -882,6 +882,152 @@ mod tests {
             "Partition 'disk2part3' is neither a member of a software RAID array nor an unformatted partition, refusing to rebuild"
         );
     }
+
+    /// Returns the Host Configuration and Host Status.
+    fn get_hostconfig_and_hoststatus() -> (HostConfiguration, trident_api::status::HostStatus) {
+        let host_config = HostConfiguration {
+            storage: Storage {
+                disks: vec![
+                    Disk {
+                        id: "disk".to_string(),
+                        device: PathBuf::from("/dev/sda"),
+                        partitions: vec![Partition {
+                            id: "raidpart1".to_string(),
+                            partition_type: PartitionType::Root,
+                            size: PartitionSize::from_str("1G").unwrap(),
+                            uuid: None,
+                            label: None,
+                        }],
+                        partition_table_type: PartitionTableType::Gpt,
+                        adopted_partitions: vec![
+                            AdoptedPartition {
+                                id: "esp".to_string(),
+                                match_label: Some("esp".to_string()),
+                                match_uuid: None,
+                            },
+                            AdoptedPartition {
+                                id: "root-a".to_string(),
+                                match_label: Some("root-a".to_string()),
+                                match_uuid: None,
+                            },
+                            AdoptedPartition {
+                                id: "root-b".to_string(),
+                                match_label: Some("root-b".to_string()),
+                                match_uuid: None,
+                            },
+                            AdoptedPartition {
+                                id: "swap".to_string(),
+                                match_label: Some("swap".to_string()),
+                                match_uuid: None,
+                            },
+                            AdoptedPartition {
+                                id: "trident".to_string(),
+                                match_label: Some("trident".to_string()),
+                                match_uuid: None,
+                            },
+                        ],
+                    },
+                    Disk {
+                        id: "disk2".to_string(),
+                        device: PathBuf::from(TEST_DISK_DEVICE_PATH),
+                        partitions: vec![Partition {
+                            id: "raidpart2".to_string(),
+                            partition_type: PartitionType::Root,
+                            size: PartitionSize::from_str("1G").unwrap(),
+                            uuid: None,
+                            label: None,
+                        }],
+                        ..Default::default()
+                    },
+                ],
+                raid: trident_api::config::Raid {
+                    software: vec![trident_api::config::SoftwareRaidArray {
+                        name: "raid1".to_string(),
+                        id: "raid1".to_string(),
+                        level: RaidLevel::Raid1,
+                        devices: vec!["raidpart1".to_string(), "raidpart2".to_string()],
+                    }],
+                    ..Default::default()
+                },
+
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let host_status = trident_api::status::HostStatus {
+            spec: host_config.clone(),
+            servicing_state: ServicingState::Provisioned,
+            ..Default::default()
+        };
+
+        (host_config, host_status)
+    }
+
+    #[test]
+    fn test_validate_rebuild_raid_validation_failure() {
+        let (host_config, mut host_status) = get_hostconfig_and_hoststatus();
+
+        // Remove disk2 UUID from Host Status.
+        host_status.disk_uuids.remove("disk2");
+
+        // Fail validation.
+        host_status.servicing_state = trident_api::status::ServicingState::CleanInstallStaged;
+
+        let disks_to_rebuild = vec!["disk2".to_string()];
+
+        let err = validate_rebuild_raid(&host_config, &mut host_status, &disks_to_rebuild);
+
+        assert_eq!(
+            err.unwrap_err().to_string(),
+            "rebuild-raid command is not allowed when servicing state is CleanInstallStaged"
+        );
+    }
+
+    #[test]
+    fn test_validate_rebuild_raid_raidrecovery_failure() {
+        let (host_config, mut host_status) = get_hostconfig_and_hoststatus();
+
+        // Remove disk2 UUID from Host Status.
+        host_status.disk_uuids.remove("disk2");
+
+        // Add a RAID array raid2 which has partitions on disk2 to the Host Configuration.
+        let mut host_config = host_config;
+        host_config.storage.disks[1].partitions.push(Partition {
+            id: "disk2part2".to_string(),
+            partition_type: PartitionType::Root,
+            size: PartitionSize::from_str("1G").unwrap(),
+            uuid: None,
+            label: None,
+        });
+        host_config.storage.disks[1].partitions.push(Partition {
+            id: "disk2part3".to_string(),
+            partition_type: PartitionType::Root,
+            size: PartitionSize::from_str("1G").unwrap(),
+            uuid: None,
+            label: None,
+        });
+        host_config
+            .storage
+            .raid
+            .software
+            .push(trident_api::config::SoftwareRaidArray {
+                name: "raid2".to_string(),
+                id: "raid2".to_string(),
+                level: RaidLevel::Raid1,
+                devices: vec!["disk2part2".to_string(), "disk2part3".to_string()],
+            });
+
+        host_status.spec = host_config.clone();
+
+        let disks_to_rebuild = vec!["disk2".to_string()];
+
+        let err = validate_rebuild_raid(&host_config, &mut host_status, &disks_to_rebuild);
+
+        assert_eq!(
+            err.unwrap_err().to_string(),
+            "Failed to validate RAID recovery"
+        );
+    }
 }
 
 #[cfg(feature = "functional-test")]
@@ -1074,71 +1220,5 @@ mod functional_test {
 
         // Delete the partition.
         delete_partition();
-    }
-
-    #[functional_test]
-    fn test_validate_rebuild_raid_validation_failure() {
-        let (host_config, mut host_status) = get_hostconfig_and_hoststatus();
-
-        // Remove disk2 UUID from Host Status.
-        host_status.disk_uuids.remove("disk2");
-
-        // Fail validation.
-        host_status.servicing_state = trident_api::status::ServicingState::CleanInstallStaged;
-
-        let disks_to_rebuild = vec!["disk2".to_string()];
-
-        let err = validate_rebuild_raid(&host_config, &mut host_status, &disks_to_rebuild);
-
-        assert_eq!(
-            err.unwrap_err().to_string(),
-            "rebuild-raid command is not allowed when servicing state is CleanInstallStaged"
-        );
-    }
-
-    #[functional_test]
-    fn test_validate_rebuild_raid_raidrecovery_failure() {
-        let (host_config, mut host_status) = get_hostconfig_and_hoststatus();
-
-        // Remove disk2 UUID from Host Status.
-        host_status.disk_uuids.remove("disk2");
-
-        // Add a RAID array raid2 which has partitions on disk2 to the Host Configuration.
-        let mut host_config = host_config;
-        host_config.storage.disks[1].partitions.push(Partition {
-            id: "disk2part2".to_string(),
-            partition_type: PartitionType::Root,
-            size: PartitionSize::from_str("1G").unwrap(),
-            uuid: None,
-            label: None,
-        });
-        host_config.storage.disks[1].partitions.push(Partition {
-            id: "disk2part3".to_string(),
-            partition_type: PartitionType::Root,
-            size: PartitionSize::from_str("1G").unwrap(),
-            uuid: None,
-            label: None,
-        });
-        host_config
-            .storage
-            .raid
-            .software
-            .push(trident_api::config::SoftwareRaidArray {
-                name: "raid2".to_string(),
-                id: "raid2".to_string(),
-                level: RaidLevel::Raid1,
-                devices: vec!["disk2part2".to_string(), "disk2part3".to_string()],
-            });
-
-        host_status.spec = host_config.clone();
-
-        let disks_to_rebuild = vec!["disk2".to_string()];
-
-        let err = validate_rebuild_raid(&host_config, &mut host_status, &disks_to_rebuild);
-
-        assert_eq!(
-            err.unwrap_err().to_string(),
-            "Failed to validate RAID recovery"
-        );
     }
 }

--- a/crates/trident/src/logging/tracestream.rs
+++ b/crates/trident/src/logging/tracestream.rs
@@ -476,6 +476,15 @@ mod tests {
         let uuid = read_product_uuid(filepath.to_str().unwrap().to_string());
         assert_eq!(uuid, "test_uuid");
     }
+
+    #[test]
+    fn test_populate_additional_fields() {
+        let additional_fields = populate_additional_fields();
+        assert_eq!(
+            additional_fields.get("trident_version").unwrap(),
+            &json!(TRIDENT_VERSION)
+        );
+    }
 }
 
 #[cfg(feature = "functional-test")]
@@ -519,15 +528,6 @@ mod functional_test {
         assert!(
             metric_found,
             "Expected test metric not found in the local metrics file"
-        );
-    }
-
-    #[functional_test]
-    fn test_populate_additional_fields() {
-        let additional_fields = populate_additional_fields();
-        assert_eq!(
-            additional_fields.get("trident_version").unwrap(),
-            &json!(TRIDENT_VERSION)
         );
     }
 

--- a/crates/trident/src/monitor_metrics.rs
+++ b/crates/trident/src/monitor_metrics.rs
@@ -547,16 +547,13 @@ mod stat_tests {
     }
 }
 
-#[cfg(feature = "functional-test")]
-#[cfg_attr(not(test), allow(unused_imports, dead_code))]
-mod functional_test {
+#[cfg(test)]
+mod tests {
     use super::*;
 
-    use std::sync::{Arc, Mutex};
+    use std::sync::Mutex;
 
     use tracing_subscriber::{layer::SubscriberExt, Registry};
-
-    use pytest_gen::functional_test;
 
     #[derive(Debug, Clone, Default)]
     struct TestTraceWriter {
@@ -590,7 +587,7 @@ mod functional_test {
         logs
     }
 
-    #[functional_test]
+    #[test]
     fn test_monitor_metrics() {
         let trace_logs = init_monitor_metrics_tracing_validation_global();
 

--- a/crates/trident/src/stream.rs
+++ b/crates/trident/src/stream.rs
@@ -175,6 +175,7 @@ mod tests {
             PathBuf::from("/dev/sdb")
         );
     }
+
 }
 
 #[cfg(feature = "functional-test")]

--- a/crates/trident/src/stream.rs
+++ b/crates/trident/src/stream.rs
@@ -175,7 +175,6 @@ mod tests {
             PathBuf::from("/dev/sdb")
         );
     }
-
 }
 
 #[cfg(feature = "functional-test")]


### PR DESCRIPTION
Converts 38 #[functional_test] tests to plain #[test]s. These tests only touch synthetic temp-root state, or invoke tools/paths already available in the plain unit-test image, with no real disk/EFI mutation, privileged mount, or VM-specific hardware/layout dependency.

9 tests initially identified as candidates were reverted after real test runs proved they need root/privileged mount, VM-specific hardware, or a tool (systemd-firstboot) absent from the plain unit-test image:
- logging::tracestream::test_populate_platform_info (hardcodes VM CPU/RAM specs)
- subsystems::extensions::mod tests x4 (loop-mount setup needs root)
- osutils::container tests x3 (writes to real root-level paths, needs root)
- subsystems::storage::verity::test_create_machine_id (needs systemd-firstboot, absent from base image)

Verified: cargo check --all-targets --workspace --all-features clean; full unit-test suites pass with zero failures (trident 396/396, osutils 167/167, osmodifier 101/101).