### PR TITLE
telemetry: add stream_image_success and clean_install_finalized completion metrics

### DIFF
--- a/crates/trident/src/lib.rs
+++ b/crates/trident/src/lib.rs
@@ -908,7 +908,17 @@ impl Trident {
         self.host_config = Some(config);
         self.is_stream_image = true;
 
-        self.install(datastore, Operations::all(), false, Some(image))
+        // `stream_image_start` above marks the beginning of a streamed
+        // install; mirror it with a completion signal here so streaming
+        // failures/successes are distinguishable in telemetry without
+        // relying on the downstream `clean_install_*` metrics (which are
+        // specific to the clean-install engine step, not the streaming
+        // entry point as a whole).
+        let result = self.install(datastore, Operations::all(), false, Some(image));
+        if result.is_ok() {
+            tracing::info!(metric_name = "stream_image_success", value = true);
+        }
+        result
     }
 
     pub fn commit(


### PR DESCRIPTION
`stream_image_start` metric is created with no matching completion signal.  add `stream_image_success` and ensure that `clean_install_success` is created for stream image.

Related PRs in stack:
* #773
* #774
* #778
* #779
* #781
* [this PR] #783