### PR TITLE
bug: create the ESP staging directory when the OS image omits it

### DIFF
--- a/crates/trident/src/engine/boot/mod.rs
+++ b/crates/trident/src/engine/boot/mod.rs
@@ -16,6 +16,11 @@ pub mod uki;
 
 pub(crate) const ESP_EXTRACTION_DIRECTORY: &str = VAR_TMP_PATH;
 
+/// Mode to create [`ESP_EXTRACTION_DIRECTORY`] with when the OS image does not
+/// ship it. `/var/tmp` is world-writable with the sticky bit set on a
+/// conventional system, and systemd-tmpfiles expects to find it that way.
+pub(crate) const ESP_EXTRACTION_DIRECTORY_MODE: u32 = 0o1777;
+
 #[derive(Default, Debug)]
 pub(super) struct BootSubsystem;
 impl Subsystem for BootSubsystem {

--- a/crates/trident/src/subsystems/esp.rs
+++ b/crates/trident/src/subsystems/esp.rs
@@ -2,6 +2,7 @@ use std::{
     fs,
     io::Read,
     ops::ControlFlow,
+    os::unix::fs::PermissionsExt,
     path::{Path, PathBuf},
 };
 
@@ -12,6 +13,7 @@ use tempfile::{NamedTempFile, TempDir};
 
 use osutils::{
     bootloaders::{BOOT_EFI, GRUB_EFI, GRUB_NOPREFIX_EFI},
+    files,
     filesystems::MountFileSystemType,
     mount::{self, MountGuard},
     path,
@@ -29,7 +31,7 @@ use trident_api::{
 
 use crate::{
     engine::{
-        boot::{self, uki, ESP_EXTRACTION_DIRECTORY},
+        boot::{self, uki, ESP_EXTRACTION_DIRECTORY, ESP_EXTRACTION_DIRECTORY_MODE},
         EngineContext, Subsystem,
     },
     io_utils::{
@@ -117,7 +119,7 @@ fn deploy_esp(ctx: &EngineContext, mount_point: &Path) -> Result<(), TridentErro
     // `<newroot>/ESP_EXTRACTION_DIRECTORY`. This location is generally
     // guaranteed to be writable and backed by a real block device, so we don't
     // have to store a potentially large ESP image in memory.
-    let esp_extraction_dir = path::join_relative(mount_point, ESP_EXTRACTION_DIRECTORY);
+    let esp_extraction_dir = ensure_esp_extraction_dir(mount_point)?;
 
     // Get the threshold and interval for reporting slow streaming speed from
     // the context, to be used in the ReadMonitor while streaming images to the
@@ -180,6 +182,40 @@ fn deploy_esp(ctx: &EngineContext, mount_point: &Path) -> Result<(), TridentErro
     }
 
     Ok(())
+}
+
+/// Returns the directory under `mount_point` to stage the ESP image in,
+/// creating it if the OS image does not ship it.
+///
+/// The staging directory is deliberately on the newly written root rather than
+/// in memory, since an ESP image can be large. It is not guaranteed to exist
+/// there, though: an immutable OS image may ship a root filesystem with no
+/// `/var` at all and leave systemd-tmpfiles to populate it on first boot. In
+/// that case create it with the mode `/var/tmp` is expected to have, so that we
+/// neither fail the deployment nor leave the installed system with a
+/// wrongly-permissioned directory.
+fn ensure_esp_extraction_dir(mount_point: &Path) -> Result<PathBuf, TridentError> {
+    let esp_extraction_dir = path::join_relative(mount_point, ESP_EXTRACTION_DIRECTORY);
+
+    if !esp_extraction_dir.exists() {
+        debug!(
+            "Creating ESP staging directory '{}'",
+            esp_extraction_dir.display()
+        );
+
+        files::create_dirs(&esp_extraction_dir)
+            .structured(ServicingError::DeployESPImages)
+            .message("Failed to create the ESP staging directory")?;
+
+        fs::set_permissions(
+            &esp_extraction_dir,
+            fs::Permissions::from_mode(ESP_EXTRACTION_DIRECTORY_MODE),
+        )
+        .structured(ServicingError::DeployESPImages)
+        .message("Failed to set permissions on the ESP staging directory")?;
+    }
+
+    Ok(esp_extraction_dir)
 }
 
 /// Takes in a reader to the raw zstd-compressed ESP image and decompresses it
@@ -1505,6 +1541,55 @@ mod tests {
                 "Failed to find shim EFI executable at path '{}'",
                 boot_efi_path.display()
             )
+        );
+    }
+
+    /// Tests that [`ensure_esp_extraction_dir`] creates the staging directory
+    /// when the OS image does not ship one.
+    ///
+    /// Immutable images such as Azure Container Linux ship a root filesystem
+    /// with no `/var` at all, leaving systemd-tmpfiles to populate it on first
+    /// boot. Staging the ESP image used to fail against such an image, after
+    /// the disk had already been repartitioned.
+    #[test]
+    fn test_ensure_esp_extraction_dir_creates_missing_dir() {
+        let newroot = TempDir::new().unwrap();
+
+        // A root filesystem with no /var whatsoever, as ACL ships.
+        assert!(!newroot.path().join("var").exists());
+
+        let dir = ensure_esp_extraction_dir(newroot.path()).unwrap();
+
+        assert!(dir.is_dir(), "staging directory should have been created");
+        assert_eq!(dir, newroot.path().join("var/tmp"));
+        assert_eq!(
+            fs::metadata(&dir).unwrap().permissions().mode() & 0o7777,
+            ESP_EXTRACTION_DIRECTORY_MODE,
+            "staging directory should be created as sticky and world-writable, \
+            like a conventional /var/tmp"
+        );
+
+        // A temporary file can actually be created there, which is what the
+        // deployment goes on to do.
+        NamedTempFile::new_in(&dir).unwrap();
+    }
+
+    /// Tests that [`ensure_esp_extraction_dir`] leaves an existing staging
+    /// directory alone, rather than changing the permissions an image chose.
+    #[test]
+    fn test_ensure_esp_extraction_dir_preserves_existing_dir() {
+        let newroot = TempDir::new().unwrap();
+        let existing = newroot.path().join("var/tmp");
+        fs::create_dir_all(&existing).unwrap();
+        fs::set_permissions(&existing, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let dir = ensure_esp_extraction_dir(newroot.path()).unwrap();
+
+        assert_eq!(dir, existing);
+        assert_eq!(
+            fs::metadata(&dir).unwrap().permissions().mode() & 0o7777,
+            0o755,
+            "an existing staging directory should be left untouched"
         );
     }
 }

--- a/crates/trident/src/subsystems/storage/osimage.rs
+++ b/crates/trident/src/subsystems/storage/osimage.rs
@@ -456,7 +456,16 @@ fn validate_esp(os_image: &OsImage, ctx: &EngineContext) -> Result<(), TridentEr
     }
 
     let Some(available_space) = ctx.filesystem_block_device_size(ESP_EXTRACTION_DIRECTORY) else {
-        warn!("Failed to check if there is enough space available on '{ESP_EXTRACTION_DIRECTORY}' to copy ESP image.");
+        // Most commonly the backing partition is sized to grow into the
+        // remaining disk space, so its size is not known ahead of servicing.
+        // Skip the check rather than fail on it, but say so: it is a check that
+        // did not happen, not a check that passed.
+        warn!(
+            "Cannot check whether there is enough space to copy the ESP image into \
+            '{ESP_EXTRACTION_DIRECTORY}': the size of its backing block device is not known, which \
+            is expected when the partition is configured to grow. Skipping the check; servicing may \
+            still fail later if the space is insufficient."
+        );
         return Ok(());
     };
 


### PR DESCRIPTION
# 🔍 Description

**bug.** File-based ESP deployment stages the ESP image through `<newroot>/var/tmp` and assumes that directory exists. It does not on an immutable image, so `trident install` fails **after the disk has already been repartitioned**.

Split out of #754, which needed this to install Azure Container Linux but is otherwise about inline dm-verity. This fix stands on its own: it applies to any image that does not ship `/var/tmp`, and depends on nothing else in that PR.

# 🤔 Rationale

`deploy_esp` extracts the ESP image to a temporary file and copies from it, rather than holding a potentially large image in memory. The comment there records the reasoning — the staging location "is generally guaranteed to be writable and backed by a real block device".

That assumption does not hold for an image that assembles its root at boot. Azure Container Linux ships a root filesystem containing only three mount points, `lost+found` and a few symlinks:

```
$ debugfs -R "ls -l /" root.raw     # root partition, straight out of the COSI
      2   40755 .          11   40700 lost+found     14   40755 usr
     13   40755 oem        15   40755 boot           37  120777 lib -> usr/lib
```

There is no `/var` at all; systemd-tmpfiles populates it on first boot. `NamedTempFile::new_in` therefore has nothing to create into, and servicing fails in Provision:

```
Failed to perform file-based deployment of ESP images
Failed to create a temporary file
```

By that point the disk has been repartitioned and the usr, oem and root filesystems written, so the failure leaves the machine in a worse state than it started.

### Changes

**Create the staging directory when it is missing**, with the sticky, world-writable mode a conventional `/var/tmp` has. The mode matters: left at the default the installed system would carry a wrongly-permissioned `/var/tmp`, which systemd-tmpfiles expects to find at `1777` — the kind of defect that surfaces much later as "why can't anything write there". An existing directory is deliberately **not** re-chmodded, so an image that ships its own keeps whatever mode it chose.

Path computation and creation move into `ensure_esp_extraction_dir`, so both branches are testable.

**Separately, reword the neighbouring space check.** It reported `Failed to check if there is enough space available` whenever the backing device size was unknown, which reads like a malfunction. The usual cause is a partition configured to `grow`, whose size is not knowable before servicing — true of ordinary images, not just unusual ones. It now says so, and makes clear the check was *skipped* rather than passed.

`stream-disk` was never affected: it writes the ESP partition image directly rather than staging it through a file.

# 📝 Checks

- [x] Check [dev-docs/manual-validation.md](/dev-docs/manual-validation.md)

Manually validated on a real ACL image, installed via `trident install` from an installer ISO in QEMU/KVM. Before this change, install failed in Provision as above; after it, install proceeds past ESP deployment. The full chain — install to a booting system — was subsequently confirmed on the same image.

Automated: two unit tests covering both branches (creates when missing, with mode `1777`; leaves an existing directory untouched), including that a temporary file can actually be created in the result. 22 test suites pass, `cargo fmt --check` clean, `cargo clippy` introduces no new warnings.

# 📌 Follow-ups

TODO:

- #754 contains this same commit, since it needed the fix to install ACL end to end. Once this merges, #754 will be rebased onto `main` and drop it.

# 🗒️ Notes

Two commits, separable on review: the fix, then the diagnostic wording. The second is not required by the first and can be dropped if unwanted.
